### PR TITLE
fix mingw64 builds

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -43,12 +43,12 @@ extern "C" {
 #define strcasecmp stricmp
 #define getdtablesize() 30000
 
-#ifndef __SSIZE_T
-#define __SSIZE_T
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
 
 typedef SSIZE_T ssize_t;
 
-#endif // __SSIZE_T
+#endif // _SSIZE_T_DEFINED
 
 #define LWS_VISIBLE
 

--- a/win32port/win32helpers/gettimeofday.h
+++ b/win32port/win32helpers/gettimeofday.h
@@ -15,13 +15,15 @@
 #else
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
- 
+
+#ifndef _TIMEZONE_DEFINED 
 struct timezone 
 {
   int  tz_minuteswest; /* minutes W of Greenwich */
   int  tz_dsttime;     /* type of dst correction */
 };
- 
+#endif
+
 int gettimeofday(struct timeval *tv, struct timezone *tz);
 
 

--- a/win32port/win32helpers/gettimeofday.h
+++ b/win32port/win32helpers/gettimeofday.h
@@ -22,9 +22,10 @@ struct timezone
   int  tz_minuteswest; /* minutes W of Greenwich */
   int  tz_dsttime;     /* type of dst correction */
 };
-#endif
 
 int gettimeofday(struct timeval *tv, struct timezone *tz);
+
+#endif
 
 
 #endif

--- a/win32port/win32helpers/websock-w32.h
+++ b/win32port/win32helpers/websock-w32.h
@@ -51,8 +51,9 @@ typedef struct pollfd {
 typedef INT (WSAAPI *PFNWSAPOLL)(LPWSAPOLLFD fdarray, ULONG nfds, INT timeout);
 extern PFNWSAPOLL poll;
 
+#ifndef  __MINGW32__
 extern INT WSAAPI emulated_poll(LPWSAPOLLFD fdarray, ULONG nfds, INT timeout);
-
+#endif
 /* override configure because we are not using Makefiles */
 
 #define LWS_NO_FORK


### PR DESCRIPTION
Fixed Mingw64 builds

_SSIZE_T_DEFINED is in mingw64 headers so It's a good swap :)

Also _TIMEZONE_DEFINED is in the mingw64 bit headers also :)

Please merge