### PR TITLE
protect the label with an ifdef

### DIFF
--- a/lib/output.c
+++ b/lib/output.c
@@ -159,7 +159,9 @@ int lws_issue_raw(struct libwebsocket *wsi, unsigned char *buf, size_t len)
 	}
 #endif
 
+#ifndef LWS_NO_EXTENSIONS
 handle_truncated_send:
+#endif
 
 	/*
 	 * already handling a truncated send?


### PR DESCRIPTION
The only part that actually goes to this label is inside such an ifdef,
so building without extension support makes gcc bail out since an unused
label is considered an error in this project.