### PR TITLE
Win CE support

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -114,7 +114,6 @@ struct sockaddr_in;
 #include <stddef.h>
 #include <basetsd.h>
 #ifndef _WIN32_WCE
-#include <stdint.h>
 #include <fcntl.h>
 #else
 #define _O_RDONLY	0x0000

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -112,16 +112,17 @@ struct sockaddr_in;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <stddef.h>
-#include <stdint.h>
 #include <basetsd.h>
 #ifndef _WIN32_WCE
+#include <stdint.h>
 #include <fcntl.h>
 #else
 #define _O_RDONLY	0x0000
 #define O_RDONLY	_O_RDONLY
 #endif
 
-#ifdef _WIN32_WCE
+// Visual studio older than 2015 and WIN_CE has only _stricmp
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || defined(_WIN32_WCE)
 #define strcasecmp _stricmp
 #else
 #define strcasecmp stricmp

--- a/lib/lws-plat-win.c
+++ b/lib/lws-plat-win.c
@@ -31,7 +31,10 @@ time_in_microseconds()
 time_t time(time_t *t)
 {
 	time_t ret = time_in_microseconds() / 1000000;
-	*t = ret;
+
+	if(t != NULL)
+		*t = ret;
+
 	return ret;
 }
 #endif

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -87,7 +87,7 @@
 #define __func__ __FUNCTION__
 #endif
 
-#ifdef _WIN32_WCE
+#if defined(_MSC_VER) || defined(_WIN32_WCE)
 #define vsnprintf _vsnprintf
 #else
 #ifdef LWS_HAVE__VSNPRINTF

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -87,7 +87,7 @@
 #define __func__ __FUNCTION__
 #endif
 
-#if defined(_MSC_VER) || defined(_WIN32_WCE)
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || defined(_WIN32_WCE)
 #define vsnprintf _vsnprintf
 #else
 #ifdef LWS_HAVE__VSNPRINTF

--- a/lib/server.c
+++ b/lib/server.c
@@ -229,7 +229,9 @@ static const char * get_mimetype(const char *file)
 int lws_http_serve(struct lws *wsi, char *uri, const char *origin)
 {
 	const char *mimetype;
+#ifndef _WIN32_WCE
 	struct stat st;
+#endif
 	char path[256], sym[256];
 	unsigned char *p = (unsigned char *)sym + 32 + LWS_PRE, *start = p;
 	unsigned char *end = p + sizeof(sym) - 32 - LWS_PRE;
@@ -240,6 +242,7 @@ int lws_http_serve(struct lws *wsi, char *uri, const char *origin)
 
 	snprintf(path, sizeof(path) - 1, "%s/%s", origin, uri);
 
+#ifndef _WIN32_WCE
 	do {
 		spin++;
 
@@ -309,6 +312,7 @@ int lws_http_serve(struct lws *wsi, char *uri, const char *origin)
 	if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_ETAG,
 			(unsigned char *)sym, n, &p, end))
 		return -1;
+#endif
 
 	mimetype = get_mimetype(path);
 	if (!mimetype) {


### PR DESCRIPTION
Hello, I have just updated to LWS 2.0 and since I have to support also WinCE i added few modifications. 

1. lib/lws-plat-win.c 
`time_t time(time_t *t)`
This was surely a bug which was causing a crash when new context was created and `time(NULL)` was called.

2. lib/libwebsockets.h
There is no `<stdint.h>` on WCE but it seems to me that it is not needed at all (i may be possibly wrong).  On WCE and in MSVC older than 2015 there is only `_stricmp`.

3. private-libwebsockets.h
 On WCE and in MSVC older than 2015 there is only `_vsnprintf`.

4. server.c
 Here is a problem that WCE does not have `struct stat` at all. This is not much of a fix just a workaround that I use to avoid the problem. I would like to ask if there is any problem with this part of code disabled on WCE. If i understood it right it takes care of serving symlinks and http expiration. If i personally don't need those features it should not affect anything else right?