### PR TITLE
uri parsing: improve dot-dot handling

### DIFF
--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -556,6 +556,9 @@ lws_parse(struct lws *wsi, unsigned char c)
 		/* special URI processing... convert %xx */
 
 		switch (wsi->u.hdr.ues) {
+		case URIES_VERBATIM:
+			/* do nothing */
+			break;
 		case URIES_IDLE:
 			if (c == '%') {
 				wsi->u.hdr.ues = URIES_SEEN_PERCENT;
@@ -565,7 +568,8 @@ lws_parse(struct lws *wsi, unsigned char c)
 		case URIES_SEEN_PERCENT:
 			if (char_to_hex(c) < 0) {
 				/* regurgitate */
-				if (issue_char(wsi, '%') < 0)
+				wsi->u.hdr.ues = URIES_VERBATIM;
+				if (lws_parse(wsi, '%') < 0)
 					return -1;
 				wsi->u.hdr.ues = URIES_IDLE;
 				/* continue on to assess c */
@@ -578,7 +582,8 @@ lws_parse(struct lws *wsi, unsigned char c)
 		case URIES_SEEN_PERCENT_H1:
 			if (char_to_hex(c) < 0) {
 				/* regurgitate */
-				if (issue_char(wsi, '%') < 0)
+				wsi->u.hdr.ues = URIES_VERBATIM;
+				if (lws_parse(wsi, '%') < 0)
 					return -1;
 				wsi->u.hdr.ues = URIES_IDLE;
 				/* regurgitate + assess */

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -770,6 +770,7 @@ enum uri_esc_states {
 	URIES_IDLE,
 	URIES_SEEN_PERCENT,
 	URIES_SEEN_PERCENT_H1,
+	URIES_VERBATIM,
 };
 
 /* notice that these union members:

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -954,6 +954,7 @@ struct _lws_header_related {
 	enum uri_esc_states ues;
 	short lextable_pos;
 	unsigned short current_token_limit;
+	unsigned short slashdotdot_pos_stash;
 	char esc_stash;
 	char post_literal_equal;
 	unsigned char parser_state; /* enum lws_token_indexes */


### PR DESCRIPTION
https://github.com/warmcat/libwebsockets/issues/481

- don't treat .../ or ..dir/ like ../
- fix handling of GET /folder/../other/

Signed-off-by: Denis Osvald <denis.osvald@sartura.hr>

Previous discussion at Opened this one instead of https://github.com/warmcat/libwebsockets/pull/482 (v1 of this request)