### PR TITLE
Fix usage in Windows XP targetting projects

### DIFF
--- a/win32port/win32helpers/websock-w32.h
+++ b/win32port/win32helpers/websock-w32.h
@@ -26,6 +26,10 @@
 #define DEF_POLL_STUFF
 #endif
 
+#if _WIN32_WINNT < 0x0600
+#define DEF_POLL_STUFF
+#endif
+
 #ifdef DEF_POLL_STUFF
 
 #include <winsock2.h>


### PR DESCRIPTION
This is important since this stuff is in publicly included headers
and even though the usage of the WSAPoll API is a runtime decision
the public headers may be used in code that needs to build with
_WIN32_WINNT=0x0501 to support WinXP.

When building a project using libwebsockets with that define set
to 0x0501 winsock.h will not define the WSAPOLLFD struct causing that
project to fail to compile.