### PR TITLE
Generate the API documentation in a reproducible way.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -970,6 +970,7 @@ if (UNIX)
 	# TODO: Fix this on Windows.
 	message("Generating API documentation")
 	file(GLOB C_FILES "${PROJECT_SOURCE_DIR}/lib/*.c")
+	list(SORT C_FILES)
 	execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/doc/")
 
 	execute_process(


### PR DESCRIPTION
Sort the list of source files before passing them to the kernel-doc
script so that it always outputs the discovered functions and
structures in the same order.

For the record, this led to a weird situation in Debian where the libwebsockets-dev package was supposed to generate some files that were byte-for-byte identical on different platforms, and it, well, didn't, because the package autobuilders for the different platforms would use different kernels and filesystems and would return the list of lib/*.c source files in different order.

Thanks again for writing and maintaining libwebsockets in such a way that the only things I have to report are that minor! :)

G'luck,
Peter