### PR TITLE
Drop wsockcompat.h header its not part of msvc

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -66,6 +66,9 @@
 #ifndef EINPROGRESS
 #define EINPROGRESS WSAEINPROGRESS
 #endif
+#ifndef EISCONN
+#define EISCONN WSAEISCONN
+#endif
 
 #define compatible_close(fd) closesocket(fd);
 #ifdef __MINGW64__

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -60,6 +60,12 @@
 #ifndef EWOULDBLOCK
 #define EWOULDBLOCK EAGAIN
 #endif
+#ifndef EALREADY
+#define EALREADY WSAEALREADY
+#endif
+#ifndef EINPROGRESS
+#define EINPROGRESS WSAEINPROGRESS
+#endif
 
 #define compatible_close(fd) closesocket(fd);
 #ifdef __MINGW64__
@@ -70,7 +76,6 @@
 #endif
 #endif
 #include <winsock2.h>
-#include <wsockcompat.h>
 #include <ws2ipdef.h>
 #include <windows.h>
 #else


### PR DESCRIPTION
I don't see a wsockcompat.h anywhere in MSVC9 or MSVC8 and their
corresponding sdk's. It does not seem like this is a standard windows
header, so better drop that and add the compat-defines to the same
place that already has other WSA compat defines.