### PR TITLE
Reset hdr_parsing_completed for WSI_STATE_HTTP:

### DIFF
--- a/lib/handshake.c
+++ b/lib/handshake.c
@@ -68,6 +68,7 @@ libwebsocket_read(struct libwebsocket_context *context,
 	switch (wsi->state) {
 http_new:
 	case WSI_STATE_HTTP:
+		wsi->hdr_parsing_completed = 0;
 	case WSI_STATE_HTTP_ISSUING_FILE:
 		wsi->state = WSI_STATE_HTTP_HEADERS;
 		wsi->u.hdr.parser_state = WSI_TOKEN_NAME_PART;


### PR DESCRIPTION
This fixes a bug where a client issues two GET requests on the same connection
(keep-alive). If the second request is split into two reads, the
hdr_parsing_complete flag gets us into trouble by ending the request read too
early and giving us bogus data.

(Re-issued pull request from a fresh branch).
