### PR TITLE
Hotfix/http streaming read

### DIFF
--- a/lib/handshake.c
+++ b/lib/handshake.c
@@ -173,9 +173,11 @@ http_complete:
 	lwsl_debug("libwebsocket_read: http_complete\n");
 	/* Handle keep-alives, by preparing for a new request: */
 	if (wsi->u.http.connection_type == HTTP_CONNECTION_KEEP_ALIVE) {
+		lwsl_debug("libwebsocket_read: keep-alive\n");
 		wsi->state = WSI_STATE_HTTP;
 		wsi->mode = LWS_CONNMODE_HTTP_SERVING;
-		lwsl_debug("libwebsocket_read: keep-alive\n");
+		/* We might be streaming HTTP content, so leave the connection open.*/
+		libwebsocket_set_timeout(wsi, NO_PENDING_TIMEOUT, 0);
 
 		if (lws_allocate_header_table(wsi))
 			goto bail;


### PR DESCRIPTION
Two fixes for HTTP streaming connections:
- If the connection is keep-alive, reset the pending timeout - timeout can be set again at the application level after the request is shipped off / TCP keep-alives can terminate the connection worst case
- After handshake returns, verify that parsing is complete, else jump to **read_ok**
