### PR TITLE
Attempt at fixing Travis for OSX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ os:
   - osx
 language: c
 install:
-  - sudo apt-get update -qq && sudo apt-get install -y -qq valgrind
-  - if [ x$LWS_METHOD == xlibev ] && [ "$COVERITY_SCAN_BRANCH" != 1 ]; then sudo apt-get install -y -qq libev-dev; fi
+  - ./travis_install.sh
 script:
   - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then mkdir build && cd build && cmake $CMAKE_ARGS .. && cmake --build .; fi
 addons:

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ "$COVERITY_SCAN_BRANCH" == 1 ]; then exit; fi
+
+if [ "$TRAVIS_OS_NAME" == "linux" ];
+then
+	sudo apt-get update -qq
+
+	if [ "$LWS_METHOD" == "libev" ];
+	then
+		sudo apt-get install -y -qq libev-dev;
+	fi
+fi
+
+if [ "$TRAVIS_OS_NAME" == "osx" ];
+then
+	if [ "$LWS_METHOD" == "libev" ];
+	then
+		brew install libev;
+	fi
+fi
+
+	


### PR DESCRIPTION
Move install into external shell script. We cannot use apt-get on OSX, use brew instead... Also valgrind isn't used at the moment so skip intalling it.
