### PR TITLE
Fixed not to use IPv4-mapped address for IPv6 only node

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -61,6 +61,8 @@ lws_client_connect_2(struct lws_context *context, struct lws *wsi)
 #ifdef LWS_USE_IPV6
 	if (LWS_IPV6_ENABLED(context)) {
 		memset(&hints, 0, sizeof(struct addrinfo));
+		hints.ai_family = AF_INET6;
+		hints.ai_flags = AI_V4MAPPED;
 		n = getaddrinfo(ads, NULL, &hints, &result);
 		if (n) {
 #ifdef _WIN32
@@ -73,16 +75,6 @@ lws_client_connect_2(struct lws_context *context, struct lws *wsi)
 
 		server_addr6.sin6_family = AF_INET6;
 		switch (result->ai_family) {
-		case AF_INET:
-			/* map IPv4 to IPv6 */
-			bzero((char *)&server_addr6.sin6_addr,
-						sizeof(struct in6_addr));
-			server_addr6.sin6_addr.s6_addr[10] = 0xff;
-			server_addr6.sin6_addr.s6_addr[11] = 0xff;
-			memcpy(&server_addr6.sin6_addr.s6_addr[12],
-				&((struct sockaddr_in *)result->ai_addr)->sin_addr,
-							sizeof(struct in_addr));
-			break;
 		case AF_INET6:
 			memcpy(&server_addr6.sin6_addr,
 			  &((struct sockaddr_in6 *)result->ai_addr)->sin6_addr,


### PR DESCRIPTION
Specifying AF_INET6 and AI_V4MAPPED for getaddrinfo, it will only return IPv6 addresses. If target host doesn't have IPv6 address, than it will return IPv4-mapped address. So this commit is both compatible with IPv6 only node and IPv6/IPv4 dual stack node. This also improve the code since you don't need to create IPv4-mapped address by self.
I tested both IPv6 only network and IPv4 network on my Mac and it worked, but I don't know about other OS like Windows. I believe this commit will work with any OS.