### PR TITLE
Define libwebsocket_write_http as a macro instead of inline

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -40,7 +40,6 @@ extern "C" {
 
 #define strcasecmp stricmp
 #define getdtablesize() 30000
-#define inline
 
 #ifdef __MINGW64__
 #else
@@ -1035,13 +1034,8 @@ libwebsocket_write(struct libwebsocket *wsi, unsigned char *buf, size_t len,
 				     enum libwebsocket_write_protocol protocol);
 
 /* helper for case where buffer may be const */
-static inline int
-libwebsocket_write_http(struct libwebsocket *wsi,
-				const unsigned char *buf, size_t len)
-{
-	return libwebsocket_write(wsi, (unsigned char *)buf, len,
-							LWS_WRITE_HTTP);
-}
+#define libwebsocket_write_http(wsi, buf, len) \
+	libwebsocket_write(wsi, (unsigned char *)(buf), len, LWS_WRITE_HTTP)
 
 LWS_VISIBLE LWS_EXTERN int
 libwebsockets_serve_http_file(struct libwebsocket_context *context,


### PR DESCRIPTION
This solves two problems:
a) We do not need to use the keyword inline in the public header.
b) We avoid a possible warning about an unused static function.
