### PR TITLE
ws protocol name matching: fix Sec-WebSocket-Protocol: reply,  make a zero-length protocol name match any requested protocol

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -669,6 +669,14 @@ libwebsockets_get_protocol(struct libwebsocket *wsi)
 	return wsi->protocol;
 }
 
+LWS_VISIBLE const char *
+libwebsockets_get_protocol_name(struct libwebsocket *wsi)
+{
+    if (wsi->selected_protocol)
+	return wsi->selected_protocol;
+    return wsi->protocol->name;
+}
+
 LWS_VISIBLE int
 libwebsocket_is_final_fragment(struct libwebsocket *wsi)
 {

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1036,6 +1036,11 @@ LWS_VISIBLE LWS_EXTERN void
 libwebsocket_set_timeout(struct libwebsocket *wsi,
 					 enum pending_timeout reason, int secs);
 
+LWS_VISIBLE LWS_EXTERN void
+libwebsocket_set_protocol(struct libwebsocket *wsi,
+			  char *protocol_name,
+			  struct libwebsocket_protocols *proto);
+
 /*
  * IMPORTANT NOTICE!
  *
@@ -1094,6 +1099,9 @@ LWS_VISIBLE LWS_EXTERN int libwebsockets_return_http_status(
 
 LWS_VISIBLE LWS_EXTERN const struct libwebsocket_protocols *
 libwebsockets_get_protocol(struct libwebsocket *wsi);
+
+LWS_VISIBLE LWS_EXTERN const char *
+libwebsockets_get_protocol_name(struct libwebsocket *wsi);
 
 LWS_VISIBLE LWS_EXTERN int
 libwebsocket_callback_on_writable(struct libwebsocket_context *context,

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -576,6 +576,7 @@ struct libwebsocket {
     struct lws_io_watcher w_write;
 #endif /* LWS_USE_LIBEV */
 	const struct libwebsocket_protocols *protocol;
+        char *selected_protocol;
 #ifndef LWS_NO_EXTENSIONS
 	struct libwebsocket_extension *
 				   active_extensions[LWS_MAX_EXTENSIONS_ACTIVE];

--- a/lib/server-handshake.c
+++ b/lib/server-handshake.c
@@ -217,10 +217,11 @@ handshake_0405(struct libwebsocket_context *context, struct libwebsocket *wsi)
 
 	if (lws_hdr_total_length(wsi, WSI_TOKEN_PROTOCOL)) {
 		LWS_CPYAPP(p, "\x0d\x0aSec-WebSocket-Protocol: ");
-		n = lws_hdr_copy(wsi, p, 128, WSI_TOKEN_PROTOCOL);
-		if (n < 0)
-			goto bail;
-		p += n;
+		const char *proto = wsi->selected_protocol ? wsi->selected_protocol :
+		    wsi->protocol->name;
+		lwsl_debug("replying with selected proto='%s'\n", proto);
+		strcpy(p, proto);
+		p += strlen(proto);
 	}
 
 #ifndef LWS_NO_EXTENSIONS

--- a/lib/server.c
+++ b/lib/server.c
@@ -395,6 +395,16 @@ int lws_handshake_server(struct libwebsocket_context *context,
 			while (context->protocols[n].callback) {
 				if (!wsi->protocol->name)
 					continue;
+				/* a zero-length protocol name always matches
+				 * later, a FILTER_PROTOCOL_CONNECTION callback
+				 * can sort out what to with the offered names
+				 */
+				if (*(wsi->protocol->name) == 0) {
+				    lwsl_info("protocol wildcard match %d\n", n);
+				    wsi->protocol = &context->protocols[n];
+				    hit = 1;
+				    break;
+				}
 				if (!strcmp(context->protocols[n].name,
 					    protocol_name)) {
 					lwsl_info("prot match %d\n", n);

--- a/lib/server.c
+++ b/lib/server.c
@@ -123,7 +123,11 @@ int lws_context_init_server(struct lws_context_creation_info *info,
 	context->listen_service_count = 0;
 	context->listen_service_fd = sockfd;
 
-	listen(sockfd, LWS_SOMAXCONN);
+	if (listen(sockfd, LWS_SOMAXCONN)) {
+		lwsl_err("listen: %s\n", strerror(LWS_ERRNO));
+		compatible_close(sockfd);
+		return 1;
+	}
 	lwsl_notice(" Listening on port %d\n", info->port);
 	
 	return 0;

--- a/lib/server.c
+++ b/lib/server.c
@@ -94,8 +94,8 @@ int lws_context_init_server(struct lws_context_creation_info *info,
 
 	n = bind(sockfd, v, n);
 	if (n < 0) {
-		lwsl_err("ERROR on binding to port %d (%d %d)\n",
-					      info->port, n, LWS_ERRNO);
+		lwsl_err("ERROR on binding to port %d (%d %d): %s\n",
+			 info->port, n, LWS_ERRNO, strerror(LWS_ERRNO));
 		compatible_close(sockfd);
 		return 1;
 	}

--- a/lib/server.c
+++ b/lib/server.c
@@ -950,3 +950,14 @@ lws_server_get_canonical_hostname(struct libwebsocket_context *context,
 
 	lwsl_notice(" canonical_hostname = %s\n", context->canonical_hostname);
 }
+
+LWS_VISIBLE void
+libwebsocket_set_protocol(struct libwebsocket *wsi,
+			  char *protocol_name,
+			  struct libwebsocket_protocols *proto)
+{
+    wsi->selected_protocol = protocol_name;
+    if (proto)
+	wsi->protocol = proto;
+}
+


### PR DESCRIPTION

Also includes #157: 

if an empty string as protocol name in struct libwebsocket_protocols is
specified, it will match any protocol the client requested.

A later FILTER_PROTOCOL_CONNECTION callback can then be used to sort out details, like
setting options in the user session structure based on the actual proto name.

The previous two commits are minor - error message improvements.