### PR TITLE
Feature request: Access to SSL from LWS_CALLBACK_ESTABLISHED

### DIFF
--- a/lib/server-handshake.c
+++ b/lib/server-handshake.c
@@ -264,7 +264,13 @@ handshake_0405(struct lws_context *context, struct lws *wsi)
 	if (wsi->protocol->callback)
 		wsi->protocol->callback(wsi->protocol->owning_server,
 				wsi, LWS_CALLBACK_ESTABLISHED,
-					  wsi->user_space, NULL, 0);
+					  wsi->user_space,
+#ifdef LWS_OPENSSL_SUPPORT
+					  wsi->ssl,
+#else
+					  NULL,
+#endif
+					  0);
 
 	return 0;
 


### PR DESCRIPTION
A small feature request that will allow access to wsi->ssl at LWS_CALLBACK_ESTABLISHED.
As far as I can tell this patch can be applied without any side effects.
It calls LWS_CALLBACK_ESTABLISHED with wsi->ssl as the value for 'in' of the protocol callback.
This allows a user to do:

X509 *x509 = SSL_get_peer_certificate((SSL*)in);

With this the application can inspect the client's SSL certificate.
(This could also be done from LWS_CALLBACK_OPENSSL_PERFORM_CLIENT_CERT_VERIFICATION but the retrieved information can not be stored from here.)