### PR TITLE
Android needs sys/resource.h

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -123,6 +123,7 @@
 #endif
 #if defined (__ANDROID__)
 #include <syslog.h>
+#include <sys/resource.h>
 #else
 #include <sys/syslog.h>
 #endif


### PR DESCRIPTION
When compiling for Android:

```
/libwebsockets/lib/context.c: In function 'lws_create_context':
/libwebsockets/lib/context.c:398:16: error: storage size of 'rt' isn't known
  struct rlimit rt;
                ^
/libwebsockets/lib/context.c:440:3: error: implicit declaration of function 'getrlimit' [-Werror=implicit-function-declaration]
   n = getrlimit ( RLIMIT_NOFILE,&rt);
   ^
/libwebsockets/lib/context.c:440:19: error: 'RLIMIT_NOFILE' undeclared (first use in this function)
   n = getrlimit ( RLIMIT_NOFILE,&rt);
                   ^
/libwebsockets/lib/context.c:440:19: note: each undeclared identifier is reported only once for each function it appears in
/libwebsockets/lib/context.c:398:16: error: unused variable 'rt' [-Werror=unused-variable]
  struct rlimit rt;

```
