### PR TITLE
Initialize openssl during client initialization.

### DIFF
--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -241,6 +241,13 @@ int lws_context_init_client_ssl(struct lws_context_creation_info *info,
 	if (info->port != CONTEXT_PORT_NO_LISTEN)
 		return 0;
 
+	/* basic openssl init */
+
+	SSL_library_init();
+
+	OpenSSL_add_all_algorithms();
+	SSL_load_error_strings();
+
 	method = (SSL_METHOD *)SSLv23_client_method();
 	if (!method) {
 		error = ERR_get_error();


### PR DESCRIPTION
Currently test client fails to work since it does not initialize openssl. This fixes this problem.
