### PR TITLE
Don't destroy ev/uv loops if they haven't been created yet

### DIFF
--- a/lib/libev.c
+++ b/lib/libev.c
@@ -138,6 +138,9 @@ lws_libev_destroyloop(struct lws_context *context, int tsi)
 	if (!(context->options & LWS_SERVER_OPTION_LIBEV))
 		return;
 
+	if (!pt->io_loop_ev)
+		return;
+
 	ev_io_stop(pt->io_loop_ev, &pt->w_accept.ev_watcher);
 	if (context->use_ev_sigint)
 		ev_signal_stop(pt->io_loop_ev,

--- a/lib/libuv.c
+++ b/lib/libuv.c
@@ -124,6 +124,9 @@ lws_libuv_destroyloop(struct lws_context *context, int tsi)
 	if (!(context->options & LWS_SERVER_OPTION_LIBUV))
 		return;
 
+	if (!pt->io_loop_uv)
+		return;
+
 	if (context->use_ev_sigint)
 		uv_signal_stop(&pt->w_sigint.uv_watcher);
 	for (m = 0; m < ARRAY_SIZE(sigs); m++)


### PR DESCRIPTION
This affects cases where the server is not able to create a context due to some error, like not being able to listen to the port. Before it would destroy uninitialized loops and most probably crash.