### PR TITLE
lib/server.c: fix ipv6 support

### DIFF
--- a/lib/server.c
+++ b/lib/server.c
@@ -67,7 +67,7 @@ lws_context_init_server(struct lws_context_creation_info *info,
 	else
 #endif
 #ifdef LWS_USE_IPV6
-	if (LWS_IPV6_ENABLED(context))
+	if (LWS_IPV6_ENABLED(vhost->context))
 		sockfd = socket(AF_INET6, SOCK_STREAM, 0);
 	else
 #endif


### PR DESCRIPTION
fixes compile error when IPv6 is enabled.