### PR TITLE
Avoid calls to gettimeofday()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,18 +275,12 @@ if (WIN32)
 
 	list(APPEND HDR_PUBLIC
 		${WIN32_HELPERS_PATH}/websock-w32.h
-		${WIN32_HELPERS_PATH}/gettimeofday.h
 		)
-	if (MINGW)
-		list(APPEND SOURCES
-			${WIN32_HELPERS_PATH}/gettimeofday.c
-			)
-	else(MINGW)
+	if (NOT MINGW)
 		list(APPEND SOURCES
 			${WIN32_HELPERS_PATH}/websock-w32.c
-			${WIN32_HELPERS_PATH}/gettimeofday.c
 			)
-	endif(MINGW)
+	endif()
 	include_directories(${WIN32_HELPERS_PATH})
 else(WIN32)
 	# Unix.

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -38,8 +38,6 @@ extern "C" {
 #include <basetsd.h>
 #include "websock-w32.h"
 
-#include "gettimeofday.h"
-
 #define strcasecmp stricmp
 #define getdtablesize() 30000
 

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -264,7 +264,7 @@ struct libwebsocket_context {
 	char canonical_hostname[128];
 	unsigned int http_proxy_port;
 	unsigned int options;
-	unsigned long last_timeout_check_s;
+	time_t last_timeout_check_s;
 
 	/*
 	 * usable by anything in the service code, but only if the scope
@@ -406,7 +406,7 @@ struct libwebsocket {
 	unsigned int hdr_parsing_completed:1;
 
 	char pending_timeout; /* enum pending_timeout */
-	unsigned long pending_timeout_limit;
+	time_t pending_timeout_limit;
 
 	int sock;
 	int position_in_fds_table;


### PR DESCRIPTION
Add a new function to get the current time in microseconds, since gettimeofday() does not exist on Windows.
Keep the current implementation for the test applications.
