### PR TITLE
Add support for coverity static analysis scan.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 env:
+  # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+  #   via the "travis encrypt" command using the project repo's public key
+  # TODO: Replace the secure key below!
+  global:
+   - secure: "<put the real key here>"
   - LWS_METHOD=default
   - LWS_METHOD=noserver CMAKE_ARGS="-DLWS_WITHOUT_SERVER=ON"
   - LWS_METHOD=noclient CMAKE_ARGS="-DLWS_WITHOUT_CLIENT=ON"
@@ -14,7 +19,15 @@ compiler:
 language: c
 install:
   - sudo apt-get update -qq && sudo apt-get install -y -qq valgrind
-  - if [ x$LWS_METHOD == xlibev ]; then sudo apt-get install -y -qq libev-dev; fi
+  - if [ x$LWS_METHOD == xlibev ] && [ "$COVERITY_SCAN_BRANCH" != 1 ]; then sudo apt-get install -y -qq libev-dev; fi
 script:
-  - mkdir build && cd build && cmake $CMAKE_ARGS .. && cmake --build .
-
+  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then mkdir build && cd build && cmake $CMAKE_ARGS .. && cmake --build .; fi
+addons:
+  coverity_scan:
+    project:
+      name: "warmcat/libwebsockets"
+      description: "This is the libwebsockets C library for lightweight websocket clients and servers."
+    notification_email: andy.green@linaro.org
+    build_command_prepend: "mkdir build && cd build && cmake .."
+    build_command:   "cmake --build ."
+    branch_pattern: coverity_scan


### PR DESCRIPTION
http://www.coverity.com/ is a great static analysis tool that is free for open source projects.

With travis-ci it is possible to make it upload builds to this service automatically. However, there is a limit on 7 scans per week, so it is not recommended to do it on each commit, but rather have a separate branch that you can push to every now and then to see if there are any new defects.

This pull request contains most of what is needed in the travis file. To complete the process you however need to add an encrypted version of your `COVERITY_SCAN_TOKEN` to the `.travis.yml` file where I have indicated.

What you need to do:
1. Go to https://scan.coverity.com/
2. Sign Up -> **Sign in with Github**
3. Click **"Add Project"** -> **"Register my Github project"** -> Find **libwebsockets** and add it.
4. On the project page click **"Submit Build"**
5. At the top of the page click **"Configure Travis CI"**
6. Copy the secure string from the example and put it in the **libwebsockets** `.travis.yml` file where indicated.

After doing this you should be able to push to the `coverity_scan` branch and soon get a report from coverity, and use their tool to classify the different defects as false positive and so on. This is a great tool for finding complicated bugs.

If you get stuck Here is the official Travis-CI guide for further details:
https://scan.coverity.com/travis_ci
