### PR TITLE
BUGFIX: Failed to get proper output dir for test-server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,7 +679,7 @@ if (NOT LWS_WITHOUT_TESTAPPS)
 
 		add_custom_command(TARGET test-server
 						POST_BUILD 
-						COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:test-server>/../share/libwebsockets-test-server")
+						COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:test-server>/../share/libwebsockets-test-server" VERBATIM)
 
 		# Copy the file needed to run the server so that the test apps can
 		# reach them from their default output location


### PR DESCRIPTION
When creating the directory where to put the files needed by the test-server CMake would fail because it tried to create the directory /../share/libwebsockets-test-server, which is not possible. This happens since the TARGET_FILE_DIR for the test-server is not fetched properly.

Also mentioned in this trac ticket:
http://libwebsockets.org/trac/libwebsockets/ticket/84
