### PR TITLE
cyassl: correct include path for 3.1.x

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -155,7 +155,7 @@
 #ifdef LWS_OPENSSL_SUPPORT
 #ifdef USE_CYASSL
 #include <cyassl/openssl/ssl.h>
-#include <cyassl/error.h>
+#include <cyassl/error-ssl.h>
 unsigned char *
 SHA1(const unsigned char *d, size_t n, unsigned char *md);
 #else


### PR DESCRIPTION
I've no idea how to _check_ for the cyassl version, but this change is required to compile with cyassl3.1.0, as found in current OpenWrt.
