### PR TITLE
Fixed the logging of OpenSSL errors to report the correct details for the current OpenSSL error

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -207,8 +207,8 @@ int lws_client_socket_service(struct libwebsocket_context *context,
 				n = ERR_get_error();
 				if (n != SSL_ERROR_NONE) {
 					lwsl_err("SSL connect error %lu: %s\n",
-						ERR_get_error(),
-						ERR_error_string(ERR_get_error(),
+						n,
+						ERR_error_string(n,
 							  (char *)context->service_buffer));
 					return 0;
 				}
@@ -267,8 +267,8 @@ int lws_client_socket_service(struct libwebsocket_context *context,
 					n = ERR_get_error();
 					if (n != SSL_ERROR_NONE) {
 						lwsl_err("SSL connect error %lu: %s\n",
-								 ERR_get_error(),
-								 ERR_error_string(ERR_get_error(),
+								 n,
+								 ERR_error_string(n,
 												  (char *)context->service_buffer));
 						return 0;
 					}

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -1980,18 +1980,20 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 
 	method = (SSL_METHOD *)SSLv23_server_method();
 	if (!method) {
+        int error = ERR_get_error();
 		lwsl_err("problem creating ssl method %lu: %s\n", 
-			ERR_get_error(),
-			ERR_error_string(ERR_get_error(),
+			error,
+			ERR_error_string(error,
 					      (char *)context->service_buffer));
 		goto bail;
 	}
 	context->ssl_ctx = SSL_CTX_new(method);	/* create context */
 	if (!context->ssl_ctx) {
+        int error = ERR_get_error();
 		lwsl_err("problem creating ssl context %lu: %s\n",
-			ERR_get_error(),
-			ERR_error_string(ERR_get_error(),
-					      (char *)context->service_buffer));
+                 error,
+                 ERR_error_string(error,
+                                  (char *)context->service_buffer));
 		goto bail;
 	}
 
@@ -2010,18 +2012,20 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 	if (info->port == CONTEXT_PORT_NO_LISTEN) {
 		method = (SSL_METHOD *)SSLv23_client_method();
 		if (!method) {
+            int error = ERR_get_error();
 			lwsl_err("problem creating ssl method %lu: %s\n",
-				ERR_get_error(),
-				ERR_error_string(ERR_get_error(),
+                     error,
+                     ERR_error_string(error,
 					      (char *)context->service_buffer));
 			goto bail;
 		}
 		/* create context */
 		context->ssl_client_ctx = SSL_CTX_new(method);
 		if (!context->ssl_client_ctx) {
+            int error = ERR_get_error();
 			lwsl_err("problem creating ssl context %lu: %s\n",
-				ERR_get_error(),
-				ERR_error_string(ERR_get_error(),
+                     error,
+                     ERR_error_string(error,
 					      (char *)context->service_buffer));
 			goto bail;
 		}
@@ -2095,10 +2099,11 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 		n = SSL_CTX_use_certificate_chain_file(context->ssl_ctx,
 					info->ssl_cert_filepath);
 		if (n != 1) {
+            int error = ERR_get_error();
 			lwsl_err("problem getting cert '%s' %lu: %s\n",
 				info->ssl_cert_filepath,
-				ERR_get_error(),
-				ERR_error_string(ERR_get_error(),
+				error,
+				ERR_error_string(error,
 					      (char *)context->service_buffer));
 			goto bail;
 		}
@@ -2106,10 +2111,11 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 		if (SSL_CTX_use_PrivateKey_file(context->ssl_ctx,
 			     info->ssl_private_key_filepath,
 						       SSL_FILETYPE_PEM) != 1) {
+            int error = ERR_get_error();
 			lwsl_err("ssl problem getting key '%s' %lu: %s\n",
 				info->ssl_private_key_filepath,
-					ERR_get_error(),
-					ERR_error_string(ERR_get_error(),
+					error,
+					ERR_error_string(error,
 					      (char *)context->service_buffer));
 			goto bail;
 		}


### PR DESCRIPTION
Due to OpenSSL having an error queue for its errors, repeated calls to ERR_get_error() when wanting to display the current error can return incorrect error details.

Example:

![screen shot 2013-11-22 at 1 23 15 pm](https://f.cloud.github.com/assets/5113791/1600162/899abb8e-5368-11e3-9b30-e320a1dba5f7.png)

when the actual error was a "tls invalid ecpointformat list" error