### PR TITLE
Fixed a memory leak in libwebsocket_context_destroy() by changing some #ifndef flags.

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -1209,10 +1209,11 @@ handled:
 LWS_VISIBLE void
 libwebsocket_context_destroy(struct libwebsocket_context *context)
 {
-#ifndef LWS_NO_EXTENSIONS
 	int n;
+#ifndef LWS_NO_EXTENSIONS
 	int m;
 	struct libwebsocket_extension *ext;
+#endif /* ndef LWS_NO_EXTENSIONS */
 	struct libwebsocket_protocols *protocol = context->protocols;
 
 #ifdef LWS_LATENCY
@@ -1228,6 +1229,7 @@ libwebsocket_context_destroy(struct libwebsocket_context *context)
 		n--;
 	}
 
+#ifndef LWS_NO_EXTENSIONS
 	/*
 	 * give all extensions a chance to clean up any per-context
 	 * allocations they might have made
@@ -1243,6 +1245,7 @@ libwebsocket_context_destroy(struct libwebsocket_context *context)
 								 NULL, NULL, 0);
 		ext++;
 	}
+#endif /* ndef LWS_NO_EXTENSIONS */
 
 	/*
 	 * inform all the protocols that they are done and will have no more
@@ -1255,7 +1258,6 @@ libwebsocket_context_destroy(struct libwebsocket_context *context)
 		protocol++;
 	}
 
-#endif
 
 #if defined(WIN32) || defined(_WIN32)
 #else

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -1814,9 +1814,11 @@ int user_callback_handle_rxflow(callback_function callback_function,
  * This is just used to interrupt poll waiting
  * we don't have to do anything with it.
  */
+#ifdef LWS_OPENSSL_SUPPORT
 static void lws_sigusr2(int sig)
 {
 }
+#endif
 
 /**
  * libwebsocket_create_context() - Create the websocket handler


### PR DESCRIPTION
In the function libwebsocket_context_destroy(), 'wsi' sessions in lws_loookup[] were only closed and freed if extensions support is enabled. (I'm not using "extensions" and discovered that sessions were not closed/freed).

This applied also with invocation of the callback with reason=PROTOCOL_DESTROY. I think it should be done with and without extensions support.

So I moved a little bit some #ifndef LWS_NO_EXTENSIONS lines to surround only extensions source code.


In my pull request, there is also another compilation fix : when compiling without OPENSSL support, the lws_sigusr2 needs to be protected inside #ifdef LWS_OPENSSL_SUPPORT.
(otherwise gcc -Werror failed saying that function is defined but not used)