### PR TITLE
server.c: test **truncated_send_len** for partial

### DIFF
--- a/lib/server.c
+++ b/lib/server.c
@@ -572,7 +572,7 @@ int lws_server_socket_service(struct libwebsocket_context *context,
 
 		/* pending truncated sends have uber priority */
 
-		if (wsi->truncated_send_malloc) {
+		if (wsi->truncated_send_len) {
 			if (pollfd->revents & LWS_POLLOUT)
 				if (lws_issue_raw(wsi, wsi->truncated_send_malloc +
 					wsi->truncated_send_offset,


### PR DESCRIPTION
Small patch to server.c:
Testing against **truncated_send_malloc** won't work if we've already buffered and completed a partial buffer, as truncated_send_malloc isn't free'd until the socket is destroyed. Test against **truncated_send_len** (as is done elsewhere) instead.
