### PR TITLE
Make sure every handle is closed before destroying the uv loop

### DIFF
--- a/lib/libev.c
+++ b/lib/libev.c
@@ -138,6 +138,9 @@ lws_libev_destroyloop(struct lws_context *context, int tsi)
 	if (!(context->options & LWS_SERVER_OPTION_LIBEV))
 		return;
 
+	if (!pt->io_loop_ev)
+		return;
+
 	ev_io_stop(pt->io_loop_ev, &pt->w_accept.ev_watcher);
 	if (context->use_ev_sigint)
 		ev_signal_stop(pt->io_loop_ev,

--- a/lib/libuv.c
+++ b/lib/libuv.c
@@ -124,6 +124,9 @@ lws_libuv_destroyloop(struct lws_context *context, int tsi)
 	if (!(context->options & LWS_SERVER_OPTION_LIBUV))
 		return;
 
+	if (!pt->io_loop_uv)
+		return;
+
 	if (context->use_ev_sigint)
 		uv_signal_stop(&pt->w_sigint.uv_watcher);
 	for (m = 0; m < ARRAY_SIZE(sigs); m++)


### PR DESCRIPTION
I don't know why there are two commits but yeah. This closes every left handles by using uv_walk to iterate over them and uv_close to close them.

http://stackoverflow.com/questions/25615340/closing-libuv-handles-correctly

We could probably optimize this a little better in the future but for now it closes down with no Valgrind issues. It should be possible to debug what handles are still open by printing the address of the uv_handle_t and compare it to any handles we create and then solve it in other ways.