### PR TITLE
Use WSAGetLastError() instead of errno on Windows

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -93,9 +93,9 @@ struct libwebsocket *libwebsocket_client_connect_2(
 	bzero(&server_addr.sin_zero, 8);
 
 	if (connect(wsi->sock, (struct sockaddr *)&server_addr,
-			  sizeof(struct sockaddr)) == -1 || errno == EISCONN)  {
+			  sizeof(struct sockaddr)) == -1 || LWS_ERRNO == LWS_EISCONN)  {
 
-		if (errno == EALREADY || errno == EINPROGRESS) {
+		if (LWS_ERRNO == LWS_EALREADY || LWS_ERRNO == LWS_EINPROGRESS) {
 			lwsl_client("nonblocking connect retry\n");
 
 			/*
@@ -107,9 +107,9 @@ struct libwebsocket *libwebsocket_client_connect_2(
 			return wsi;
 		}
 
-		if (errno != EISCONN) {
+		if (LWS_ERRNO != LWS_EISCONN) {
 		
-			lwsl_debug("Connect failed errno=%d\n", errno);
+			lwsl_debug("Connect failed errno=%d\n", LWS_ERRNO);
 			goto failed;
 		}
 	}

--- a/lib/client.c
+++ b/lib/client.c
@@ -78,7 +78,7 @@ int lws_client_socket_service(struct libwebsocket_context *context,
 					sizeof(context->service_buffer), 0);
 		if (n < 0) {
 			
-			if (errno == EAGAIN) {
+			if (LWS_ERRNO == LWS_EAGAIN) {
 				lwsl_debug(
 						   "Proxy read returned EAGAIN... retrying\n");
 				return 0;

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -523,12 +523,12 @@ just_kill_connection:
 			n = shutdown(wsi->sock, SHUT_RDWR);
 			if (n)
 				lwsl_debug("closing: shutdown returned %d\n",
-									errno);
+									LWS_ERRNO);
 
 			n = compatible_close(wsi->sock);
 			if (n)
 				lwsl_debug("closing: close returned %d\n",
-									errno);
+									LWS_ERRNO);
 		}
 #ifdef LWS_OPENSSL_SUPPORT
 	}
@@ -585,14 +585,14 @@ libwebsockets_get_peer_addresses(struct libwebsocket_context *context,
 
 	len = sizeof(sin);
 	if (getpeername(fd, (struct sockaddr *) &sin, &len) < 0) {
-		lwsl_warn("getpeername: %s\n", strerror(errno));
+		lwsl_warn("getpeername: %s\n", strerror(LWS_ERRNO));
 		goto bail;
 	}
 
 	host = gethostbyaddr((char *) &sin.sin_addr, sizeof(sin.sin_addr),
 								       AF_INET);
 	if (host == NULL) {
-		lwsl_warn("gethostbyaddr: %s\n", strerror(errno));
+		lwsl_warn("gethostbyaddr: %s\n", strerror(LWS_ERRNO));
 		goto bail;
 	}
 
@@ -1149,8 +1149,8 @@ read_pending:
 
 		if (eff_buf.token_len < 0) {
 			lwsl_debug("service_fd read ret = %d, errno = %d\n",
-						      eff_buf.token_len, errno);
-			if (errno != EINTR && errno != EAGAIN)
+						      eff_buf.token_len, LWS_ERRNO);
+			if (LWS_ERRNO != LWS_EINTR && LWS_ERRNO != LWS_EAGAIN)
 				goto close_and_handled;
 			n = 0;
 			goto handled;
@@ -1425,7 +1425,7 @@ libwebsocket_service(struct libwebsocket_context *context, int timeout_ms)
 	}
 
 	if (n < 0) {
-		if (errno != EINTR)
+		if (LWS_ERRNO != LWS_EINTR)
 			return -1;
 		else
 			return 0;
@@ -2428,7 +2428,7 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 							     sizeof(serv_addr));
 		if (n < 0) {
 			lwsl_err("ERROR on binding to port %d (%d %d)\n",
-							info->port, n, errno);
+							info->port, n, LWS_ERRNO);
 			compatible_close(sockfd);
 			goto bail;
 		}
@@ -2467,10 +2467,10 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 #else
 	if (info->gid != -1)
 		if (setgid(info->gid))
-			lwsl_warn("setgid: %s\n", strerror(errno));
+			lwsl_warn("setgid: %s\n", strerror(LWS_ERRNO));
 	if (info->uid != -1)
 		if (setuid(info->uid))
-			lwsl_warn("setuid: %s\n", strerror(errno));
+			lwsl_warn("setuid: %s\n", strerror(LWS_ERRNO));
 #endif
 
 	/* initialize supported protocols */

--- a/lib/output.c
+++ b/lib/output.c
@@ -156,7 +156,7 @@ int lws_issue_raw(struct libwebsocket *wsi, unsigned char *buf, size_t len)
 		n = SSL_write(wsi->ssl, buf, len);
 		lws_latency(context, wsi, "SSL_write lws_issue_raw", n, n >= 0);
 		if (n < 0) {
-			if (errno == EAGAIN || errno == EINTR) {
+			if (LWS_ERRNO == LWS_EAGAIN || LWS_ERRNO == LWS_EINTR) {
 				n = 0;
 				goto handle_truncated_send;
 			}
@@ -168,7 +168,7 @@ int lws_issue_raw(struct libwebsocket *wsi, unsigned char *buf, size_t len)
 		n = send(wsi->sock, buf, len, MSG_NOSIGNAL);
 		lws_latency(context, wsi, "send lws_issue_raw", n, n == len);
 		if (n < 0) {
-			if (errno == EAGAIN || errno == EINTR) {
+			if (LWS_ERRNO == LWS_EAGAIN || LWS_ERRNO == LWS_EINTR) {
 				n = 0;
 				goto handle_truncated_send;
 			}

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -61,18 +61,13 @@
 
 #if defined(WIN32) || defined(_WIN32)
 #define LWS_NO_DAEMONIZE
-#ifndef EWOULDBLOCK
-#define EWOULDBLOCK EAGAIN
-#endif
-#ifndef EALREADY
-#define EALREADY WSAEALREADY
-#endif
-#ifndef EINPROGRESS
-#define EINPROGRESS WSAEINPROGRESS
-#endif
-#ifndef EISCONN
-#define EISCONN WSAEISCONN
-#endif
+#define LWS_ERRNO WSAGetLastError()
+#define LWS_EAGAIN WSAEWOULDBLOCK
+#define LWS_EALREADY WSAEALREADY
+#define LWS_EINPROGRESS WSAEINPROGRESS
+#define LWS_EINTR WSAEINTR
+#define LWS_EISCONN WSAEISCONN
+#define LWS_EWOULDBLOCK WSAEWOULDBLOCK
 
 #define compatible_close(fd) closesocket(fd);
 #ifdef __MINGW64__
@@ -103,6 +98,13 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#define LWS_ERRNO errno
+#define LWS_EAGAIN EAGAIN
+#define LWS_EALREADY EALREADY
+#define LWS_EINPROGRESS EINPROGRESS
+#define LWS_EINTR EINTR
+#define LWS_EISCONN EISCONN
+#define LWS_EWOULDBLOCK EWOULDBLOCK
 #define LWS_INVALID_FILE -1
 #define compatible_close(fd) close(fd);
 #endif

--- a/lib/server.c
+++ b/lib/server.c
@@ -153,7 +153,7 @@ int lws_server_socket_service(struct libwebsocket_context *context,
 
 			if (len < 0) {
 				lwsl_debug("Socket read returned %d\n", len);
-				if (errno != EINTR && errno != EAGAIN)
+				if (LWS_ERRNO != LWS_EINTR && LWS_ERRNO != LWS_EAGAIN)
 					libwebsocket_close_and_free_session(
 						context, wsi,
 						LWS_CLOSE_STATUS_NOSTATUS);
@@ -226,11 +226,11 @@ int lws_server_socket_service(struct libwebsocket_context *context,
 			"unencrypted accept LWS_CONNMODE_SERVER_LISTENER",
 						     accept_fd, accept_fd >= 0);
 		if (accept_fd < 0) {
-			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			if (LWS_ERRNO == LWS_EAGAIN || LWS_ERRNO == LWS_EWOULDBLOCK) {
 				lwsl_debug("accept asks to try again\n");
 				break;
 			}
-			lwsl_warn("ERROR on accept: %s\n", strerror(errno));
+			lwsl_warn("ERROR on accept: %s\n", strerror(LWS_ERRNO));
 			break;
 		}
 

--- a/win32port/win32helpers/websock-w32.c
+++ b/win32port/win32helpers/websock-w32.c
@@ -11,7 +11,6 @@
 #endif
 
 #include <stdlib.h>
-#include <errno.h>
 #include "websock-w32.h"
 
 PFNWSAPOLL poll = NULL;
@@ -29,7 +28,7 @@ INT WSAAPI emulated_poll(LPWSAPOLLFD fdarray, ULONG nfds, INT timeout)
 	WSAPOLLFD * poll_fd = fdarray;
 
 	if (NULL == fdarray) {
-		errno = EFAULT;
+		WSASetLastError(WSAEFAULT);
 		return -1;
 	}
 


### PR DESCRIPTION
Error codes set by Windows Sockets are not made available through the errno
variable. Checking them via WSAGetLastError() is the corret solution.
