### PR TITLE
lib/ssl.c: fix libre- and boringssl

### DIFF
--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -197,7 +197,9 @@ lws_ssl_destroy(struct lws_vhost *vhost)
 #if (OPENSSL_VERSION_NUMBER < 0x01000000) || defined(USE_WOLFSSL)
 	ERR_remove_state(0);
 #else
-#if (OPENSSL_VERSION_NUMBER >= 0x10100005L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100005L) && \
+	!defined(LIBRESSL_VERSION_NUMBER) && \
+	!defined(OPENSSL_IS_BORINGSSL)
 	ERR_remove_thread_state();
 #else
 	ERR_remove_thread_state(NULL);
@@ -689,7 +691,9 @@ lws_ssl_context_destroy(struct lws_context *context)
 #if (OPENSSL_VERSION_NUMBER < 0x01000000) || defined(USE_WOLFSSL)
 	ERR_remove_state(0);
 #else
-#if (OPENSSL_VERSION_NUMBER >= 0x10100005L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100005L) && \
+	!defined(LIBRESSL_VERSION_NUMBER) && \
+	!defined(OPENSSL_IS_BORINGSSL)
 	ERR_remove_thread_state();
 #else
 	ERR_remove_thread_state(NULL);


### PR DESCRIPTION
This PR fixes support for libreSSL and BoringSSL.