### PR TITLE
Not free external allocated memory blocks.

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -278,10 +278,6 @@ just_kill_connection:
 	context->protocols[0].callback(context, wsi,
 			LWS_CALLBACK_WSI_DESTROY, wsi->user_space, NULL, 0);
 
-	if (wsi->protocol && wsi->protocol->per_session_data_size &&
-					wsi->user_space) /* user code may own */
-		free(wsi->user_space);
-
 	free(wsi);
 }
 


### PR DESCRIPTION
The pointer wsi->user_space is an external allocated memory block.
For caller (the user of libwebsocket), it will be clearer ownership that libwebsocket don’t free it but let the owner do handling the cleanup and free.
