### PR TITLE
Define 'daemonize' flag if LWS_NO_DAEMONIZE is not defined.

### DIFF
--- a/test-server/test-server-pthreads.c
+++ b/test-server/test-server-pthreads.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
 	int syslog_options = LOG_PID | LOG_PERROR;
 #endif
 #ifndef LWS_NO_DAEMONIZE
-// 	int daemonize = 0;
+ 	int daemonize = 0;
 #endif
 
 	/* 

--- a/test-server/test-server.c
+++ b/test-server/test-server.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 	int syslog_options = LOG_PID | LOG_PERROR;
 #endif
 #ifndef LWS_NO_DAEMONIZE
-// 	int daemonize = 0;
+ 	int daemonize = 0;
 #endif
 
 	/* 


### PR DESCRIPTION
This is required (for me) when building current master with: `-DLWS_WITHOUT_DAEMONIZE:BOOL=OFF`