### PR TITLE
Fixes for building with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if(GIT_EXECUTABLE)
     OUTPUT_VARIABLE GIT_HOST
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+	string(REGEX REPLACE "([^\\])[\\]([^\\])" "\\1\\\\\\\\\\2" GIT_USER ${GIT_USER})
     set(LWS_BUILD_HASH ${GIT_USER}@${GIT_HOST}-${GIT_HASH})
     message("Git commit hash: ${LWS_BUILD_HASH}")
 endif()

--- a/lib/lws-plat-win.c
+++ b/lib/lws-plat-win.c
@@ -541,7 +541,6 @@ _lws_plat_file_read(struct lws *wsi, lws_filefd_type fd, unsigned long *amount,
 {
 	DWORD _amount;
 
-	(void *)wsi;
 	if (!ReadFile((HANDLE)fd, buf, (DWORD)len, &_amount, NULL)) {
 		*amount = 0;
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -233,7 +233,6 @@ int lws_http_serve(struct lws *wsi, char *uri, const char *origin)
 	char path[256], sym[256];
 	unsigned char *p = (unsigned char *)sym + 32 + LWS_PRE, *start = p;
 	unsigned char *end = p + sizeof(sym) - 32 - LWS_PRE;
-	size_t len;
 	int n, spin = 0;
 
 	snprintf(path, sizeof(path) - 1, "%s/%s", origin, uri);

--- a/lib/server.c
+++ b/lib/server.c
@@ -234,7 +234,7 @@ int lws_http_serve(struct lws *wsi, char *uri, const char *origin)
 	unsigned char *p = (unsigned char *)sym + 32 + LWS_PRE, *start = p;
 	unsigned char *end = p + sizeof(sym) - 32 - LWS_PRE;
 #if !defined(WIN32)
-	size len;
+	size_t len;
 #endif
 	int n, spin = 0;
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -233,6 +233,9 @@ int lws_http_serve(struct lws *wsi, char *uri, const char *origin)
 	char path[256], sym[256];
 	unsigned char *p = (unsigned char *)sym + 32 + LWS_PRE, *start = p;
 	unsigned char *end = p + sizeof(sym) - 32 - LWS_PRE;
+#if !defined(WIN32)
+	size len;
+#endif
 	int n, spin = 0;
 
 	snprintf(path, sizeof(path) - 1, "%s/%s", origin, uri);

--- a/test-server/test-client.c
+++ b/test-server/test-client.c
@@ -17,6 +17,8 @@
  * may be proprietary.  So unlike the library itself, they are licensed
  * Public Domain.
  */
+ 
+#include "lws_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/win32port/win32helpers/gettimeofday.h
+++ b/win32port/win32helpers/gettimeofday.h
@@ -7,7 +7,9 @@
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
 
-#include <winsock2.h>
+#ifdef LWS_MINGW_SUPPORT
+  #include <winsock2.h>
+#endif
 
 #ifndef _TIMEZONE_DEFINED 
 struct timezone 

--- a/win32port/win32helpers/gettimeofday.h
+++ b/win32port/win32helpers/gettimeofday.h
@@ -7,6 +7,8 @@
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
 
+#include <winsock2.h>
+
 #ifndef _TIMEZONE_DEFINED 
 struct timezone 
 {


### PR DESCRIPTION
Added fixes to avoid compile errors and warnings when building under
Windows using MinGW