### PR TITLE
Fix leak caused by undestroyed pthread mutex

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -850,6 +850,7 @@ lws_context_destroy(struct lws_context *context)
 				/* no protocol close */);
 			n--;
 		}
+		lws_pt_mutex_destroy(pt);
 	}
 	/*
 	 * give all extensions a chance to clean up any per-context

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1616,6 +1616,13 @@ lws_pt_mutex_init(struct lws_context_per_thread *pt)
 {
 	pthread_mutex_init(&pt->lock, NULL);
 }
+
+static LWS_INLINE void
+lws_pt_mutex_destroy(struct lws_context_per_thread *pt)
+{
+	pthread_mutex_destroy(&pt->lock);
+}
+
 static LWS_INLINE void
 lws_pt_lock(struct lws_context_per_thread *pt)
 {
@@ -1629,6 +1636,7 @@ lws_pt_unlock(struct lws_context_per_thread *pt)
 }
 #else
 #define lws_pt_mutex_init(_a) (void)(_a)
+#define lws_pt_mutex_destroy(_a) (void)(_a)
 #define lws_pt_lock(_a) (void)(_a)
 #define lws_pt_unlock(_a) (void)(_a)
 #endif


### PR DESCRIPTION
On freebsd valgrind reports 80 bytes definitely lost by lws_pt_mutex_init, this fixes that.