### PR TITLE
Only check for '?' URI args during URI path parse

### DIFF
--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -365,16 +365,6 @@ int libwebsocket_parse(
 			break;
 		}
 
-check_eol:
-
-		/* bail at EOL */
-		if (wsi->u.hdr.parser_state != WSI_TOKEN_CHALLENGE &&
-								  c == '\x0d') {
-			c = '\0';
-			wsi->u.hdr.parser_state = WSI_TOKEN_SKIPPING_SAW_CR;
-			lwsl_parser("*\n");
-		}
-
 		if (c == '?') { /* start of URI arguments */
 			/* seal off uri header */
 			wsi->u.hdr.ah->data[wsi->u.hdr.ah->pos++] = '\0';
@@ -395,6 +385,16 @@ check_eol:
 			/* defeat normal uri path processing */
 			wsi->u.hdr.ups = URIPS_ARGUMENTS;
 			goto swallow;
+		}
+
+check_eol:
+
+		/* bail at EOL */
+		if (wsi->u.hdr.parser_state != WSI_TOKEN_CHALLENGE &&
+								  c == '\x0d') {
+			c = '\0';
+			wsi->u.hdr.parser_state = WSI_TOKEN_SKIPPING_SAW_CR;
+			lwsl_parser("*\n");
 		}
 
 		{


### PR DESCRIPTION
HTTP referer strings may also contain HTTP query arguments. To avoid overwriting the http args with the referer string, we simply move the query string parsing _above_ check_eol, so that it's only executed for GET, POST, OPTIONS.
