### PR TITLE
Fix bug parsing unknown headers

### DIFF
--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -422,8 +422,11 @@ swallow:
 			 * treat as dangerous
 			 */
 
-			lwsl_info("Unknown method - dropping\n");
-			return -1;
+			if (m == ARRAY_SIZE(methods)) {
+				lwsl_info("Unknown method - dropping\n");
+				return -1;
+			}
+			break;
 		}
 		if (lextable[wsi->u.hdr.lextable_pos] < FAIL_CHAR) {
 			/* terminal state */


### PR DESCRIPTION
Bug was introduced in 49f72aa45.

Discovered this as a user was sending `DNT: 1` (Do Not Track) due to enabling a browser setting. This is actually a handy way to test sending an unknown header from a browser.