### PR TITLE
Fix nonblocking connect on Windows

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -177,7 +177,8 @@ struct libwebsocket *libwebsocket_client_connect_2(
 
 	if (connect(wsi->sock, v, n) == -1 || LWS_ERRNO == LWS_EISCONN) {
 
-		if (LWS_ERRNO == LWS_EALREADY || LWS_ERRNO == LWS_EINPROGRESS) {
+		if (LWS_ERRNO == LWS_EALREADY || LWS_ERRNO == LWS_EINPROGRESS
+		                              || LWS_ERRNO == LWS_EWOULDBLOCK) {
 			lwsl_client("nonblocking connect retry\n");
 
 			/*

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -694,7 +694,7 @@ int lws_set_socket_options(struct libwebsocket_context *context, int fd)
 	int optval = 1;
 	socklen_t optlen = sizeof(optval);
 #if defined(WIN32) || defined(_WIN32)
-	unsigned long optl = 0;
+	u_long optl = 1;
 #endif
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
 	struct protoent *tcp_proto;


### PR DESCRIPTION
Use the correct value for the call to ioctlsocket() to set the socket to
nonblocking mode and check for WSAWOULDBLOCK return value of connect().
