### PR TITLE
Remove checks for inline from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,27 +116,6 @@ endif()
 
 include_directories("${PROJECT_BINARY_DIR}")
 
-include(CheckCSourceCompiles)
-
-# Check for different inline keyword versions.
-foreach(KEYWORD "inline" "__inline__" "__inline")
-	set(CMAKE_REQUIRED_DEFINITIONS "-DKEYWORD=${KEYWORD}")
-	CHECK_C_SOURCE_COMPILES(
-		"
-		#include <stdio.h>
-		KEYWORD void a() {}
-		int main(int argc, char **argv) { a(); return 0; }
-		" HAVE_${KEYWORD})
-endforeach()
-
-if (NOT HAVE_inline)
-	if (HAVE___inline__)
-		set(inline __inline__)
-	elseif(HAVE___inline)
-		set(inline __inline)
-	endif()
-endif()
-
 # Put the libaries and binaries that get built into directories at the
 # top of the build tree rather than in hard-to-find leaf directories. 
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -154,6 +154,3 @@
 
 /* Define as `fork' if `vfork' does not work. */
 //#cmakedefine vfork
-
-/* Define if the inline keyword doesn't exist. */
-#cmakedefine inline


### PR DESCRIPTION
Since we required the keyword in the public header file we can not use
the lws_config.h files, which makes the checks useless. So remove them.
