### PR TITLE
 Add callback LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED 

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -165,6 +165,7 @@ enum libwebsocket_callback_reasons {
 	LWS_CALLBACK_HTTP_WRITEABLE,
 	LWS_CALLBACK_FILTER_NETWORK_CONNECTION,
 	LWS_CALLBACK_FILTER_HTTP_CONNECTION,
+	LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED,
 	LWS_CALLBACK_FILTER_PROTOCOL_CONNECTION,
 	LWS_CALLBACK_OPENSSL_LOAD_EXTRA_CLIENT_VERIFY_CERTS,
 	LWS_CALLBACK_OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS,
@@ -554,6 +555,14 @@ struct libwebsocket_extension;
  *		network connection from the client, there's no websocket protocol
  *		selected yet so this callback is issued only to protocol 0.
  * 
+ *	LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED: A new client just had
+ *		been connected, accepted, and instantiated into the pool. This
+ *		callback allows setting any relevant property to it. Because this
+ *		happens immediately after the instantiation of a new client,
+ *		there's no websocket protocol selected yet so this callback is
+ *		issued only to protocol 0. Only @wsi is defined, pointing to the
+ *		new client, and the return value is ignored.
+ *
  *	LWS_CALLBACK_FILTER_HTTP_CONNECTION: called when the request has
  *		been received and parsed from the client, but the response is
  *		not sent yet.  Return non-zero to disallow the connection.

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -547,11 +547,12 @@ struct libwebsocket_extension;
  *		the server at network level; the connection is accepted but then
  *		passed to this callback to decide whether to hang up immediately
  *		or not, based on the client IP.  @in contains the connection
- *		socket's descriptor.  Return non-zero to terminate
- *		the connection before sending or receiving anything.
- *		Because this happens immediately after the network connection
- *		from the client, there's no websocket protocol selected yet so
- *		this callback is issued only to protocol 0.
+ *		socket's descriptor. Since the client connection information is
+ *		not available yet, @wsi still pointing to the main server socket.
+ *		Return non-zero to terminate the connection before sending or
+ *		receiving anything. Because this happens immediately after the
+ *		network connection from the client, there's no websocket protocol
+ *		selected yet so this callback is issued only to protocol 0.
  * 
  *	LWS_CALLBACK_FILTER_HTTP_CONNECTION: called when the request has
  *		been received and parsed from the client, but the response is

--- a/lib/server.c
+++ b/lib/server.c
@@ -282,6 +282,16 @@ int lws_server_socket_service(struct libwebsocket_context *context,
 
 		new_wsi->sock = accept_fd;
 
+		/*
+		 * A new connection was accepted. Give the user a chance to
+		 * set properties of the newly created wsi. There's no protocol
+		 * selected yet so we issue this to protocols[0]
+		 */
+
+		(context->protocols[0].callback)(context, new_wsi,
+			LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED, NULL, NULL, 0);
+
+
 #ifdef LWS_OPENSSL_SUPPORT
 		new_wsi->ssl = NULL;
 		if (!context->use_ssl) {


### PR DESCRIPTION
This new callback allows the user to read or change the socket properties just after it was instantiated by the library. For example, to add a timer to drop clients who never request anything (but keep the TCP session open), so they can not hold a file descriptor for too long, make poll queue longer, etc. as I was trying to do (by the wrong way) in issue #48.

I think it can be very for another people so, please, merge it.

Best regards,

