### PR TITLE
Update appveyor to latest openssl.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 environment:
+  SSL_VERSION: 1_0_2d
+
   matrix:
     - LWS_METHOD: default
 
@@ -14,8 +16,8 @@ environment:
     - LWS_METHOD: nossl
       CMAKE_ARGS: -DLWS_WITH_SSL=OFF
 install:
-  - appveyor DownloadFile http://strcpy.net/packages/Win32OpenSSL-1_0_2a.exe
-  - Win32OpenSSL-1_0_2a.exe /silent /verysilent /sp- /suppressmsgboxes
+  - appveyor DownloadFile http://slproweb.com/download/Win32OpenSSL-%SSL_VER%.exe
+  - Win32OpenSSL-%SSL_VER%.exe /silent /verysilent /sp- /suppressmsgboxes
   - cinst -y nsis
   - SET PATH=C:\Program Files\NSIS\;%PATH%
 build:


### PR DESCRIPTION
slproweb.com is as far as I can see a good trustworthy source of windows builds for openssl. They make a point of not providing out of date (most likely insecure) binaries, hence why there was a problem downloading it.

strcpy.net by comparison looks very dodgy.

This request updates to the most recent openssl installer from slproweb.com.