### PR TITLE
Fix build with musl libc

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -264,7 +264,6 @@ typedef unsigned __int64 u_int64_t;
 #else
 
 #include <sys/stat.h>
-#include <sys/cdefs.h>
 #include <sys/time.h>
 
 #if defined(__APPLE__)

--- a/lib/sha-1.c
+++ b/lib/sha-1.c
@@ -99,7 +99,6 @@ static const unsigned int _K[] =
 		sha1_step(ctxt);		\
 	}
 
-static void sha1_step __P((struct sha1_ctxt *));
 
 static void
 sha1_step(struct sha1_ctxt *ctxt)


### PR DESCRIPTION
Fix building libwebsockets with the musl C libary.

<sys/cdefs.h> is an internal glibc header and should be avoided in user code.

__P() was used for compatibility with some old K&R C compilers, when there were
no prototypes (which were introduced to C with C89). As supporting legacy
non-ANSI compilers is nowadays not necessary anymore get rid of the unnecessary
function prototype using __P().