### PR TITLE
Provide HTTP/<version> string via WSI_TOKEN_HTTP

### DIFF
--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -397,7 +397,6 @@ check_eol:
 			goto swallow;
 		}
 
-spill:
 		{
 			int issue_result = issue_char(wsi, c);
 			if (issue_result < 0) {


### PR DESCRIPTION
Think this little change _ought_ to do it. With this tweak, **lws_hdr_copy** for WSI_TOKEN_HTTP should yield HTTP/1.1 for 1.1 clients and an empty string for HTTP 1.0. Differentiating between the two (somehow) is necessary to support streaming HTTP protocols for some mobile clients which don't have websockets or HTTP 1.1.
