### PR TITLE
BUGFIX: Failed to get proper output dir for test-server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,7 +679,9 @@ if (NOT LWS_WITHOUT_TESTAPPS)
 
 		add_custom_command(TARGET test-server
 						POST_BUILD 
-						COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:test-server>/../share/libwebsockets-test-server")
+						COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:test-server>/../share/libwebsockets-test-server"
+						COMMENT "Creating test-server $<TARGET_FILE_DIR:test-server> share directory"
+						VERBATIM)
 
 		# Copy the file needed to run the server so that the test apps can
 		# reach them from their default output location
@@ -687,7 +689,9 @@ if (NOT LWS_WITHOUT_TESTAPPS)
 			if (EXISTS ${TEST_FILE})
 				add_custom_command(TARGET test-server
 							POST_BUILD 
-							COMMAND "${CMAKE_COMMAND}" -E copy "${TEST_FILE}" "$<TARGET_FILE_DIR:test-server>/../share/libwebsockets-test-server" VERBATIM)
+							COMMAND "${CMAKE_COMMAND}" -E copy "${TEST_FILE}" "$<TARGET_FILE_DIR:test-server>/../share/libwebsockets-test-server"
+							COMMENT "Copying test-server files"
+							VERBATIM)
 			endif()
 		endforeach()
 	endif(NOT LWS_WITHOUT_SERVER)

--- a/test-server/test-server.c
+++ b/test-server/test-server.c
@@ -842,6 +842,8 @@ int main(int argc, char **argv)
 	lwsl_notice("libwebsockets test server - "
 			"(C) Copyright 2010-2014 Andy Green <andy@warmcat.com> - "
 						    "licensed under LGPL2.1\n");
+
+	printf("Using resource path \"%s\"\n", resource_path);
 #ifdef EXTERNAL_POLL
 	max_poll_elements = getdtablesize();
 	pollfds = malloc(max_poll_elements * sizeof (struct pollfd));


### PR DESCRIPTION
When creating the directory where to put the files needed by the test-server CMake would fail because it tried to create the directory /../share/libwebsockets-test-server, which is not possible. This happens since the TARGET_FILE_DIR for the test-server is not fetched properly.

Also mentioned in this trac ticket:
http://libwebsockets.org/trac/libwebsockets/ticket/84
