### PR TITLE
Fixing occasional failure of connect() on Windows

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -203,8 +203,14 @@ struct libwebsocket *libwebsocket_client_connect_2(
 
 	if (connect(wsi->sock, v, n) == -1 || LWS_ERRNO == LWS_EISCONN) {
 
-		if (LWS_ERRNO == LWS_EALREADY || LWS_ERRNO == LWS_EINPROGRESS
-		                              || LWS_ERRNO == LWS_EWOULDBLOCK) {
+		if (LWS_ERRNO == LWS_EALREADY
+			|| LWS_ERRNO == LWS_EINPROGRESS
+			|| LWS_ERRNO == LWS_EWOULDBLOCK
+#ifdef _WIN32
+			|| LWS_ERRNO == WSAEINVAL
+#endif
+			)
+		{
 			lwsl_client("nonblocking connect retry\n");
 
 			/*


### PR DESCRIPTION
This happens sporadically, depending on the exact timings of subsequent calls to connect().

See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms737625(v=vs.85).aspx

Specifically the section reading:

"Until the connection attempt completes on a nonblocking socket, all subsequent calls to connect on the same socket will fail with the error code WSAEALREADY, and WSAEISCONN when the connection completes successfully. Due to ambiguities in version 1.1 of the Windows Sockets specification, error codes returned from connect while a connection is already pending may vary among implementations. As a result, it is not recommended that applications use multiple calls to connect to detect connection completion. If they do, they must be prepared to handle WSAEINVAL and WSAEWOULDBLOCK error values the same way that they handle WSAEALREADY, to assure robust operation."