### PR TITLE
Remove duplicated implementations for bzero()

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -109,6 +109,10 @@
 #define compatible_close(fd) close(fd);
 #endif
 
+#ifndef HAVE_BZERO
+#define bzero(b, len) (memset((b), '\0', (len)), (void) 0)
+#endif
+
 #ifndef HAVE_STRERROR
 #define strerror(x) ""
 #endif

--- a/lib/sha-1.c
+++ b/lib/sha-1.c
@@ -61,8 +61,6 @@ typedef unsigned __int64 u_int64_t;
 #endif
 #endif
 
-#define bzero(b, len) (memset((b), '\0', (len)), (void) 0)
-
 #else
 
 #include <sys/stat.h>

--- a/win32port/win32helpers/websock-w32.h
+++ b/win32port/win32helpers/websock-w32.h
@@ -9,8 +9,6 @@
 
 #pragma warning(disable : 4996)
 
-#define bzero(b,len) (memset((b), '\0', (len)), (void) 0)
-
 #define MSG_NOSIGNAL 0
 #define SHUT_RDWR SD_BOTH
 


### PR DESCRIPTION
Define bzero() in a central place if HAVE_BZERO is not set
