### PR TITLE
Pass the correct hostname when using a proxy

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -134,7 +134,7 @@ int lws_client_socket_service(struct libwebsocket_context *context,
 		if (wsi->use_ssl && !wsi->ssl) {
 #if defined(CYASSL_SNI_HOST_NAME) || defined(SSL_CTRL_SET_TLSEXT_HOSTNAME)
 			const char *hostname = lws_hdr_simple_ptr(wsi,
-						_WSI_TOKEN_CLIENT_PEER_ADDRESS);
+						_WSI_TOKEN_CLIENT_HOST);
 #endif
 
 			wsi->ssl = SSL_new(context->ssl_client_ctx);


### PR DESCRIPTION
The proxy doesn't modify the SNI request, so we need to pass the name of
the host we're trying to reach instead of the proxy we're reaching it
through.