### PR TITLE
Optimize payload exhaustion

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1289,6 +1289,9 @@ lws_client_interpret_server_handshake(struct lws *wsi);
 LWS_EXTERN int LWS_WARN_UNUSED_RESULT
 lws_rx_sm(struct lws *wsi, unsigned char c);
 
+LWS_EXTERN void
+lws_payload_until_length_exhausted(struct lws *wsi, unsigned char **buf, size_t *len);
+
 LWS_EXTERN int LWS_WARN_UNUSED_RESULT
 lws_issue_raw_ext_access(struct lws *wsi, unsigned char *buf, size_t len);
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -1235,6 +1235,9 @@ lws_interpret_incoming_packet(struct lws *wsi, unsigned char **buf, size_t len)
 		if (wsi->rxflow_buffer)
 			wsi->rxflow_pos++;
 
+		/* consume payload bytes efficiently */
+		lws_payload_until_length_exhausted(wsi, buf, &len);
+
 		/* process the byte */
 		m = lws_rx_sm(wsi, *(*buf)++);
 		if (m < 0)


### PR DESCRIPTION
Hi.

This optimization bypasses the parser's per-byte strategy when in state LWS_RXPS_PAYLOAD_UNTIL_LENGTH_EXHAUSTED. This makes receiving large amount of data about 10x faster. We can test it more but it seems to work pretty okay. The state it handles really only does copying or copying and unmasking (if I understand it correctly?). I leave 1 byte left for the real parser so that proper state transition can happen using the old code.