### PR TITLE
fix required CMake version

### DIFF
--- a/README.build
+++ b/README.build
@@ -31,7 +31,7 @@ see below on how to toggle compile options.
 Building on Unix:
 -----------------
 
-1. Install CMake 2.6 or greater: http://cmake.org/cmake/resources/software.html
+1. Install CMake 2.8 or greater: http://cmake.org/cmake/resources/software.html
    (Most Unix distributions comes with a packaged version also)
 
 2. Install OpenSSL.


### PR DESCRIPTION
CMakeLists.txt doesn't work on CMake 2.6.
export(PACKAGE, name) requires CMake 2.8 or greater.
