### PR TITLE
Fix TCP keepalive use in UNIX systems

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -122,6 +122,10 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 	context->http_proxy_address[0] = '\0';
 	context->options = info->options;
 	context->iface = info->iface;
+	context->ka_time = info->ka_time;
+	context->ka_interval = info->ka_interval;
+	context->ka_probes = info->ka_probes;
+
 	/* to reduce this allocation, */
 	context->max_fds = getdtablesize();
 	lwsl_notice(" static allocation: %u + (%u x %u fds) = %u bytes\n",
@@ -209,10 +213,10 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 		" per-conn mem: %u + %u headers + protocol rx buf\n",
 				sizeof(struct libwebsocket),
 					      sizeof(struct allocated_headers));
-		
+
 	if (lws_context_init_server_ssl(info, context))
 		goto bail;
-	
+
 	if (lws_context_init_client_ssl(info, context))
 		goto bail;
 

--- a/lib/lws-plat-unix.c
+++ b/lib/lws-plat-unix.c
@@ -173,17 +173,17 @@ lws_plat_set_socket_options(struct libwebsocket_context *context, int fd)
 #else
 		/* set the keepalive conditions we want on it too */
 		optval = context->ka_time;
-		if (setsockopt(fd, IPPROTO_IP, TCP_KEEPIDLE,
+		if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
 					     (const void *)&optval, optlen) < 0)
 			return 1;
 
 		optval = context->ka_interval;
-		if (setsockopt(fd, IPPROTO_IP, TCP_KEEPINTVL,
+		if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,
 					     (const void *)&optval, optlen) < 0)
 			return 1;
 
 		optval = context->ka_probes;
-		if (setsockopt(fd, IPPROTO_IP, TCP_KEEPCNT,
+		if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
 					     (const void *)&optval, optlen) < 0)
 			return 1;
 #endif
@@ -213,7 +213,7 @@ lws_plat_drop_app_privileges(struct lws_context_creation_info *info)
 			lwsl_warn("setgid: %s\n", strerror(LWS_ERRNO));
 	if (info->uid != -1)
 		if (setuid(info->uid))
-			lwsl_warn("setuid: %s\n", strerror(LWS_ERRNO));	
+			lwsl_warn("setuid: %s\n", strerror(LWS_ERRNO));
 }
 
 LWS_VISIBLE int
@@ -233,7 +233,7 @@ lws_plat_init_fd_tables(struct libwebsocket_context *context)
 	context->fds[0].events = LWS_POLLIN;
 	context->fds[0].revents = 0;
 	context->fds_count = 1;
-	
+
 	context->fd_random = open(SYSTEM_RANDOM_FILEPATH, O_RDONLY);
 	if (context->fd_random < 0) {
 		lwsl_err("Unable to open random device %s %d\n",
@@ -259,7 +259,7 @@ lws_plat_context_early_init(void)
 	sigaddset(&mask, SIGUSR2);
 
 	sigprocmask(SIG_BLOCK, &mask, NULL);
-	
+
 	signal(SIGPIPE, sigpipe_handler);
 
 	return 0;
@@ -336,7 +336,7 @@ interface_to_sa(struct libwebsocket_context *context,
 	}
 
 	freeifaddrs(ifr);
-	
+
 	if (rc == -1) {
 		/* check if bind to IP adddress */
 #ifdef LWS_USE_IPV6
@@ -398,7 +398,7 @@ lws_plat_open_file(const char* filename, unsigned long* filelen)
 #ifdef LWS_USE_IPV6
 LWS_VISIBLE const char *
 lws_plat_inet_ntop(int af, const void *src, char *dst, int cnt)
-{ 
+{
 	return inet_ntop(af, src, dst, cnt);
 }
 #endif


### PR DESCRIPTION
Under UNIX systems the TCP keepalive is not taken into use properly. This commit tries to fix that.
1. In the libwebsocket_create_context() function, the info->ka_\* fields were not copied to their corresponding fields of the context variable. Later on when the context.ka_time is inspected to check whether the TCP keepalive should be enabled on the connection, the condition always returns false.
- the fix for this consists in copying the ka_\* fields from the info to the context variable, which enables keepalive on the socket.
1. In the lws_plat_set_socket_options() function, the keepalive parameters were written to the wrong protocol level. The keepalive is a TCP feature not an IP feature, so the proper protocol level for the keepalive parameters has to be "IPPROTO_TCP". Without this second fix, the keepalive feature is activated, but the timeout data is controled by the default values (/proc/sys/net/ipv4/tcp_keepalive_*) instead of those programmed when creating the context.
- the fix for this was changing the IPPROTO_IP level to the IPPROTO_TCP when calling setsockopt() with the keepalive parameters

The bahaviour was tested with the "libwebsockets-test-server" test application started on a machine (host1), a web browser started on another machine (host2) and connecting to the http://host1:7681. Then the physical connection (the ethernet cable) was disconnected between host1 and host2 and it was noticed that after the timers expired, the connection was ended on the server side, causing LWS_CALLBACK_CLOSED to be called on the server (the intended behaviour).

Prior to this fix, the keepalive did not work as intended on the websocket.
