### PR TITLE
Add LWS_VISIBLE to libwebsocket_set_timeout() so it can be used externally

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -1608,7 +1608,7 @@ libwebsocket_callback_all_protocol(
  * @secs:	how many seconds
  */
 
-void
+LWS_VISIBLE void
 libwebsocket_set_timeout(struct libwebsocket *wsi,
 					  enum pending_timeout reason, int secs)
 {


### PR DESCRIPTION
libwebsocket_set_timeout() was declared in the header, but (in Linux at least) the library symbol wasn't visible, so it couldn't be linked to from a program. Adding LWS_VISIBLE fixes that.
