### PR TITLE
Hdr table free

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -88,8 +88,7 @@ libwebsocket_close_and_free_session(struct libwebsocket_context *context,
 		context->protocols[0].callback(context, wsi,
 			LWS_CALLBACK_CLIENT_CONNECTION_ERROR, wsi->user_space, NULL, 0);
 
-		free(wsi->u.hdr.ah);
-		wsi->u.hdr.ah = NULL;
+		lws_free_header_table(wsi);
 		goto just_kill_connection;
 	}
 

--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -73,6 +73,15 @@ int lws_allocate_header_table(struct libwebsocket *wsi)
 	return 0;
 }
 
+int lws_free_header_table(struct libwebsocket *wsi)
+{
+    if( wsi->u.hdr.ah ) {
+        free( wsi->u.hdr.ah );
+        wsi->u.hdr.ah = NULL;
+    };
+    return 0;
+};
+
 LWS_VISIBLE int lws_hdr_total_length(struct libwebsocket *wsi, enum lws_token_indexes h)
 {
 	int n;

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1013,6 +1013,9 @@ lws_plat_set_socket_options(struct libwebsocket_context *context, int fd);
 LWS_EXTERN int
 lws_allocate_header_table(struct libwebsocket *wsi);
 
+LWS_EXTERN int
+lws_free_header_table(struct libwebsocket *wsi);
+
 LWS_EXTERN char *
 lws_hdr_simple_ptr(struct libwebsocket *wsi, enum lws_token_indexes h);
 

--- a/lib/server-handshake.c
+++ b/lib/server-handshake.c
@@ -268,10 +268,7 @@ handshake_0405(struct libwebsocket_context *context, struct libwebsocket *wsi)
 
 bail:
 	/* free up his parsing allocations */
-
-	if (wsi->u.hdr.ah)
-		free(wsi->u.hdr.ah);
-
+	lws_free_header_table(wsi);
 	return -1;
 }
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -550,9 +550,7 @@ upgrade_ws:
 		}
 
 		/* drop the header info -- no bail_nuke_ah after this */
-
-		if (wsi->u.hdr.ah)
-			free(wsi->u.hdr.ah);
+		lws_free_header_table(wsi);
 
 		wsi->mode = LWS_CONNMODE_WS_SERVING;
 
@@ -589,8 +587,7 @@ upgrade_ws:
 
 bail_nuke_ah:
 	/* drop the header info */
-	if (wsi->u.hdr.ah)
-		free(wsi->u.hdr.ah);
+	lws_free_header_table(wsi);
 	return 1;
 }
 
@@ -713,7 +710,7 @@ int lws_server_socket_service(struct libwebsocket_context *context,
 				lwsl_info("lws_server_skt_srv: read 0 len\n");
 				/* lwsl_info("   state=%d\n", wsi->state); */
 				if (!wsi->hdr_parsing_completed)
-					free(wsi->u.hdr.ah);
+					lws_free_header_table(wsi);
 				/* fallthru */
 			case LWS_SSL_CAPABLE_ERROR:
 				libwebsocket_close_and_free_session(


### PR DESCRIPTION
Hey Andy, I added this in my fork to clear up some memory issues we'd run into at high load. Thought I'd submit a pull request for the canonical repo.

Rationale: Failing client WS handshakes resulted in a double-free of wsi->u.hdr.ah. This change adds lws_free_header_table to wrap the logic for freeing the allocated header table which should prevent future errors.

Ciao!
