### PR TITLE
Use fread() when serving http files

### DIFF
--- a/lib/handshake.c
+++ b/lib/handshake.c
@@ -219,7 +219,6 @@ http_postbody:
 				memset(&wsi->u, 0, sizeof(wsi->u));
 				wsi->mode = LWS_CONNMODE_HTTP_SERVING_ACCEPTED;
 				wsi->state = WSI_STATE_HTTP;
-				wsi->u.http.fd = -1;
 
 				/* expose it at the same offset as u.hdr */
 				wsi->u.http.ah = ah;

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -257,10 +257,10 @@ libwebsocket_close_and_free_session(struct libwebsocket_context *context,
 			free(wsi->u.http.post_buffer);
 			wsi->u.http.post_buffer = NULL;
 		}
-		if (wsi->u.http.fd >= 0) {
-			lwsl_debug("closing http fd %d\n", wsi->u.http.fd);
-			close(wsi->u.http.fd);
-			wsi->u.http.fd = -1;
+		if (wsi->u.http.fp) {
+			lwsl_debug("closing http fp %p\n", wsi->u.http.fp);
+			fclose(wsi->u.http.fp);
+			wsi->u.http.fp = NULL;
 			context->protocols[0].callback(context, wsi,
 				LWS_CALLBACK_CLOSED_HTTP, wsi->user_space, NULL, 0);
 		}

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -344,9 +344,9 @@ struct allocated_headers {
 
 struct _lws_http_mode_related {
 	struct allocated_headers *ah; /* mirroring  _lws_header_related */
-	int fd;
-	unsigned long filepos;
-	unsigned long filelen;
+	FILE* fp;
+	long filepos;
+	long filelen;
 
 	int content_length;
 	int content_length_seen;


### PR DESCRIPTION
This change allows compilation on platforms without read().
