### PR TITLE
add function to manually setup proxy. Useful on iOS where getenv doesn't return proxy settings

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -830,6 +830,9 @@ lwsl_emit_syslog(int level, const char *line);
 
 LWS_VISIBLE LWS_EXTERN struct libwebsocket_context *
 libwebsocket_create_context(struct lws_context_creation_info *info);
+	
+LWS_VISIBLE LWS_EXTERN int
+libwebsocket_set_proxy(struct libwebsocket_context *context, const char *proxy);
 
 LWS_VISIBLE LWS_EXTERN void
 libwebsocket_context_destroy(struct libwebsocket_context *context);


### PR DESCRIPTION
On iOS getenv("http_proxy") doesn't return proxy settings so you have to use some iOS SDK (CFNetwork) calls to get proxy. I have added this function to be able to set proxy manually after I got it from system. I have considered also to add proxy setting as a parameter to libwebsocket_create_context but I thought it would be to intrusive and not that commonly used. Please  check if it suits the overall style of library since maybe I have missed something. If the code is not OK, please add the functionality to set proxy as you think would be best.   
