### PR TITLE
Feature/ev sigint

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -314,6 +314,17 @@ libwebsocket_context_destroy(struct libwebsocket_context *context)
 		n--;
 	}
 
+#ifdef LWS_USE_LIBEV
+	/* (Issue #264) In order to *avoid breaking backwards compatibility*, we
+	 * enable libev mediated SIGINT handling with a default handler of
+	 * libwebsocket_sigint_cb. The handler can be overridden or disabled
+	 * by invoking libwebsocket_sigint_cfg after creating the context, but
+	 * before invoking libwebsocket_initloop:
+	 */
+	context->use_ev_sigint = 1;
+	context->lws_ev_sigint_cb = &libwebsocket_sigint_cb;
+#endif /* LWS_USE_LIBEV */
+
 	/*
 	 * give all extensions a chance to clean up any per-context
 	 * allocations they might have made

--- a/lib/context.c
+++ b/lib/context.c
@@ -126,6 +126,18 @@ libwebsocket_create_context(struct lws_context_creation_info *info)
 	context->ka_interval = info->ka_interval;
 	context->ka_probes = info->ka_probes;
 
+#ifdef LWS_USE_LIBEV
+	/* (Issue #264) In order to *avoid breaking backwards compatibility*, we
+	 * enable libev mediated SIGINT handling with a default handler of
+	 * libwebsocket_sigint_cb. The handler can be overridden or disabled
+	 * by invoking libwebsocket_sigint_cfg after creating the context, but
+	 * before invoking libwebsocket_initloop:
+	 */
+	context->use_ev_sigint = 1;
+	context->lws_ev_sigint_cb = &libwebsocket_sigint_cb;
+#endif /* LWS_USE_LIBEV */
+
+
 	/* to reduce this allocation, */
 	context->max_fds = getdtablesize();
 	lwsl_notice(" static allocation: %u + (%u x %u fds) = %u bytes\n",
@@ -313,17 +325,6 @@ libwebsocket_context_destroy(struct libwebsocket_context *context)
 			wsi, LWS_CLOSE_STATUS_NOSTATUS_CONTEXT_DESTROY /* no protocol close */);
 		n--;
 	}
-
-#ifdef LWS_USE_LIBEV
-	/* (Issue #264) In order to *avoid breaking backwards compatibility*, we
-	 * enable libev mediated SIGINT handling with a default handler of
-	 * libwebsocket_sigint_cb. The handler can be overridden or disabled
-	 * by invoking libwebsocket_sigint_cfg after creating the context, but
-	 * before invoking libwebsocket_initloop:
-	 */
-	context->use_ev_sigint = 1;
-	context->lws_ev_sigint_cb = &libwebsocket_sigint_cb;
-#endif /* LWS_USE_LIBEV */
 
 	/*
 	 * give all extensions a chance to clean up any per-context

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1137,6 +1137,14 @@ lws_add_http_header_status(struct libwebsocket_context *context,
 LWS_EXTERN int lws_http_transaction_completed(struct libwebsocket *wsi);
 
 #ifdef LWS_USE_LIBEV
+typedef void (lws_ev_signal_cb)(EV_P_ struct ev_signal *w, int revents);
+
+LWS_VISIBLE LWS_EXTERN int
+libwebsocket_sigint_cfg(
+	struct libwebsocket_context *context,
+	int use_ev_sigint,
+	lws_ev_signal_cb* cb);
+
 LWS_VISIBLE LWS_EXTERN int
 libwebsocket_initloop(
 	struct libwebsocket_context *context, struct ev_loop *loop);

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -432,6 +432,8 @@ struct libwebsocket_context {
 	struct ev_loop* io_loop;
 	struct lws_io_watcher w_accept;
 	struct lws_signal_watcher w_sigint;
+	lws_ev_signal_cb* lws_ev_sigint_cb;
+	int use_ev_sigint;
 #endif /* LWS_USE_LIBEV */
 	int max_fds;
 	int listen_port;


### PR DESCRIPTION
Resolves issue #264 in a backwards compatible way:

**_ONLY IF LWS_USE_LIBEV IS DEFINED_**

A new API function is provided:
```C
LWS_VISIBLE LWS_EXTERN int
libwebsocket_sigint_cfg(
    struct libwebsocket_context *context,
    int use_ev_sigint,
    lws_ev_signal_cb* cb);
```
It can (optionally) be invoked *after libwebsocket_create_context* and *before libwebsocket_initloop*.
 * To _prevent libwebsockets from setting the libev SIGINT handler entirely_: pass *use_ev_sigint* as *0*.
 * To instruct libwebsockets to install a _custom handler_, set *use_ev_sigint* to *1*, and pass your callback function as the third argument.
 * To instruct libwebsockets to use its _default handler_, set *use_ev_sigint* to *1* and set *cb* to ```NULL```.

If no action is taken, libwebsocket_sigint_cb will be installed, as usual to prevent breaking backwards compatibility.
For your convenience, the ev_signal callback has been typedef'ed for you as  lws_ev_signal_cb.