### PR TITLE
Add support for client certificates and Certificate Revocation List to the test applications.

### DIFF
--- a/test-server/test-server-http.c
+++ b/test-server/test-server-http.c
@@ -34,6 +34,15 @@
  *				using this protocol, including the sender
  */
 
+#ifdef LWS_OPENSSL_SUPPORT
+#include <openssl/err.h>
+#endif
+
+#ifdef LWS_OPENSSL_SUPPORT
+/* location of the certificate revocation list */
+char crl_path[1024] = "";
+#endif
+
 extern int debug_level;
 
 enum demo_protocols {
@@ -619,6 +628,38 @@ bail:
 		/* return pthread_getthreadid_np(); */
 
 		break;
+
+#ifdef LWS_OPENSSL_SUPPORT
+	case LWS_CALLBACK_OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS:
+		if (crl_path[0]) {
+			/* Enable CRL checking */
+			X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new();
+			X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_CRL_CHECK);
+			SSL_CTX_set1_param((SSL_CTX*)user, param);
+			X509_STORE *store = SSL_CTX_get_cert_store((SSL_CTX*)user);
+			X509_LOOKUP *lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
+			n = X509_load_cert_crl_file(lookup, crl_path, X509_FILETYPE_PEM);
+			X509_VERIFY_PARAM_free(param);
+			if (n != 1) {
+				char errbuf[256];
+				n = ERR_get_error();
+				lwsl_err("LWS_CALLBACK_OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS: SSL error: %s (%d)\n", ERR_error_string(n, errbuf), n);
+				return 1;
+			}
+		}
+		break;
+
+	case LWS_CALLBACK_OPENSSL_PERFORM_CLIENT_CERT_VERIFICATION:
+		/* Verify the client certificate */
+		if (!len || (SSL_get_verify_result((SSL*)in) != X509_V_OK)) {
+			int err = X509_STORE_CTX_get_error((X509_STORE_CTX*)user);
+			int depth = X509_STORE_CTX_get_error_depth((X509_STORE_CTX*)user);
+			const char* msg = X509_verify_cert_error_string(err);
+			lwsl_err("LWS_CALLBACK_OPENSSL_PERFORM_CLIENT_CERT_VERIFICATION: SSL error: %s (%d), depth: %d\n", msg, err, depth);
+			return 1;
+		}
+		break;
+#endif
 
 	default:
 		break;

--- a/test-server/test-server.c
+++ b/test-server/test-server.c
@@ -165,6 +165,10 @@ static struct option options[] = {
 	{ "ssl-cert",  required_argument,	NULL, 'C' },
 	{ "ssl-key",  required_argument,	NULL, 'K' },
 	{ "ssl-ca",  required_argument,		NULL, 'A' },
+#ifdef LWS_OPENSSL_SUPPORT
+	{ "ssl-verify-client",  no_argument,		NULL, 'v' },
+	{ "ssl-crl",  required_argument,		NULL, 'R' },
+#endif
 	{ "libev",  no_argument,		NULL, 'e' },
 #ifndef LWS_NO_DAEMONIZE
 	{ "daemonize", 	no_argument,		NULL, 'D' },
@@ -201,7 +205,7 @@ int main(int argc, char **argv)
 	info.port = 7681;
 
 	while (n >= 0) {
-		n = getopt_long(argc, argv, "eci:hsap:d:Dr:C:K:A:u:g:", options, NULL);
+		n = getopt_long(argc, argv, "eci:hsap:d:Dr:C:K:A:R:vu:g:", options, NULL);
 		if (n < 0)
 			continue;
 		switch (n) {
@@ -258,6 +262,15 @@ int main(int argc, char **argv)
 		case 'A':
 			strncpy(ca_path, optarg, sizeof ca_path);
 			break;
+#ifdef LWS_OPENSSL_SUPPORT
+		case 'R':
+			strncpy(crl_path, optarg, sizeof crl_path);
+			break;
+		case 'v':
+			use_ssl = 1;
+			opts |= LWS_SERVER_OPTION_REQUIRE_VALID_OPENSSL_CLIENT_CERT;
+			break;
+#endif
 		case 'h':
 			fprintf(stderr, "Usage: test-server "
 					"[--port=<p>] [--ssl] "

--- a/test-server/test-server.h
+++ b/test-server/test-server.h
@@ -57,6 +57,9 @@ extern int count_pollfds;
 extern volatile int force_exit;
 extern struct lws_context *context;
 extern char *resource_path;
+#ifdef LWS_OPENSSL_SUPPORT
+extern char crl_path[1024];
+#endif
 
 extern void test_server_lock(int care);
 extern void test_server_unlock(int care);


### PR DESCRIPTION
As a followup to issue #489 I have written this patch for the server and client test applications.
For the test server:
 - Added option --ssl-verify-client (-v) to enable verification of client certificates.
 - Added option --ssl-crl (-R) to load a CRL to check for revoked client certs (if LWS_OPENSSL_SUPPORT is defined).

For the test client:
 - Added option --ssl-cert (-C) so a client certificate can be specified.
 - Added option --ssl-key (-K) so the client certificate key can be specified.
 - Added option --ssl-ca (-A) to load a CA certificate
 - Added option --ssl-crl (-R) to load a CRL to check for a revoked server cert (if LWS_OPENSSL_SUPPORT is defined).
