### PR TITLE
ws protocol name matching:  make a zero-length protocol name match any requested protocol

### DIFF
--- a/lib/server.c
+++ b/lib/server.c
@@ -395,6 +395,16 @@ int lws_handshake_server(struct libwebsocket_context *context,
 			while (context->protocols[n].callback) {
 				if (!wsi->protocol->name)
 					continue;
+				/* a zero-length protocol name always matches
+				 * later, a FILTER_PROTOCOL_CONNECTION callback
+				 * can sort out what to with the offered names
+				 */
+				if (*(wsi->protocol->name) == 0) {
+				    lwsl_info("protocol wildcard match %d\n", n);
+				    wsi->protocol = &context->protocols[n];
+				    hit = 1;
+				    break;
+				}
 				if (!strcmp(context->protocols[n].name,
 					    protocol_name)) {
 					lwsl_info("prot match %d\n", n);


### PR DESCRIPTION
if an empty string as protocol name in struct libwebsocket_protocols is
specified, it will match any protocol the client requested.

A later FILTER_PROTOCOL_CONNECTION callback can then be used to sort out details, like
setting options in the user session structure based on the actual proto name.

The previous two commits are minor - error message improvements.
