### PR TITLE
Callback with LWS_CALLBACK_CLOSED_HTTP when HTTP closed before serve

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -92,6 +92,11 @@ libwebsocket_close_and_free_session(struct libwebsocket_context *context,
 		goto just_kill_connection;
 	}
 
+	if (wsi->mode == LWS_CONNMODE_HTTP_SERVING) {
+		context->protocols[0].callback(context, wsi,
+			LWS_CALLBACK_CLOSED_HTTP, wsi->user_space, NULL, 0);
+	}
+
 	if (wsi->mode == LWS_CONNMODE_HTTP_SERVING_ACCEPTED) {
 		if (wsi->u.http.fd != LWS_INVALID_FILE) {
 			lwsl_debug("closing http file\n");


### PR DESCRIPTION
If the remote HTTP client closes the connection before serving commences, the only notification client code receives is `LWS_CALLBACK_WSI_DESTROY`. This commit gives `LWS_CALLBACK_CLOSED_HTTP` as well, as would happen if HTTP serving had already commenced.

Without this patch we experienced a hard-to-debug segfault where we weren't aware the other end of the connection was gone and tried to asynchronously write to a stored wsi which has since been destroyed.