### PR TITLE
How to change timeout of HTTP POST?

### DIFF
--- a/lib/handshake.c
+++ b/lib/handshake.c
@@ -279,7 +279,6 @@ leave:
 				wsi->u.http.ah = NULL;
 
 				if (n) {
-					libwebsocket_set_timeout(wsi, NO_PENDING_TIMEOUT, 0);
 					lwsl_info("LWS_CALLBACK_HTTP closing\n");
 					goto bail; /* struct ah ptr already nuked */
 				}


### PR DESCRIPTION
I would like to do an HTTP POST (firmware upload) which takes longer than 5 seconds. What is the best way to set a longer timeout? Can I call `libwebsocket_set_timeout()` from some callback? I tried calling it from the `LWS_CALLBACK_HTTP` callback, but it didn't seem to make a difference. I guess it's getting overwritten after that.
