### PR TITLE
Recognize Debian GNU/kFreeBSD as FreeBSD-ish.

### DIFF
--- a/lib/lws-plat-unix.c
+++ b/lib/lws-plat-unix.c
@@ -201,7 +201,9 @@ lws_plat_set_socket_options(struct lws_context *context, int fd)
 	int optval = 1;
 	socklen_t optlen = sizeof(optval);
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || \
+#if defined(__APPLE__) || \
+    defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \
+    defined(__NetBSD__) || \
     defined(__OpenBSD__)
 	struct protoent *tcp_proto;
 #endif
@@ -213,7 +215,9 @@ lws_plat_set_socket_options(struct lws_context *context, int fd)
 			       (const void *)&optval, optlen) < 0)
 			return 1;
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || \
+#if defined(__APPLE__) || \
+    defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \
+    defined(__NetBSD__) || \
         defined(__CYGWIN__) || defined(__OpenBSD__)
 
 		/*
@@ -241,7 +245,9 @@ lws_plat_set_socket_options(struct lws_context *context, int fd)
 
 	/* Disable Nagle */
 	optval = 1;
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && \
+#if !defined(__APPLE__) && \
+    !defined(__FreeBSD__) && !defined(__FreeBSD_kernel__) && \
+    !defined(__NetBSD__) && \
     !defined(__OpenBSD__)
 	if (setsockopt(fd, SOL_TCP, TCP_NODELAY, (const void *)&optval, optlen) < 0)
 		return 1;


### PR DESCRIPTION
Some of the FreeBSD-specific code in libwebsockets is related to
the FreeBSD kernel, not the general build environment.  Thus, it is
important to make this distinction, especially when building on
platforms that have a FreeBSD kernel and a non-FreeBSD userland build
environment, such as Debian GNU/kFreeBSD.

When checking for FreeBSD kernel features, also check for the newly
introduced __FreeBSD_kernel__ preprocessor constant; it is present in
the GNU/kFreeBSD kernel and also in FreeBSD itself since the 9.1 release
about three years ago.