### PR TITLE
Fix for binding socket to a specific interface (fixes #116)

### DIFF
--- a/lib/lws-plat-unix.c
+++ b/lib/lws-plat-unix.c
@@ -334,6 +334,17 @@ interface_to_sa(struct libwebsocket_context *context,
 
 	freeifaddrs(ifr);
 	
+	if (rc == -1) {
+		/* check if bind to IP adddress */
+#ifdef LWS_USE_IPV6
+		if (inet_pton(AF_INET6, ifname, &addr6->sin6_addr) == 1)
+			rc = 0;
+		else
+#endif
+		if (inet_pton(AF_INET, ifname, &addr->sin_addr) == 1)
+			rc = 0;
+	}
+
 	return rc;
 }
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -78,7 +78,6 @@ int lws_context_init_server(struct lws_context_creation_info *info,
 		bzero((char *) &serv_addr4, sizeof(serv_addr4));
 		serv_addr4.sin_addr.s_addr = INADDR_ANY;
 		serv_addr4.sin_family = AF_INET;
-		serv_addr4.sin_port = htons(info->port);
 
 		if (info->iface) {
 			if (interface_to_sa(context, info->iface,
@@ -89,6 +88,8 @@ int lws_context_init_server(struct lws_context_creation_info *info,
 				return 1;
 			}
 		}
+
+		serv_addr4.sin_port = htons(info->port);
 	} /* ipv4 */
 
 	n = bind(sockfd, v, n);


### PR DESCRIPTION
also allow binding to IP address with @iface
info.iface = "eth0";
info.iface = "192.168.1.5";

I only tested IPv4 code - don't have any IPv6 system.
