### PR TITLE
Request "send" not to trigger SIGPIPE on errors.

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -85,7 +85,7 @@ struct libwebsocket *__libwebsocket_client_connect_2(
 
 	if (context->http_proxy_port) {
 
-		n = send(wsi->sock, context->service_buffer, plen, 0);
+		n = send(wsi->sock, context->service_buffer, plen, MSG_NOSIGNAL);
 		if (n < 0) {
 			compatible_close(wsi->sock);
 			lwsl_debug("ERROR writing to proxy socket\n");

--- a/lib/client.c
+++ b/lib/client.c
@@ -229,7 +229,7 @@ int lws_client_socket_service(struct libwebsocket_context *context,
 		else
 #endif
 			n = send(wsi->sock, context->service_buffer,
-					p - (char *)context->service_buffer, 0);
+					p - (char *)context->service_buffer, MSG_NOSIGNAL);
 		lws_latency(context, wsi,
 			"send or SSL_write LWS_CONNMODE...HANDSHAKE",
 								     n, n >= 0);


### PR DESCRIPTION
Added "MSG_NOSIGNAL" to other occurrences of "send(...)".