### PR TITLE
Revert using AI_V4MAPPED flag to getaddrinfo for Android

### DIFF
--- a/lib/client-handshake.c
+++ b/lib/client-handshake.c
@@ -63,8 +63,10 @@ lws_client_connect_2(struct lws_context *context, struct lws *wsi)
 #ifdef LWS_USE_IPV6
 	if (LWS_IPV6_ENABLED(context)) {
 		memset(&hints, 0, sizeof(struct addrinfo));
+#if !defined(__ANDROID__)
 		hints.ai_family = AF_INET6;
 		hints.ai_flags = AI_V4MAPPED;
+#endif
 		n = getaddrinfo(ads, NULL, &hints, &result);
 		if (n) {
 #ifdef _WIN32
@@ -77,6 +79,18 @@ lws_client_connect_2(struct lws_context *context, struct lws *wsi)
 
 		server_addr6.sin6_family = AF_INET6;
 		switch (result->ai_family) {
+#if defined(__ANDROID__)
+		case AF_INET:
+			/* map IPv4 to IPv6 */
+			bzero((char *)&server_addr6.sin6_addr,
+						sizeof(struct in6_addr));
+			server_addr6.sin6_addr.s6_addr[10] = 0xff;
+			server_addr6.sin6_addr.s6_addr[11] = 0xff;
+			memcpy(&server_addr6.sin6_addr.s6_addr[12],
+				&((struct sockaddr_in *)result->ai_addr)->sin_addr,
+							sizeof(struct in_addr));
+			break;
+#endif
 		case AF_INET6:
 			memcpy(&server_addr6.sin6_addr,
 			  &((struct sockaddr_in6 *)result->ai_addr)->sin6_addr,


### PR DESCRIPTION
I found getaddrinfo will return error on Android when AI_V4MAPPED is specified. So we should use old implemntation only for Android. Android support of IPv6 is very poor, unfortunately.
It does not mean we should not use AI_V4MAPPED for other environment, because old implementation lack support of IPv6-only network.