### PR TITLE
removed needless __MINGW64__ #defines

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -45,10 +45,6 @@ int openssl_websocket_private_data_index;
 
 #ifdef __MINGW32__
 #include "../win32port/win32helpers/websock-w32.c"
-#else
-#ifdef __MINGW64__
-#include "../win32port/win32helpers/websock-w32.c"
-#endif
 #endif
 
 #ifndef LWS_BUILD_HASH

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -43,13 +43,10 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <limits.h>
-#ifdef __MINGW64__
-#else
 #ifdef __MINGW32__
 #elif _MSC_VER > 1000 || defined(_WIN32)
 #else
 #include <netdb.h>
-#endif
 #endif
 #include <stdarg.h>
 
@@ -71,12 +68,9 @@
 #endif
 
 #define compatible_close(fd) closesocket(fd);
-#ifdef __MINGW64__
-#else
 #ifdef __MINGW32__
 #else
 #include <time.h >
-#endif
 #endif
 #include <winsock2.h>
 #include <ws2ipdef.h>

--- a/win32port/win32helpers/gettimeofday.h
+++ b/win32port/win32helpers/gettimeofday.h
@@ -1,12 +1,8 @@
 #ifndef _GET_TIME_OF_DAY_H
 #define _GET_TIME_OF_DAY_H
 
-#ifdef  __MINGW64__
-#else
-#ifdef  __MINGW32__
-#else
+#ifndef  __MINGW32__
 #include < time.h >
-#endif
 #endif
 
 #include <windows.h> //I've ommited context line.

--- a/win32port/win32helpers/websock-w32.c
+++ b/win32port/win32helpers/websock-w32.c
@@ -1,14 +1,6 @@
 #define FD_SETSIZE 256
 
-#ifdef __MINGW32__
 #include <winsock2.h>
-#else
-#ifdef __MINGW64__
-#include <winsock2.h>
-#else
-#include <WinSock2.h>
-#endif
-#endif
 
 #include <stdlib.h>
 #include <errno.h>

--- a/win32port/win32helpers/websock-w32.h
+++ b/win32port/win32helpers/websock-w32.h
@@ -19,9 +19,6 @@
 #define random rand
 #define usleep _sleep
 
-#ifdef  __MINGW64__                                                             
-#define DEF_POLL_STUFF
-#endif
 #ifdef  __MINGW32__                                                             
 #define DEF_POLL_STUFF
 #endif


### PR DESCRIPTION
Mingw64 also defines __MINGW32__ so a lot of code is redundant.

Also visual studio includes are case sensitive so websock-w32.c just needs to
#include winsock2 in lower case to support all platforms