### PR TITLE
Add warn_unused_result check, attribute only supported by GCC 3.4 or …

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -166,8 +166,15 @@ struct sockaddr_in;
 #endif
 
 #if defined(__GNUC__)
+
+/* warn_unused_result attribute only supported by GCC 3.4 or later */
+#if __GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
+#define LWS_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#define LWS_WARN_UNUSED_RESULT
+#endif
+
 #define LWS_VISIBLE __attribute__((visibility("default")))
-#define LWS_WARN_UNUSED_RESULT __attribute__ ((warn_unused_result))
 #define LWS_WARN_DEPRECATED __attribute__ ((deprecated))
 #else
 #define LWS_VISIBLE


### PR DESCRIPTION
…later.

warn_unused_result was introduced in GCC version 3.4.

Change-Id: I6c2cc938d2b868ddfe0889cc41d7fa9d70e1b907