### PR TITLE
Make LWS_SEND_BUFFER_PRE_PADDING preprocessor if-friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,7 @@ CHECK_INCLUDE_FILES("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
 
 CHECK_TYPE_SIZE(pid_t PID_T_SIZE)
 CHECK_TYPE_SIZE(size_t SIZE_T_SIZE)
+CHECK_TYPE_SIZE("void *" LWS_SIZEOFPTR LANGUAGE C)
 
 if (NOT PID_T_SIZE)
 	set(pid_t int)

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1231,7 +1231,7 @@ libwebsocket_set_timeout(struct libwebsocket *wsi,
 #if __x86_64__
 #define _LWS_PAD_SIZE 16       // Intel recommended for best performance.
 #else
-#define _LWS_PAD_SIZE sizeof(void *)   // The pointer size on any unknown arch.
+#define _LWS_PAD_SIZE LWS_SIZEOFPTR   /* Size of a pointer on the target architecture */
 #endif
 #define _LWS_PAD(n) (((n) % _LWS_PAD_SIZE) ? ((n) + (_LWS_PAD_SIZE - ((n) % _LWS_PAD_SIZE))) : (n))
 #define LWS_SEND_BUFFER_PRE_PADDING _LWS_PAD(4 + 10 + (2 * MAX_MUX_RECURSION))

--- a/lws_config.h.in
+++ b/lws_config.h.in
@@ -61,3 +61,5 @@
 
 /* use SHA1() not internal libwebsockets_SHA1 */
 #cmakedefine LWS_SHA1_USE_OPENSSL_NAME
+
+${LWS_SIZEOFPTR_CODE}


### PR DESCRIPTION
Commit 173e9c4e made LWS_SEND_BUFFER_SIZE a multiple of a certain
value returned by _LWS_PAD_SIZE macro. This macro expanded to
"sizeof(void *)" on non-x86_64 architectures, which made it
unsuitable to use LWS_SEND_BUFFER_SIZE in preprocessor #if
expressions in the library user code.

This patch preserves the padding logic since commit 173e9c4e but
makes it more preprocessor-friendly for applications using
libwebsockets by setting _LWS_PAD_SIZE to the size of "void *"
determined by cmake when libwebsockets is configured for the
target platform.

Signed-off-by: Alexander Lukichev <alexander.lukichev@gmail.com>