### PR TITLE
Fix inet_ntop linking error on Windows

### DIFF
--- a/README.build.md
+++ b/README.build.md
@@ -327,6 +327,19 @@ cmake .. -DLWS_USE_CYASSL=1 \
 
 **NOTE**: On windows use the .lib file extension for `LWS_CYASSL_LIBRARIES` instead.
 
+Compiling libwebsockets with PolarSSL
+-------------------------------------
+
+Caution... at some point PolarSSL became MbedTLS.  But it did not happen all at once.
+The name changed first then at mbedTLS 2.0 the apis changed.  So eg in Fedora 22,
+there is an "mbedtls" package which is actually using polarssl for the include dir
+and polarssl apis... this should be treated as polarssl then.
+
+Example config for this case is
+
+cmake .. -DLWS_USE_POLARSSL=1 -DLWS_POLARSSL_LIBRARIES=/usr/lib64/libmbedtls.so \
+	 -DLWS_POLARSSL_INCLUDE_DIRS=/usr/include/polarssl/
+
 Reproducing HTTP2.0 tests
 -------------------------
 

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -686,7 +686,7 @@ lws_get_peer_simple(struct lws *wsi, char *name, int namelen)
 		return NULL;
 	}
 
-	return inet_ntop(af, q, name, namelen);
+	return lws_plat_inet_ntop(af, q, name, namelen);
 #else
 	return NULL;
 #endif

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -215,13 +215,19 @@ struct sockaddr_in;
 #else
 #if defined(LWS_USE_POLARSSL)
 #include <polarssl/ssl.h>
-#define SSL_CTX ssl_context
-#define SSL ssl_session
+struct lws_polarssl_context {
+	x509_crt ca;
+	x509_crt certificate;
+	rsa_context key;
+};
+typedef struct lws_polarssl_context SSL_CTX;
+typedef ssl_context SSL;
 #else
 #if defined(LWS_USE_MBEDTLS)
 #include <mbedtls/ssl.h>
 #else
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 #endif /* not USE_MBEDTLS */
 #endif /* not USE_POLARSSL */
 #endif /* not USE_WOLFSSL */

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -200,6 +200,9 @@ static inline int compatible_close(int fd) { return close(fd); }
 #include <polarssl/md5.h>
 #include <polarssl/sha1.h>
 #include <polarssl/ecdh.h>
+#define SSL_ERROR_WANT_READ POLARSSL_ERR_NET_WANT_READ
+#define SSL_ERROR_WANT_WRITE POLARSSL_ERR_NET_WANT_WRITE
+#define OPENSSL_VERSION_NUMBER  0x10002000L
 #else
 #if defined(LWS_USE_MBEDTLS)
 #include <mbedtls/ssl.h>

--- a/lib/sha-1.c
+++ b/lib/sha-1.c
@@ -189,7 +189,7 @@ sha1_step(struct sha1_ctxt *ctxt)
 /*------------------------------------------------------------*/
 
 static void
-sha1_init(struct sha1_ctxt *ctxt)
+_sha1_init(struct sha1_ctxt *ctxt)
 {
 	bzero(ctxt, sizeof(struct sha1_ctxt));
 	H(0) = 0x67452301;
@@ -290,7 +290,7 @@ lws_SHA1(const unsigned char *d, size_t n, unsigned char *md)
 {
 	struct sha1_ctxt ctx;
 
-	sha1_init(&ctx);
+	_sha1_init(&ctx);
 	sha1_loop(&ctx, d, n);
 	sha1_result(&ctx, (void *)md);
 

--- a/plugins/protocol_lws_mirror.c
+++ b/plugins/protocol_lws_mirror.c
@@ -19,6 +19,7 @@
  */
 #include "../lib/libwebsockets.h"
 #include <string.h>
+#include <stdlib.h>
 
 /* lws-mirror_protocol */
 

--- a/plugins/protocol_lws_server_status.c
+++ b/plugins/protocol_lws_server_status.c
@@ -19,6 +19,7 @@
  */
 #include "../lib/libwebsockets.h"
 #include <string.h>
+#include <stdlib.h>
 
 #define LWS_SS_VERSIONS 3
 

--- a/test-server/test-server-http.c
+++ b/test-server/test-server-http.c
@@ -34,13 +34,15 @@
  *				using this protocol, including the sender
  */
 
-#ifdef LWS_OPENSSL_SUPPORT
-#include <openssl/err.h>
-#endif
-
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
 #if defined(LWS_OPENSSL_SUPPORT) && defined(LWS_HAVE_SSL_CTX_set1_param)
 /* location of the certificate revocation list */
-char crl_path[1024] = "";
+extern char crl_path[1024];
+#endif
+#endif
 #endif
 
 extern int debug_level;
@@ -629,6 +631,10 @@ bail:
 
 		break;
 
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
 #if defined(LWS_OPENSSL_SUPPORT)
 	case LWS_CALLBACK_OPENSSL_PERFORM_CLIENT_CERT_VERIFICATION:
 		/* Verify the client certificate */
@@ -659,6 +665,8 @@ bail:
 			}
 		}
 		break;
+#endif
+#endif
 #endif
 #endif
 

--- a/test-server/test-server-libev.c
+++ b/test-server/test-server-libev.c
@@ -30,6 +30,16 @@ struct lws_plat_file_ops fops_plat;
 #define LOCAL_RESOURCE_PATH INSTALL_DATADIR"/libwebsockets-test-server"
 char *resource_path = LOCAL_RESOURCE_PATH;
 
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
+#if defined(LWS_OPENSSL_SUPPORT) && defined(LWS_HAVE_SSL_CTX_set1_param)
+char crl_path[1024] = "";
+#endif
+#endif
+#endif
+
 /*
  * libev dumps their hygiene problems on their users blaming compiler
  * http://lists.schmorp.de/pipermail/libev/2008q4/000442.html

--- a/test-server/test-server-libuv.c
+++ b/test-server/test-server-libuv.c
@@ -31,6 +31,16 @@ struct lws_plat_file_ops fops_plat;
 #define LOCAL_RESOURCE_PATH INSTALL_DATADIR"/libwebsockets-test-server"
 char *resource_path = LOCAL_RESOURCE_PATH;
 
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
+#if defined(LWS_OPENSSL_SUPPORT) && defined(LWS_HAVE_SSL_CTX_set1_param)
+char crl_path[1024] = "";
+#endif
+#endif
+#endif
+
 /* singlethreaded version --> no locks */
 
 void test_server_lock(int care)

--- a/test-server/test-server-pthreads.c
+++ b/test-server/test-server-pthreads.c
@@ -33,6 +33,16 @@ int count_pollfds;
 volatile int force_exit = 0;
 struct lws_context *context;
 
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
+#if defined(LWS_OPENSSL_SUPPORT) && defined(LWS_HAVE_SSL_CTX_set1_param)
+char crl_path[1024] = "";
+#endif
+#endif
+#endif
+
 /*
  * This mutex lock protects code that changes or relies on wsi list outside of
  * the service thread.  The service thread will acquire it when changing the

--- a/test-server/test-server.c
+++ b/test-server/test-server.c
@@ -36,6 +36,15 @@ struct lws_plat_file_ops fops_plat;
 /* http server gets files from this path */
 #define LOCAL_RESOURCE_PATH INSTALL_DATADIR"/libwebsockets-test-server"
 char *resource_path = LOCAL_RESOURCE_PATH;
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
+#if defined(LWS_OPENSSL_SUPPORT) && defined(LWS_HAVE_SSL_CTX_set1_param)
+char crl_path[1024] = "";
+#endif
+#endif
+#endif
 
 /* singlethreaded version --> no locks */
 
@@ -269,10 +278,16 @@ int main(int argc, char **argv)
 			use_ssl = 1;
 			opts |= LWS_SERVER_OPTION_REQUIRE_VALID_OPENSSL_CLIENT_CERT;
 			break;
+#if defined(LWS_USE_POLARSSL)
+#else
+#if defined(LWS_USE_MBEDTLS)
+#else
 #if defined(LWS_HAVE_SSL_CTX_set1_param)
 		case 'R':
 			strncpy(crl_path, optarg, sizeof crl_path);
 			break;
+#endif
+#endif
 #endif
 #endif
 		case 'h':


### PR DESCRIPTION
This fixes libwebsockets not building correctly on Windows, because it couldn't link to inet_ntop