### PR TITLE
Fixes occasional segfault in lws_chage_pollfd

### DIFF
--- a/lib/pollfd.c
+++ b/lib/pollfd.c
@@ -131,7 +131,11 @@ do_ext:
 int
 lws_change_pollfd(struct libwebsocket *wsi, int _and, int _or)
 {
+	if (!wsi || !wsi->protocol || wsi->position_in_fds_table<0)
+		return 1;
 	struct libwebsocket_context *context = wsi->protocol->owning_server;
+	if (!context)
+		return 1;
 	int tid;
 	int sampled_tid;
 	struct libwebsocket_pollfd *pfd;


### PR DESCRIPTION
- so it happens that sometimes lws_change_pollfd is called with
  bad or incomplete data structures, mainly the context pointer
  obtained from wsi->protocol is null or wsi->position_in_fds_table
  is -1; checks have been added to avoid this condition
