### PR TITLE
fix #309. Receive large messages over WSS

### DIFF
--- a/lib/output.c
+++ b/lib/output.c
@@ -604,3 +604,9 @@ lws_ssl_capable_write_no_ssl(struct libwebsocket *wsi, unsigned char *buf, int l
 	lwsl_debug("ERROR writing len %d to skt %d\n", len, n);
 	return LWS_SSL_CAPABLE_ERROR;
 }
+
+LWS_VISIBLE int
+lws_ssl_pending_no_ssl(struct libwebsocket *wsi)
+{
+	return 0;
+}

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1111,6 +1111,7 @@ enum lws_ssl_capable_status {
 #define lws_context_init_http2_ssl(_a)
 #define lws_ssl_capable_read lws_ssl_capable_read_no_ssl
 #define lws_ssl_capable_write lws_ssl_capable_write_no_ssl
+#define lws_ssl_pending lws_ssl_pending_no_ssl
 #define lws_server_socket_service_ssl(_a, _b, _c, _d, _e) (0)
 #define lws_ssl_close(_a) (0)
 #define lws_ssl_context_destroy(_a)
@@ -1121,9 +1122,10 @@ LWS_EXTERN int openssl_websocket_private_data_index;
 LWS_EXTERN int
 lws_ssl_capable_read(struct libwebsocket_context *context,
 		     struct libwebsocket *wsi, unsigned char *buf, int len);
-
 LWS_EXTERN int
 lws_ssl_capable_write(struct libwebsocket *wsi, unsigned char *buf, int len);
+LWS_EXTERN int
+lws_ssl_pending(struct libwebsocket *wsi);
 LWS_EXTERN int
 lws_server_socket_service_ssl(struct libwebsocket_context *context,
 		struct libwebsocket **wsi, struct libwebsocket *new_wsi,
@@ -1161,6 +1163,9 @@ lws_ssl_capable_read_no_ssl(struct libwebsocket_context *context,
 
 LWS_EXTERN int
 lws_ssl_capable_write_no_ssl(struct libwebsocket *wsi, unsigned char *buf, int len);
+
+LWS_EXTERN int
+lws_ssl_pending_no_ssl(struct libwebsocket *wsi);
 
 #ifndef LWS_NO_CLIENT
 	LWS_EXTERN int lws_client_socket_service(

--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -458,6 +458,15 @@ lws_ssl_capable_read(struct libwebsocket_context *context,
 }
 
 LWS_VISIBLE int
+lws_ssl_pending(struct libwebsocket *wsi)
+{
+	if (!wsi->ssl)
+		return 0;
+
+	return SSL_pending(wsi->ssl);
+}
+
+LWS_VISIBLE int
 lws_ssl_capable_write(struct libwebsocket *wsi, unsigned char *buf, int len)
 {
 	int n;


### PR DESCRIPTION
Read the full incoming TLS/SSL record at once in libwebsocket_service_fd().

SSL_read() is called until no more pending data for the current record is buffered in SSL.
SSL_read() is never requested more than the pending data size for the current record
to ensure that the fd is not read again for new data, which would be copied in the SSL buffer otherwise.

With this patch, the libwebsockets internal pending data handling (wsi->pending_read_list...) is not needed anymore. If the PR is accepted I could take care of removing it from the code.