### PR TITLE
updated SO version in spec file when building RPM

### DIFF
--- a/libwebsockets.spec
+++ b/libwebsockets.spec
@@ -51,7 +51,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(755,root,root) /usr/bin/libwebsockets-test-echo
 %attr(755,root,root) /usr/bin/libwebsockets-test-fraggle
 %attr(755,root,root) 
-/%{_libdir}/libwebsockets.so.4.0.0
+/%{_libdir}/libwebsockets.so.5
 /%{_libdir}/libwebsockets.so
 %attr(755,root,root) /usr/share/libwebsockets-test-server
 %doc


### PR DESCRIPTION
received an error when building RPM, looking for libwebsocekts.so.4.0.0 but libwebsockets.so.5 was actually built.  updated the spec file to reflect the version change