### PR TITLE
Declare "sha1_init" statically to avoid naming conflicts

### DIFF
--- a/lib/sha-1.c
+++ b/lib/sha-1.c
@@ -215,7 +215,7 @@ sha1_step(struct sha1_ctxt *ctxt)
 
 /*------------------------------------------------------------*/
 
-void
+static void
 sha1_init(struct sha1_ctxt *ctxt)
 {
 	bzero(ctxt, sizeof(struct sha1_ctxt));


### PR DESCRIPTION
Such conflicts can happen if linked statically with another library providing a method with the same name.