### PR TITLE
Fix broken libev support in client mode

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -151,6 +151,7 @@ struct libwebsocket *libwebsocket_client_connect_2(
 
 		wsi->mode = LWS_CONNMODE_WS_CLIENT_WAITING_CONNECT;
 
+		lws_libev_accept(context, wsi, wsi->sock);
 		insert_wsi_socket_into_fds(context, wsi);
 
 		libwebsocket_set_timeout(wsi,
@@ -212,6 +213,7 @@ struct libwebsocket *libwebsocket_client_connect_2(
 			 */
 			if (lws_change_pollfd(wsi, 0, LWS_POLLOUT))
 				goto oom4;
+			lws_libev_io(context, wsi, LWS_EV_START | LWS_EV_WRITE);
 
 			return wsi;
 		}

--- a/lib/lws-plat-unix.c
+++ b/lib/lws-plat-unix.c
@@ -274,6 +274,13 @@ lws_plat_drop_app_privileges(struct lws_context_creation_info *info)
 LWS_VISIBLE int
 lws_plat_init_fd_tables(struct libwebsocket_context *context)
 {
+	context->fd_random = open(SYSTEM_RANDOM_FILEPATH, O_RDONLY);
+	if (context->fd_random < 0) {
+		lwsl_err("Unable to open random device %s %d\n",
+				    SYSTEM_RANDOM_FILEPATH, context->fd_random);
+		return 1;
+	}
+
 	if (lws_libev_init_fd_table(context))
 		/* libev handled it instead */
 		return 0;
@@ -288,13 +295,6 @@ lws_plat_init_fd_tables(struct libwebsocket_context *context)
 	context->fds[0].events = LWS_POLLIN;
 	context->fds[0].revents = 0;
 	context->fds_count = 1;
-
-	context->fd_random = open(SYSTEM_RANDOM_FILEPATH, O_RDONLY);
-	if (context->fd_random < 0) {
-		lwsl_err("Unable to open random device %s %d\n",
-				    SYSTEM_RANDOM_FILEPATH, context->fd_random);
-		return 1;
-	}
 
 	return 0;
 }


### PR DESCRIPTION
Maybe it will be better to move all lws_libev_io() inside
lws_change_pollfd() to avoid similar problems in future.
The same for lws_libev_accept() and insert_wsi_socket_into_fds().