### PR TITLE
Adding lws_config.h to list of installed headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,11 +260,11 @@ include_directories("${PROJECT_SOURCE_DIR}/lib")
 # Some IDEs use this for nicer file structure.
 set(HDR_PRIVATE
 	lib/private-libwebsockets.h
-	"${PROJECT_BINARY_DIR}/lws_config.h"
 	)
 
 set(HDR_PUBLIC	
 	"${PROJECT_SOURCE_DIR}/lib/libwebsockets.h"
+	"${PROJECT_BINARY_DIR}/lws_config.h"
 	)
 
 set(SOURCES


### PR DESCRIPTION
The lws_config.h is generated based on configuration
options for the build process. In order to write
applications which compile code depending of the
presence of a feature (like the test-server does)
this header file needs to be installed.

Signed-off-by: Christoph Muellner christoph.muellner@theobroma-systems.com
