### PR TITLE
Don't include <sys/cdefs.h> for NetBSD

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -141,7 +141,6 @@ struct sockaddr_in;
 #include <unistd.h>
 
 #if defined(__NetBSD__)
-#include <sys/cdefs.h>
 #include <netinet/in.h>
 #endif
 

--- a/test-server/fuzxy.c
+++ b/test-server/fuzxy.c
@@ -63,7 +63,6 @@
 #endif
 
 #if defined(__NetBSD__)
-#include <sys/cdefs.h>
 #include <netinet/in.h>
 #endif
 
@@ -958,4 +957,3 @@ bail1:
 
 	return 0;
 }
-


### PR DESCRIPTION
We needed it for the BSD symbol to be defined, while __NetBSD__ is defined
with a compiler.

Thanks Andy Green for the initial fix.

Signed-off-by: Kamil Rytarowski <n54@gmx.com>