### PR TITLE
RFC: openwrt: Package both cyassl and openssl

### DIFF
--- a/cross-openwrt-makefile
+++ b/cross-openwrt-makefile
@@ -1,33 +1,28 @@
 #
-# libwebsockets makefile for openwrt
+# Copyright (C) 2014 OpenWrt.org
 #
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebsockets
-PKG_VERSION:=2014-03-01
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/warmcat/libwebsockets.git
+PKG_VERSION:=1.3-chrome37-firefox30
+PKG_RELEASE:=1
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/warmcat/$(PKG_NAME)/archive/
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=388dc7d201d8d123841869fb49ec4d94d6dd7f54
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_SOURCE_SUBDIR)
+
 CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-CMAKE_OPTIONS += -DLWS_OPENSSL_CLIENT_CERTS=/etc/ssl/certs
-CMAKE_OPTIONS += -DLWS_OPENSSL_SUPPORT=ON
-CMAKE_OPTIONS += -DLWS_WITH_SSL=ON
-CMAKE_OPTIONS += -DLWS_WITHOUT_TESTAPPS=$(if $(CONFIG_PACKAGE_libwebsockets-examples),"OFF","ON")
+CMAKE_OPTIONS += $(if $(CONFIG_IPV6),,-DLWS_IPV6=)
 
-# for cyassl, define these in addition to LWS_OPENSSL_SUPPORT and
-# edit package/libs/cyassl/Makefile to include --enable-opensslextra
-# CMAKE_OPTIONS += -DLWS_USE_CYASSL=ON
-# CMAKE_OPTIONS += -DLWS_CYASSL_LIB=$(STAGING_DIR)/usr/lib/libcyassl.so
-# CMAKE_OPTIONS += -DLWS_CYASSL_INCLUDE_DIRS=$(STAGING_DIR)/usr/include
+CMAKE_OPTIONS += -DLWS_WITHOUT_TESTAPPS=ON
 
 # other options worth noting
 # CMAKE_OPTIONS += -DLWS_WITHOUT_EXTENSIONS=ON
@@ -36,56 +31,51 @@ CMAKE_OPTIONS += -DLWS_WITHOUT_TESTAPPS=$(if $(CONFIG_PACKAGE_libwebsockets-exam
 # CMAKE_OPTIONS += -DLWS_WITHOUT_DEBUG=ON
 
 
-define Package/libwebsockets/Default
+define Package/$(PKG_NAME)/Default
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE:=libwebsockets
-	DEPENDS:=+zlib +libopenssl
+	DEPENDS:=+zlib
 endef
 
-define Package/libwebsockets
-	$(call Package/libwebsockets/Default)
-	TITLE+= (libraries)
+define Package/libwebsockets-openssl
+	$(call Package/$(PKG_NAME)/Default)
+	TITLE += (OpenSSL)
+	DEPENDS += +libopenssl
+	VARIANT:=openssl
 endef
 
-define Package/libwebsockets/description
-	libwebsockets
-	This package contains libwebsocket libraries
+define Package/libwebsockets-cyassl
+	$(call Package/$(PKG_NAME)/Default)
+	TITLE += (CyaSSL)
+	DEPENDS += +libcyassl
+	VARIANT:=cyassl
 endef
 
-define Package/libwebsockets-examples
-	$(call Package/libwebsockets/Default)
-	DEPENDS:=libwebsockets
-	TITLE+= (examples)
-endef
+ifeq ($(BUILD_VARIANT),openssl)
+    CMAKE_OPTIONS += -DLWS_OPENSSL_CLIENT_CERTS=/etc/ssl/certs
+    CMAKE_OPTIONS += -DLWS_OPENSSL_SUPPORT=ON
+    CMAKE_OPTIONS += -DLWS_WITH_SSL=ON
+endif
 
-define Package/libwebsockets-examples/description
-	libwebsockets examples
-	This package contains libwebsockets examples
-endef
+ifeq ($(BUILD_VARIANT),cyassl)
+    CMAKE_OPTIONS += -DLWS_OPENSSL_CLIENT_CERTS=/etc/ssl/certs
+    CMAKE_OPTIONS += -DLWS_OPENSSL_SUPPORT=ON
+    CMAKE_OPTIONS += -DLWS_WITH_SSL=ON
+# for cyassl, edit package/libs/cyassl/Makefile to include --enable-opensslextra
+# NOTE: it will compile without it, untested whether it it's needed?!
+    CMAKE_OPTIONS += -DLWS_USE_CYASSL=ON
+    CMAKE_OPTIONS += -DLWS_CYASSL_LIB=$(STAGING_DIR)/usr/lib/libcyassl.so
+    CMAKE_OPTIONS += -DLWS_CYASSL_INCLUDE_DIRS=$(STAGING_DIR)/usr/include
+endif
 
 define Package/libwebsockets/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebsockets.so* $(1)/usr/lib/
 endef
 
-define Package/libwebsockets-examples/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libwebsockets-test-client $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libwebsockets-test-echo $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libwebsockets-test-fraggle $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libwebsockets-test-ping $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libwebsockets-test-server $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libwebsockets-test-server-extpoll $(1)/usr/bin/
+Package/$(PKG_NAME)-cyassl/install = $(Package/$(PKG_NAME)/install)
+Package/$(PKG_NAME)-openssl/install = $(Package/$(PKG_NAME)/install)
 
-	$(INSTALL_DIR) $(1)/usr/share/libwebsockets-test-server
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libwebsockets-test-server/favicon.ico $(1)/usr/share/libwebsockets-test-server/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libwebsockets-test-server/leaf.jpg $(1)/usr/share/libwebsockets-test-server/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libwebsockets-test-server/libwebsockets.org-logo.png $(1)/usr/share/libwebsockets-test-server/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libwebsockets-test-server/libwebsockets-test-server.key.pem $(1)/usr/share/libwebsockets-test-server/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libwebsockets-test-server/libwebsockets-test-server.pem $(1)/usr/share/libwebsockets-test-server/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libwebsockets-test-server/test.html $(1)/usr/share/libwebsockets-test-server/
-endef
-
-$(eval $(call BuildPackage,libwebsockets))
-$(eval $(call BuildPackage,libwebsockets-examples))
+$(eval $(call BuildPackage,libwebsockets-openssl))
+$(eval $(call BuildPackage,libwebsockets-cyassl))


### PR DESCRIPTION
This is alternative openwrt package makefile.  It drops the example
applications, as they're 600k+ and it's tedious to get them to build for
both variants of the ssl library.  It includes packages for both cyassl
and openssl variants, though the cyassl variant is only compile tested.
The notes in the original file about needing to add
--enable-opensslextra don't seem to get in the way of building at least?

If this all works out, I can get this into standard openwrt package
repositories.

I'd like some more feedback on this of course, should the other options be given config choices? Is there call for a -nossl variant?  Are the example apps really really useful?