### PR TITLE
Memory leak fix for dangling header tables.

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -295,6 +295,8 @@ just_kill_connection:
 	    wsi->user_space && !wsi->user_space_externally_allocated)
 		free(wsi->user_space);
 
+	/* As a precaution, free the header table in case it lingered: */
+	lws_free_header_table(wsi);
 	free(wsi);
 }
 

--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -61,6 +61,8 @@ int lextable_decode(int pos, char c)
 
 int lws_allocate_header_table(struct libwebsocket *wsi)
 {
+	/* Be sure to free any existing header data to avoid mem leak: */
+	lws_free_header_table(wsi);
 	wsi->u.hdr.ah = malloc(sizeof(*wsi->u.hdr.ah));
 	if (wsi->u.hdr.ah == NULL) {
 		lwsl_err("Out of memory\n");


### PR DESCRIPTION
Be sure to invoke _lws_free_header_table_:
- Just prior to freeing a session
- When allocating a new header table

This prevents some memory leaks we've found.
