### PR TITLE
Fix endian detection on non-linux systems

### DIFF
--- a/lib/sha-1.c
+++ b/lib/sha-1.c
@@ -63,7 +63,14 @@ typedef unsigned __int64 u_int64_t;
 #include <sys/stat.h>
 #include <sys/cdefs.h>
 #include <sys/time.h>
+
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
+#elif defined(__linux__)
 #include <endian.h>
+#endif
 
 #if !defined(BYTE_ORDER)
 # define BYTE_ORDER __BYTE_ORDER


### PR DESCRIPTION
f975f736408f32e7384cf38270a7806e68d5e112 introduced inclusion of endian.h, which is not a standard header. Move the code of this commit into a **linux** condition to fix this problem.
