### PR TITLE
config: introduce integer LWS_LIBRARY_VERSION_NUMBER, micro numbering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,15 @@ set(PACKAGE "libwebsockets")
 set(CPACK_PACKAGE_NAME "${PACKAGE}")
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "3")
-set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_MICRO "1")
+
+MATH( EXPR CPACK_PACKAGE_VERSION_INT "${CPACK_PACKAGE_VERSION_MAJOR} * 1000000" )
+MATH( EXPR CPACK_PACKAGE_VERSION_INT "${CPACK_PACKAGE_VERSION_INT} + ${CPACK_PACKAGE_VERSION_MINOR} * 1000" )
+MATH( EXPR CPACK_PACKAGE_VERSION_INT "${CPACK_PACKAGE_VERSION_INT} + ${CPACK_PACKAGE_VERSION_MICRO}" )
+MESSAGE( "CPACK_PACKAGE_VERSION_INT set to ${CPACK_PACKAGE_VERSION_INT}" )
+
+
+set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_MICRO}")
 set(CPACK_PACKAGE_VENDOR "andy@warmcat.com")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PACKAGE} ${PACKAGE_VERSION}")
 set(SOVERSION "4.0.0")
@@ -15,6 +23,8 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSIO
 set(VERSION "${CPACK_PACKAGE_VERSION}")
 
 set(LWS_LIBRARY_VERSION ${CPACK_PACKAGE_VERSION})
+set(LWS_LIBRARY_VERSION_NUMBER ${CPACK_PACKAGE_VERSION_INT})
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 message(STATUS "CMAKE_TOOLCHAIN_FILE='${CMAKE_TOOLCHAIN_FILE}'")
@@ -244,10 +254,16 @@ if (NOT HAVE_REALLOC)
 	set(realloc rpl_realloc)
 endif()
 
-# Generate the config.h that includes all the compilation settings.
+# Generate the lws_config.h that includes all the compilation settings.
 configure_file(
        "${PROJECT_SOURCE_DIR}/config.h.cmake"
        "${PROJECT_BINARY_DIR}/lws_config.h")
+
+# Generate the lws_version.h for using code inclusion.
+# this avoids importing library build settings into using code.
+configure_file(
+       "${PROJECT_SOURCE_DIR}/version.h.cmake"
+       "${PROJECT_BINARY_DIR}/lws_version.h")
 
 if (MSVC)
 	# Turn off stupid microsoft security warnings.

--- a/changelog
+++ b/changelog
@@ -16,6 +16,22 @@ be used by the user code to mark the selected protocol by user-defined version
 or capabliity flag information, for the case multiple versions of a protocol are
 supported.
 
+The LWS_LIBRARY_VERSION string contains a 'micro' field now (e.g "1.3.1"),
+set from macros in CMakelists.txt. At least the micro field should be
+incremented for each API change.
+
+There's a new integer macro symbol LWS_LIBRARY_VERSION_NUMBER (e.g. 1003001).
+This number represents major*10^6 + minor*10^3 + micro and increases for
+each version increment. This technique is used in Google protobuf and
+very useful to track API changes in using code.
+
+to use version-dependent features from now on, use like so:
+
+#if defined(LWS_LIBRARY_VERSION_NUMBER) && (LWS_LIBRARY_VERSION_NUMBER > 1003000)
+	// use feature introduced post 1.3.0
+#endif
+
+
 
 v1.3-chrome37-firefox30
 =======================

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Libwebsocket version is now in a separate lws_version.h include */
+#include "lws_version.h"
+
 #ifndef WIN32
 #cmakedefine _DEBUG
 #endif
@@ -7,12 +10,6 @@
 /* Define to 1 to use CyaSSL as a replacement for OpenSSL. 
  * LWS_OPENSSL_SUPPORT needs to be set also for this to work. */
 #cmakedefine USE_CYASSL
-
-/* The Libwebsocket version */
-#cmakedefine LWS_LIBRARY_VERSION "${LWS_LIBRARY_VERSION}"
-
-/* The current git commit hash that we're building from */
-#cmakedefine LWS_BUILD_HASH "${LWS_BUILD_HASH}"
 
 /* Build with OpenSSL support */
 #cmakedefine LWS_OPENSSL_SUPPORT

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -26,10 +26,12 @@
 extern "C" {
 #include <cstddef>
 #endif
-	
+
 #ifdef CMAKE_BUILD
 #include "lws_config.h"
 #endif
+
+#include "lws_version.h"
 
 #if defined(WIN32) || defined(_WIN32)
 

--- a/version.h.cmake
+++ b/version.h.cmake
@@ -1,0 +1,13 @@
+#ifndef _LWS_VERSION_H_INCLUDED
+#define _LWS_VERSION_H_INCLUDED
+
+/* The Libwebsocket version */
+#cmakedefine LWS_LIBRARY_VERSION "${LWS_LIBRARY_VERSION}"
+
+/* The Libwebsocket version as an int, for easy comparison */
+#cmakedefine LWS_LIBRARY_VERSION_NUMBER ${LWS_LIBRARY_VERSION_NUMBER}
+
+/* The current git commit hash that we're building from */
+#cmakedefine LWS_BUILD_HASH "${LWS_BUILD_HASH}"
+
+#endif // _LWS_VERSION_H_INCLUDED


### PR DESCRIPTION
the current LWS_LIBRARY_VERSION macro is a string, which makes it hard
to test for version-dependent features in using code.

This patch adopts the Google version number method, which encodes a version
as an integer as 'major \* 10^6 + minor \* 10^3 + micro'.

This makes it easy to test:
# if defined(LWS_LIBRARY_VERSION_NUMBER) && (LWS_LIBRARY_VERSION_NUMBER > 1003000)

```
// use feature introduced post 1.3.0
```
# endif

Also, spin out version information into a separate include since
including library build information from lws_config.h is a bad idea as
it interferes with using code.

Signed-off-by: Michael Haberler git@mah.priv.at
