### PR TITLE
Use CP rather than INSTALL_BIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,14 +753,6 @@ endif()
 
 set(LWS_INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
-# Make sure the paths are absolute.
-foreach(p LIB BIN INCLUDE CMAKE)
-    set(var LWS_INSTALL_${p}_DIR)
-    if(NOT IS_ABSOLUTE "${${var}}")
-        set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
-    endif()
-endforeach()
-
 # Export targets (This is used for other CMake projects to easily find the libraries and include files).
 export(TARGETS websockets websockets_shared
         FILE "${PROJECT_BINARY_DIR}/LibwebsocketsTargets.cmake")
@@ -776,10 +768,12 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/LibwebsocketsConfig.cmake.in
                 @ONLY)
 
 # Generate the config file for the installation tree.
+get_filename_component(LWS_ABSOLUTE_INSTALL_CMAKE_DIR ${LWS_INSTALL_CMAKE_DIR} ABSOLUTE)
+get_filename_component(LWS_ABSOLUTE_INSTALL_INCLUDE_DIR ${LWS_INSTALL_INCLUDE_DIR} ABSOLUTE)
 file(RELATIVE_PATH 
     REL_INCLUDE_DIR 
-    "${LWS_INSTALL_CMAKE_DIR}"
-    "${LWS_INSTALL_INCLUDE_DIR}") # Calculate the relative directory from the Cmake dir.
+    "${LWS_ABSOLUTE_INSTALL_CMAKE_DIR}"
+    "${LWS_ABSOLUTE_INSTALL_INCLUDE_DIR}") # Calculate the relative directory from the cmake dir.
 
 # Note the EVENT_CMAKE_DIR is defined in JanssonConfig.cmake.in, 
 # we escape it here so it's evaluated when it is included instead

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1034,13 +1034,8 @@ libwebsocket_write(struct libwebsocket *wsi, unsigned char *buf, size_t len,
 				     enum libwebsocket_write_protocol protocol);
 
 /* helper for case where buffer may be const */
-static inline int
-libwebsocket_write_http(struct libwebsocket *wsi,
-				const unsigned char *buf, size_t len)
-{
-	return libwebsocket_write(wsi, (unsigned char *)buf, len,
-							LWS_WRITE_HTTP);
-}
+#define libwebsocket_write_http(wsi, buf, len) \
+	libwebsocket_write(wsi, (unsigned char *)(buf), len, LWS_WRITE_HTTP)
 
 LWS_VISIBLE LWS_EXTERN int
 libwebsockets_serve_http_file(struct libwebsocket_context *context,


### PR DESCRIPTION
Using INSTALL_BIN causes the symbolic link to become a copy of the original in the target. Using CP preserves the original symbolic link (i.e. libwebsockets.so -> libwebsockets.so.4.0.0).
