### PR TITLE
Define getdtablesize() for android

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -70,6 +70,10 @@ extern "C" {
 #define LWS_VISIBLE
 #endif
 
+#if defined(__ANDROID__)
+#define getdtablesize() 1024
+#endif
+
 #endif
 
 #ifdef LWS_USE_LIBEV


### PR DESCRIPTION
getdtablesize() has been removed from headers since android-21.
Its value was 1024 in previous android api levels