### PR TITLE
missing endian preprocessor defines on Linux environments

### DIFF
--- a/lib/sha-1.c
+++ b/lib/sha-1.c
@@ -59,9 +59,22 @@ typedef unsigned __int64 u_int64_t;
 #define bzero(b, len) (memset((b), '\0', (len)), (void) 0)
 
 #else
+
 #include <sys/stat.h>
 #include <sys/cdefs.h>
 #include <sys/time.h>
+#include <endian.h>
+
+#if !defined(BYTE_ORDER)
+# define BYTE_ORDER __BYTE_ORDER
+#endif
+#if !defined(LITTLE_ENDIAN)
+# define LITTLE_ENDIAN __LITTLE_ENDIAN
+#endif
+#if !defined(BIG_ENDIAN)
+# define BIG_ENDIAN __BIG_ENDIAN
+#endif
+
 #endif
 
 #include <string.h>
@@ -83,7 +96,9 @@ struct sha1_ctxt {
 };
 
 /* sanity check */
-#if BYTE_ORDER != BIG_ENDIAN
+#if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN) || !defined(BIG_ENDIAN)
+# define unsupported 1
+#elif BYTE_ORDER != BIG_ENDIAN
 # if BYTE_ORDER != LITTLE_ENDIAN
 #  define unsupported 1
 # endif


### PR DESCRIPTION
I'm compiling libwebsockets on different Debian environments, using my own GCC build toolchain. I'm just building a websocket client which connects to a Java websocket server.

Win32 works fine, but the Linux version fails with an invalid handshake. I tracked the issue down to sha-1.c producing invalid results because BYTE_ORDER, BIG_ENDIAN and LITTLE_ENDIAN are not defined, and the two '#if BYTE_ORDER == BIG_ENDIAN' directives are true. No idea if that's a valid or undefined preprocessor behavior.