### PR TITLE
Fix shared library name for all platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,23 +416,37 @@ source_group("Sources"          FILES ${SOURCES})
 # Create the lib.
 #
 set(LWS_LIBRARIES)
+
 if (LWS_WITH_STATIC)
 	add_library(websockets STATIC
 				${HDR_PRIVATE}
 				${HDR_PUBLIC}
 				${SOURCES})
 	list(APPEND LWS_LIBRARIES websockets)
+
+	if (WIN32)
+		# Windows uses the same .lib ending for static libraries and shared
+		# library linker files, so rename the static library.
+		set_target_properties(websockets
+			PROPERTIES
+			OUTPUT_NAME websockets_static)
+	endif()
 endif()
+
 if (LWS_WITH_SHARED)
 	add_library(websockets_shared SHARED
 				${HDR_PRIVATE}
 				${HDR_PUBLIC}
 				${SOURCES})
 	list(APPEND LWS_LIBRARIES websockets_shared)
-endif()
 
-if (WIN32)
-	if (LWS_WITH_SHARED)
+	# We want the shared lib to be named "libwebsockets"
+	# not "libwebsocket_shared".
+	set_target_properties(websockets_shared
+		PROPERTIES
+		OUTPUT_NAME websockets)
+
+	if (WIN32)
 		# Compile as DLL (export function declarations)
 		set_property(
 			TARGET websockets_shared
@@ -440,15 +454,12 @@ if (WIN32)
 			LWS_DLL
 			LWS_INTERNAL)
 	endif()
-elseif(APPLE)
-	if (LWS_WITH_SHARED)
+
+	if (APPLE)
 		set_property(TARGET websockets_shared PROPERTY MACOSX_RPATH YES)
 	endif()
-else()
-	set_target_properties(websockets_shared
-	PROPERTIES
-	OUTPUT_NAME websockets)
 endif()
+
 
 # Set the so version of the lib.
 # Equivalent to LDFLAGS=-version-info x:x:x

--- a/win32port/libwebsockets.nsi
+++ b/win32port/libwebsockets.nsi
@@ -45,7 +45,7 @@ Section "Files" SecInstall
 	File "..\build\bin\Release\libwebsockets-test-ping.exe"
 	File /nonfatal "..\build\bin\Release\libwebsockets-test-server.exe"
 	File /nonfatal "..\build\bin\Release\libwebsockets-test-server-extpoll.exe"
-	File "..\build\bin\Release\websockets_shared.dll"
+	File "..\build\bin\Release\websockets.dll"
 
 	SetOutPath "$INSTDIR\libwebsockets-test-server"
 	File /nonfatal "..\build\bin\share\libwebsockets-test-server\favicon.ico"
@@ -56,8 +56,8 @@ Section "Files" SecInstall
 	File /nonfatal "..\build\bin\share\libwebsockets-test-server\test.html"
 
 	SetOutPath "$INSTDIR\lib"
-	File "..\build\lib\Release\websockets_shared.lib"
 	File "..\build\lib\Release\websockets.lib"
+	File "..\build\lib\Release\websockets_static.lib"
 
 	SetOutPath "$INSTDIR\include"
 	File "..\lib\libwebsockets.h"
@@ -86,7 +86,7 @@ Section "Uninstall"
 	Delete "$INSTDIR\libwebsockets-test-ping.exe"
 	Delete "$INSTDIR\libwebsockets-test-server.exe"
 	Delete "$INSTDIR\libwebsockets-test-server-extpoll.exe"
-	Delete "$INSTDIR\websockets_shared.dll"
+	Delete "$INSTDIR\websockets.dll"
 
 	Delete "$INSTDIR\libwebsockets-test-server\favicon.ico"
 	Delete "$INSTDIR\libwebsockets-test-server\leaf.jpg"
@@ -96,8 +96,8 @@ Section "Uninstall"
 	Delete "$INSTDIR\libwebsockets-test-server\test.html"
 	RMDir "$INSTDIR\libwebsockets-test-server"
 
-	Delete "$INSTDIR\lib\websockets_shared.lib"
 	Delete "$INSTDIR\lib\websockets.lib"
+	Delete "$INSTDIR\lib\websockets_static.lib"
 	RMDir "$INSTDIR\lib"
 
 	Delete "$INSTDIR\include\libwebsockets.h"


### PR DESCRIPTION
This is a further fix to f1b1254, building on 26fd0d2.

Tidy up the LWS_WITH_SHARED and LWS_WITH_STATIC options.