### PR TITLE
cmake: set the project language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(libwebsockets)
+project(libwebsockets C)
 
 set(PACKAGE "libwebsockets")
 set(CPACK_PACKAGE_NAME "${PACKAGE}")


### PR DESCRIPTION
By default, CMake sets C and C++ as languages used by the project.
This makes the configuration failed if no C++ compiler is found.

Since libwesockets in written in pure C, no C++, there is no reason to
disable it when the toolchain has no C++ support.

This patch just make the CMake code reflecting the real status of the
project with regard to the languages used.

Signed-off-by: Samuel Martin s.martin49@gmail.com
Signed-off-by: Christoph Muellner christoph.muellner@theobroma-systems.com
