### PR TITLE
added timeout reset in serve_http_file_fragment, to prevent timeout on big files.

### DIFF
--- a/lib/output.c
+++ b/lib/output.c
@@ -538,6 +538,7 @@ LWS_VISIBLE int libwebsockets_serve_http_file_fragment(
 		if (n < 0)
 			return -1; /* caller will close */
 		if (n) {
+			libwebsocket_set_timeout(wsi,PENDING_TIMEOUT_HTTP_CONTENT,AWAITING_TIMEOUT);
 			wsi->u.http.filepos += n;
 			m = libwebsocket_write(wsi, context->service_buffer, n,
 					       wsi->u.http.filepos == wsi->u.http.filelen ? LWS_WRITE_HTTP_FINAL : LWS_WRITE_HTTP);


### PR DESCRIPTION
When sending big files (hundreds of MB over wifi), the connection always timed out after the AWAITING_TIMEOUT time, which is 5 seconds. So i added this line to reset it at each fragment sending and now I'm able to send the whole file.