### PR TITLE
Handle pending SSL reads which would otherwise not trigger a POLLIN.

### DIFF
--- a/lib/service.c
+++ b/lib/service.c
@@ -490,11 +490,12 @@ libwebsocket_service_fd(struct libwebsocket_context *context,
 		n = lws_server_socket_service(context, wsi, pollfd);
 		if (n < 0)
 			goto close_and_handled;
-		if( lws_ssl_pending(wsi) ) {
+		pending = lws_ssl_pending(wsi);
+		if( pending ) {
 			goto handle_pending;
 		}
 		else {
-		    goto handled;
+			goto handled;
 		};
 
 	case LWS_CONNMODE_WS_SERVING:
@@ -590,8 +591,8 @@ drain:
 			eff_buf.token_len = 0;
 		} while (more);
 
-handle_pending:
 		pending = lws_ssl_pending(wsi);
+handle_pending:
 		if (pending) {
 			pending = pending > sizeof(context->service_buffer)?
 				sizeof(context->service_buffer):pending;

--- a/lib/service.c
+++ b/lib/service.c
@@ -490,7 +490,12 @@ libwebsocket_service_fd(struct libwebsocket_context *context,
 		n = lws_server_socket_service(context, wsi, pollfd);
 		if (n < 0)
 			goto close_and_handled;
-		goto handled;
+		if( lws_ssl_pending(wsi) ) {
+			goto handle_pending;
+		}
+		else {
+		    goto handled;
+		};
 
 	case LWS_CONNMODE_WS_SERVING:
 	case LWS_CONNMODE_WS_CLIENT:
@@ -585,6 +590,7 @@ drain:
 			eff_buf.token_len = 0;
 		} while (more);
 
+handle_pending:
 		pending = lws_ssl_pending(wsi);
 		if (pending) {
 			pending = pending > sizeof(context->service_buffer)?

--- a/lib/service.c
+++ b/lib/service.c
@@ -592,8 +592,8 @@ drain:
 		} while (more);
 
 		pending = lws_ssl_pending(wsi);
-handle_pending:
 		if (pending) {
+handle_pending:
 			pending = pending > sizeof(context->service_buffer)?
 				sizeof(context->service_buffer):pending;
 			goto read;

--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -515,6 +515,7 @@ lws_ssl_close(struct libwebsocket *wsi)
 	SSL_shutdown(wsi->ssl);
 	compatible_close(n);
 	SSL_free(wsi->ssl);
+	wsi->ssl = NULL;
 
 	return 1; /* handled */
 }


### PR DESCRIPTION
*To Reproduce:*
 * Using libwebsockets with libev backend
 * Setting max token length for headers to be some fixed number smaller than the server recv buffer (i.e. to avoid "excessive header content").
 * Send a request with an excess of read data

*Symptoms:*
 * libwebsockets appropriately handles TLS negotiation and reads data
 * SSL data exceeds receive buffer and is added to pending list
 * No additional POLLIN events are fired (as kernel has already notified us and SSL has consumed)
 * The pending list is never consulted.

*Changes:*
 * service.c: Add handle_pending label and jump if more content after lws_server_socket_service
 * ssl.c: set wsi->ssl = NULL on close (prevents potential segfault)

*Test:*
`curl -vk -H "Giant-header: $( for i in $( seq 5000 ); do echo -n 'a' ; done )" https://localhost:443/`

*Output*:
The request hangs after:
```
libwebsockets: insert_wsi_socket_into_fds: wsi=0x7f7f99f39350, sock=9, fds pos=1
libwebsockets: inserted SSL accept into fds, trying SSL_accept
libwebsockets: SSL_accept failed 2 / error:00000002:lib(0):func(0):system lib
libwebsockets: SSL_ERROR_WANT_READ
libwebsockets: SSL_accept failed 2 / error:00000002:lib(0):func(0):system lib
libwebsockets: SSL_ERROR_WANT_READ
libwebsockets: accepted new SSL conn
libwebsockets: libwebsocket_read: read_ok
```