### PR TITLE
new API function libwebsocket_wsi_user

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -420,6 +420,21 @@ libwebsocket_context_user(struct libwebsocket_context *context)
 	return context->user_space;
 }
 
+/**
+ * libwebsocket_wsi_user() - get the user data associated with the wsi
+ * @wsi: struct libwebsocket
+ *
+ *	This returns the optional user allocation that is attached to
+ *	the wsi.
+ */
+LWS_EXTERN void *
+libwebsocket_wsi_user(struct libwebsocket *wsi)
+{
+	if (wsi == NULL)
+		return NULL;
+	else
+		return wsi->user_space;
+}
 
 /**
  * libwebsocket_callback_all_protocol() - Callback all connections using

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -999,6 +999,9 @@ libwebsocket_service_fd(struct libwebsocket_context *context,
 LWS_VISIBLE LWS_EXTERN void *
 libwebsocket_context_user(struct libwebsocket_context *context);
 
+LWS_VISIBLE LWS_EXTERN void *
+libwebsocket_wsi_user(struct libwebsocket *wsi);
+
 enum pending_timeout {
 	NO_PENDING_TIMEOUT = 0,
 	PENDING_TIMEOUT_AWAITING_PROXY_RESPONSE,


### PR DESCRIPTION
which returns the optional user allocation that is attached to the wsi
useful to get wsi's user_space from outside of libwsockets callback functions
