### PR TITLE
Fix error handling when calling "REQUIRES PRIVATE KEY" callback.

### DIFF
--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -208,9 +208,10 @@ lws_context_init_server_ssl(struct lws_context_creation_info *info,
 		else {
 			if (context->protocols[0].callback(context, NULL,
 				LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-						context->ssl_ctx, NULL, 0))
+						context->ssl_ctx, NULL, 0)) {
 				lwsl_err("ssl private key not set\n");
 				return 1;
+			}
 		}
 
 		/* verify private key */


### PR DESCRIPTION
A recent patch in ssl.c introduced a callback for setting the
private key of the SSL context. This code contained a bug, which
resulted in lws_context_init_server_ssl() returning always
with a return value of 1, indicating an error.

This patch introduces the missing curly braces to fix the code's
intended behaviour.