### PR TITLE
update spec file for RPM generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,7 +824,7 @@ Name: libwebsockets
 Description: Websockets server and client library
 Version: ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}
 
-Libs: -L\${libdir} -lwebsockets
+Libs: -L\${libdir} -lwebsockets_shared
 Cflags: -I\${includedir}"
 )
 

--- a/libwebsockets.spec
+++ b/libwebsockets.spec
@@ -50,9 +50,11 @@ rm -rf $RPM_BUILD_ROOT
 %attr(755,root,root) /usr/bin/libwebsockets-test-ping
 %attr(755,root,root) /usr/bin/libwebsockets-test-echo
 %attr(755,root,root) /usr/bin/libwebsockets-test-fraggle
+%attr(644,root,root) /usr/lib/cmake/libwebsockets/LibwebsocketsTargets-release.cmake
+%attr(644,root,root) /usr/lib/cmake/libwebsockets/LibwebsocketsTargets.cmake
 %attr(755,root,root) 
-/%{_libdir}/libwebsockets.so.5
-/%{_libdir}/libwebsockets.so
+/%{_libdir}/libwebsockets_shared.so.5
+/%{_libdir}/libwebsockets_shared.so
 %attr(755,root,root) /usr/share/libwebsockets-test-server
 %doc
 %files devel


### PR DESCRIPTION
Missing files that are installed, old name of shared object (missing
_shared in the name).

Additionally, for dynamic linkage, it was needed to update -l in the pc file.