### PR TITLE
Fix deprecated NDK tools for Android test-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ option(LWS_WITH_ACCESS_LOG "Support generating Apache-compatible access logs" OF
 option(LWS_WITH_SERVER_STATUS "Support json + jscript server monitoring" OFF)
 option(LWS_WITH_LEJP "With the Lightweight JSON Parser" OFF)
 option(LWS_WITH_LEJP_CONF "With LEJP configuration parser as used by lwsws" OFF)
+option(LWS_WITH_GENERIC_SESSIONS "With the Generic Sessions plugin" OFF)
+option(LWS_WITH_SQLITE3 "Require SQLITE3 support" OFF)
+option(LWS_WITH_SMTP "Provide SMTP support" OFF)
 
 if (LWS_WITH_LWSWS)
  message(STATUS "LWS_WITH_LWSWS --> Enabling LWS_WITH_PLUGINS and LWS_WITH_LIBUV")
@@ -112,6 +115,16 @@ endif()
 
 if (LWS_WITH_PLUGINS AND NOT LWS_WITH_LIBUV)
 message(STATUS "LWS_WITH_PLUGINS --> Enabling LWS_WITH_LIBUV")
+ set(LWS_WITH_LIBUV 1)
+endif()
+
+if (LWS_WITH_GENERIC_SESSIONS)
+ set(LWS_WITH_SQLITE3 1)
+ set(LWS_WITH_SMTP 1)
+endif()
+
+if (LWS_WITH_SMTP AND NOT LWS_WITH_LIBUV)
+message(STATUS "LWS_WITH_SMTP --> Enabling LWS_WITH_LIBUV")
  set(LWS_WITH_LIBUV 1)
 endif()
 
@@ -187,6 +200,9 @@ set( CACHE PATH "Path to the libev library")
 set(LWS_LIBEV_INCLUDE_DIRS CACHE PATH "Path to the libev include directory")
 set(LWS_LIBUV_LIBRARIES CACHE PATH "Path to the libuv library")
 set(LWS_LIBUV_INCLUDE_DIRS CACHE PATH "Path to the libuv include directory")
+set(LWS_SQLITE3_LIBRARIES CACHE PATH "Path to the libuv library")
+set(LWS_SQLITE3_INCLUDE_DIRS CACHE PATH "Path to the libuv include directory")
+
 
 if (NOT LWS_WITH_SSL)
 	set(LWS_WITHOUT_BUILTIN_SHA1 OFF)
@@ -271,6 +287,15 @@ if (LWS_WITH_LIBUV)
 		set(LIBUV_LIBRARIES ${LWS_LIBUV_LIBRARIES})
 		set(LIBUV_INCLUDE_DIRS ${LWS_LIBUV_INCLUDE_DIRS})
 		set(LIBUV_FOUND 1)
+	endif()
+endif()
+
+if (LWS_WITH_SQLITE3)
+	if ("${LWS_SQLITE3_LIBRARIES}" STREQUAL "" OR "${LWS_SQLITE3_INCLUDE_DIRS}" STREQUAL "")
+	else()
+		set(SQLITE3_LIBRARIES ${LWS_SQLITE3_LIBRARIES})
+		set(SQLITE3_INCLUDE_DIRS ${LWS_SQLITE3_INCLUDE_DIRS})
+		set(SQLITE3_FOUND 1)
 	endif()
 endif()
 
@@ -592,6 +617,11 @@ if (LWS_WITH_LEJP_CONF)
 		)
 endif()
 
+if (LWS_WITH_SMTP)
+	list(APPEND SOURCES
+		lib/smtp.c)
+endif()
+
 # Add helper files for Windows.
 if (WIN32)
 	set(WIN32_HELPERS_PATH win32port/win32helpers)
@@ -854,6 +884,22 @@ if (LWS_WITH_LIBUV)
 	include_directories("${LIBUV_INCLUDE_DIRS}")
 	list(APPEND LIB_LIST ${LIBUV_LIBRARIES})
 endif()
+
+if (LWS_WITH_SQLITE3)
+	if (NOT SQLITE3_FOUND)
+		find_path(SQLITE3_INCLUDE_DIRS NAMES sqlite3.h)
+		find_library(SQLITE3_LIBRARIES NAMES sqlite3)
+		if(SQLITE3_INCLUDE_DIRS AND SQLITE3_LIBRARIES)
+			set(SQLITE3_FOUND 1)
+		endif()
+	endif()
+	message("sqlite3 include dir: ${SQLITE3_INCLUDE_DIRS}")
+	message("sqlite3 libraries: ${SQLITE3_LIBRARIES}")
+	include_directories("${SQLITE3_INCLUDE_DIRS}")
+	list(APPEND LIB_LIST ${SQLITE3_LIBRARIES})
+endif()
+
+
 if (LWS_WITH_HTTP_PROXY)
 	find_library(LIBHUBBUB_LIBRARIES NAMES libhubbub)
 	list(APPEND LIB_LIST ${LIBHUBBUB_LIBRARIES} )
@@ -1244,6 +1290,17 @@ if (NOT LWS_WITHOUT_CLIENT)
                               "plugins/protocol_client_loopback_test.c")
 endif(NOT LWS_WITHOUT_CLIENT)
 
+if (LWS_WITH_GENERIC_SESSIONS)
+		create_plugin(protocol_generic_sessions
+                              "plugins/protocol_generic_sessions.c")
+	if (WIN32)
+		target_link_libraries(protocol_generic_sessions ${LWS_SQLITE3_LIBRARIES})
+	else()
+		target_link_libraries(protocol_generic_sessions sqlite3 )
+	endif(WIN32)
+endif(LWS_WITH_GENERIC_SESSIONS)
+
+
 	endif(LWS_WITH_PLUGINS AND LWS_WITH_SHARED)
 
 	#
@@ -1444,6 +1501,31 @@ if (LWS_WITH_SERVER_STATUS)
 		DESTINATION share/libwebsockets-test-server/server-status
 			COMPONENT examples)
 endif()
+if (LWS_WITH_GENERIC_SESSIONS)
+	install(FILES plugins/generic-sessions-login-example.html
+		      plugins/generic-sessions-register-example.html
+		      plugins/lwsws-logo.png
+		      plugins/failed-login.html
+		      plugins/lwsgs.js
+		      plugins/post-register-fail.html
+		      plugins/post-register-ok.html
+		      plugins/post-verify-ok.html
+		      plugins/post-verify-fail.html
+		      plugins/sent-forgot-ok.html
+		      plugins/sent-forgot-fail.html
+		      plugins/post-forgot-ok.html
+		      plugins/post-forgot-fail.html
+		      plugins/index.html
+		DESTINATION share/libwebsockets-test-server/generic-sessions
+			COMPONENT examples)
+	install(FILES plugins/successful-login.html 
+		DESTINATION share/libwebsockets-test-server/generic-sessions/needauth
+			COMPONENT examples)
+	install(FILES plugins/admin-login.html
+		DESTINATION share/libwebsockets-test-server/generic-sessions/needadmin
+			COMPONENT examples)
+endif()
+
 endif()
 
 # Install the LibwebsocketsConfig.cmake and LibwebsocketsConfigVersion.cmake
@@ -1514,6 +1596,9 @@ message(" LWS_WITH_ACCESS_LOG = ${LWS_WITH_ACCESS_LOG}")
 message(" LWS_WITH_SERVER_STATUS = ${LWS_WITH_SERVER_STATUS}")
 message(" LWS_WITH_LEJP = ${LWS_WITH_LEJP}")
 message(" LWS_WITH_LEJP_CONF = ${LWS_WITH_LEJP_CONF}")
+message(" LWS_WITH_GENERIC_SESSIONS = ${LWS_WITH_GENERIC_SESSIONS}")
+message(" LWS_WITH_SMTP = ${LWS_WITH_SMTP}")
+
 message("---------------------------------------------------------------------")
 
 # These will be available to parent projects including libwebsockets using add_subdirectory()

--- a/README.generic-sessions.md
+++ b/README.generic-sessions.md
@@ -1,0 +1,198 @@
+Generic Sessions Plugin
+-----------------------
+
+Enabling for build
+------------------
+
+Enable at CMake with -DLWS_WITH_GENERIC_SESSIONS=1
+
+This also needs sqlite3 (libsqlite3-dev or similar package)
+
+
+Introduction
+------------
+
+The generic-sessions protocol plugin provides cookie-based login
+authentication for lws web and ws connections.
+
+The plugin handles everything about generic account registration,
+email verification, lost password, and other generic account
+management.
+
+Other code, in another eg, ws protocol handler, only needs very high-level
+state information from generic-sessions, ie, which user the client is
+authenticated as.  Everything underneath is managed in generic-sessions.
+
+
+ - random 20-byte session id managed in a cookie
+
+ - all information related to the session held at the server, nothing managed clientside
+
+ - sqlite3 used at the server to manage active sessions and users
+
+ - defaults to creating anonymous sessions with no user associated
+
+ - admin account (with user-selectable username) is defined in config with a SHA-1 of the password; rest of the accounts are in sqlite3
+
+ - login, logout, register account + email verification built-in with examples
+
+ - in a mount, some file suffixes (ie, .js) can be associated with a protocol for the purposes of rewriting symbolnames.  These are read-only copies of logged-in server state.
+
+ - When your page fetches .js or other rewritten files from that mount, "$lwsgs_user" and so on are rewritten on the fly using chunked transfer encoding
+
+ - Eliminates server-side scripting with a few rewritten symbols and javascript on client side
+
+ - 32-bit bitfield for authentication sectoring, mounts can provide a mask on the loggin-in session's associated server-side bitfield that must be set for access.
+
+ - No code (just config) required for, eg, private URL namespace that requires login to access. 
+
+
+Overall Flow
+------------
+
+When the protocol is initialized, it gets per-vhost information from the config, such
+as where the sqlite3 databases are to be stored.  The admin username and sha-1 of the
+admin password are also taken from here.
+
+In the mounts using protocol-generic-sessions, a cookie is maintained against any requests;
+if no cookie was active on the initial request a new session is created with no attached user.
+So there should always be an active session after any transactions with the server.
+
+In the example html going to the mount /lwsgs loads a login / register page as the default.
+
+The <form> in the login page contains 'next url' hidden inputs that let the html 'program'
+where the form handler will go after a successful admin login, a successful user login and
+a failed login.
+
+After a successful login, the sqlite record at the server for the current session is updated
+to have the logged-in username associated with it. 
+
+Configuration
+------------
+
+(subject to change...)
+
+"auth-mask" defines the autorization sector bits that must be enabled on the session to gain access.
+
+"auth-mask" 0 is the default.
+
+  - b0 is set if you are logged in as a user at all.
+  - b1 is set if you are logged in with the user configured to be admin
+  - b2 is set if the account has been verified (the account configured for admin is always verified)
+
+```
+      {
+        # things in here can always be served
+        "mountpoint": "/lwsgs",
+        "origin": "file:///usr/share/libwebsockets-test-server/generic-sessions",
+        "origin": "callback://protocol-generic-sessions",
+        "default": "generic-sessions-login-example.html",
+        "auth-mask": "0",
+        "interpret": {
+                ".js": "protocol-generic-sessions"
+        }
+       }, {
+        # things in here can only be served if logged in as a user
+        "mountpoint": "/lwsgs/needauth",
+        "origin": "file:///usr/share/libwebsockets-test-server/generic-sessions/needauth",
+        "origin": "callback://protocol-generic-sessions",
+        "default": "generic-sessions-login-example.html",
+        "auth-mask": "5", # logged in as a verified user
+        "interpret": {
+                ".js": "protocol-generic-sessions"
+        }
+       }, {
+        # things in here can only be served if logged in as admin
+        "mountpoint": "/lwsgs/needadmin",
+        "origin": "file:///usr/share/libwebsockets-test-server/generic-sessions/needadmin",
+        "origin": "callback://protocol-generic-sessions",
+        "default": "generic-sessions-login-example.html",
+        "auth-mask": "7", # b2 = verified (by email / or admin), b1 = admin, b0 = logged in with any user name
+        "interpret": {
+                ".js": "protocol-generic-sessions"
+        }
+       }
+```
+
+The vhost configures the storage dir, admin credentials and session cookie lifetimes:
+
+```
+     "ws-protocols": [{
+       "protocol-generic-sessions": {
+         "status": "ok",
+         "admin-user": "admin",
+
+# create the pw hash like this (for the example pw, "jipdocesExunt" )
+# $ echo -n "jipdocesExunt" | sha1sum
+# 046ce9a9cca769e85798133be06ef30c9c0122c9 -
+#
+# Obviously ** change this password hash to a secret one before deploying **
+#
+         "admin-password-sha1": "046ce9a9cca769e85798133be06ef30c9c0122c9",
+         "session-db": "/var/www/sessions/lws.sqlite3",
+         "timeout-idle-secs": "600",
+	 "timeout-anon-idle-secs": "1200",
+         "timeout-absolute-secs": "6000",
+# the confounder is part of the salted password hashes.  If this config
+# file is in a 0700 root:root dir, an attacker with apache credentials
+# will have to get the confounder out of the process image to even try
+# to guess the password hashes.
+         "confounder": "Change to <=31 chars of junk",
+
+         "email-from": "noreply@example.com",
+         "email-smtp-ip": "127.0.0.1",
+         "email-expire": "3600",
+         "email-helo": "myhost.com",
+         "email-contact-person": "Set Me <real-person@email.com>",
+         "email-confirm-url-base": "http://localhost:7681/lwsgs"
+       }
+```
+
+The email- related settings control generation of automatic emails for
+registration and forgotten password.
+
+ - email-from: The email address automatic emails are sent from
+
+ - email-smtp-ip: Normally 127.0.0.1, if you have a suitable server on port
+   25 on your lan you can use this instead here.
+
+ - email-expire: Seconds that links sent in email will work before being
+   deleted
+
+ - email-helo: HELO to use when communicating with your SMTP server
+
+ - email-contact-person: mentioned in the automatic emails as a human who can
+   answer questions
+
+ - email-confirm-url-base: the URL to start links with in the emails, so the
+   recipient can get back to the web server
+
+
+Password Confounder
+-------------------
+
+You can also define a per-vhost confounder used when aggregating the password
+with the salt when it is hashed.  Any attacker will also need to get the
+confounder along with the database, which you can make harder by making the
+config dir only eneterable / readable by root.
+
+
+Preparing the db directory
+--------------------------
+
+You will have to prepare the db directory so it's suitable for the lwsws user to use,
+that usually means apache, eg
+
+```
+# mkdir -p /var/www/sessions
+# chown root:apache /var/www/sessions
+# chmod 770 /var/www/sessions
+```
+
+Email configuration
+-------------------
+
+lwsgs will can send emails by talking to an SMTP server on localhost:25.  That
+will usually be sendmail or postfix, you should confirm that works first by
+itself using the `mail` application to send on it.
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - LWS_METHOD: lwsws
-      CMAKE_ARGS: -DLWS_WITH_LWSWS=1 -DLIBUV_INCLUDE_DIRS=C:\assets\libuv\include -DLIBUV_LIBRARIES=C:\assets\libuv\libuv.lib
+      CMAKE_ARGS: -DLWS_WITH_LWSWS=1 -DSQLITE3_INCLUDE_DIRS=C:\assets\sqlite3 -DSQLITE3_LIBRARIES=C:\assets\sqlite3\sqlite3.lib -DLIBUV_INCLUDE_DIRS=C:\assets\libuv\include -DLIBUV_LIBRARIES=C:\assets\libuv\libuv.lib
 
     - LWS_METHOD: default
 
@@ -26,6 +26,9 @@ install:
   - Win32OpenSSL-1_0_2h.exe /silent /verysilent /sp- /suppressmsgboxes
   - appveyor DownloadFile https://libwebsockets.org:444/nsis-3.0rc1-setup.exe
   - cmd /c start /wait nsis-3.0rc1-setup.exe /S /D=C:\nsis
+  - appveyor DownloadFile https://libwebsockets.org:444/sqlite-dll-win32-x86-3130000.zip
+  - mkdir c:\assets\sqlite3
+  - 7z x -oc:\assets\sqlite3 sqlite-dll-win32-x86-3130000.zip
   - SET PATH=C:\Program Files\NSIS\;C:\Program Files (x86)\NSIS\;c:\nsis;%PATH%
 build:
 

--- a/lib/lejp-conf.c
+++ b/lib/lejp-conf.c
@@ -59,7 +59,9 @@ static const char * const paths_vhosts[] = {
 	"vhosts[].access-log",
 	"vhosts[].mounts[].mountpoint",
 	"vhosts[].mounts[].origin",
+	"vhosts[].mounts[].protocol",
 	"vhosts[].mounts[].default",
+	"vhosts[].mounts[].auth-mask",
 	"vhosts[].mounts[].cgi-timeout",
 	"vhosts[].mounts[].cgi-env[].*",
 	"vhosts[].mounts[].cache-max-age",
@@ -67,6 +69,7 @@ static const char * const paths_vhosts[] = {
 	"vhosts[].mounts[].cache-revalidate",
 	"vhosts[].mounts[].cache-intermediaries",
 	"vhosts[].mounts[].extra-mimetypes.*",
+	"vhosts[].mounts[].interpret.*",
 	"vhosts[].ws-protocols[].*.*",
 	"vhosts[].ws-protocols[].*",
 	"vhosts[].ws-protocols[]",
@@ -92,7 +95,9 @@ enum lejp_vhost_paths {
 	LEJPVP_ACCESS_LOG,
 	LEJPVP_MOUNTPOINT,
 	LEJPVP_ORIGIN,
+	LEJPVP_MOUNT_PROTOCOL,
 	LEJPVP_DEFAULT,
+	LEJPVP_DEFAULT_AUTH_MASK,
 	LEJPVP_CGI_TIMEOUT,
 	LEJPVP_CGI_ENV,
 	LEJPVP_MOUNT_CACHE_MAX_AGE,
@@ -100,6 +105,7 @@ enum lejp_vhost_paths {
 	LEJPVP_MOUNT_CACHE_REVALIDATE,
 	LEJPVP_MOUNT_CACHE_INTERMEDIARIES,
 	LEJPVP_MOUNT_EXTRA_MIMETYPES,
+	LEJPVP_MOUNT_INTERPRET,
 	LEJPVP_PROTOCOL_NAME_OPT,
 	LEJPVP_PROTOCOL_NAME,
 	LEJPVP_PROTOCOL,
@@ -123,6 +129,7 @@ struct jpargs {
 
 	struct lws_protocol_vhost_options *pvo;
 	struct lws_protocol_vhost_options *pvo_em;
+	struct lws_protocol_vhost_options *pvo_int;
 	struct lws_http_mount m;
 	const char **plugin_dirs;
 	int count_plugin_dirs;
@@ -332,8 +339,10 @@ lejp_vhosts_cb(struct lejp_ctx *ctx, char reason)
 		for (n = 0; n < ARRAY_SIZE(mount_protocols); n++)
 			if (!strncmp(a->m.origin, mount_protocols[n],
 			     strlen(mount_protocols[n]))) {
+				lwsl_err("----%s\n", a->m.origin);
 				m->origin_protocol = n;
-				m->origin = a->m.origin + strlen(mount_protocols[n]);
+				m->origin = a->m.origin +
+					    strlen(mount_protocols[n]);
 				break;
 			}
 
@@ -393,11 +402,18 @@ lejp_vhosts_cb(struct lejp_ctx *ctx, char reason)
 		a->m.mountpoint_len = (unsigned char)strlen(ctx->buf);
 		break;
 	case LEJPVP_ORIGIN:
-		a->m.origin = a->p;
+		if (!strncmp(ctx->buf, "callback://", 11))
+			a->m.protocol = a->p + 11;
+
+		if (!a->m.origin)
+			a->m.origin = a->p;
 		break;
 	case LEJPVP_DEFAULT:
 		a->m.def = a->p;
 		break;
+	case LEJPVP_DEFAULT_AUTH_MASK:
+		a->m.auth_mask = atoi(ctx->buf);
+		return 0;
 	case LEJPVP_MOUNT_CACHE_MAX_AGE:
 		a->m.cache_max_age = atoi(ctx->buf);
 		return 0;
@@ -472,6 +488,22 @@ lejp_vhosts_cb(struct lejp_ctx *ctx, char reason)
 		a->p += n;
 		a->pvo_em->value = a->p;
 		a->pvo_em->options = NULL;
+		break;
+
+	case LEJPVP_MOUNT_INTERPRET:
+		a->pvo_int = lwsws_align(a);
+		a->p += sizeof(*a->pvo_int);
+
+		n = lejp_get_wildcard(ctx, 0, a->p, a->end - a->p);
+		/* ie, enable this protocol, no options yet */
+		a->pvo_int->next = a->m.interpret;
+		a->m.interpret = a->pvo_int;
+		a->pvo_int->name = a->p;
+		lwsl_notice("  adding interpret %s -> %s\n", a->p,
+			    ctx->buf);
+		a->p += n;
+		a->pvo_int->value = a->p;
+		a->pvo_int->options = NULL;
 		break;
 
 	case LEJPVP_ENABLE_CLIENT_SSL:

--- a/lib/output.c
+++ b/lib/output.c
@@ -566,7 +566,9 @@ LWS_VISIBLE int lws_serve_http_file_fragment(struct lws *wsi)
 {
 	struct lws_context *context = wsi->context;
 	struct lws_context_per_thread *pt = &context->pt[(int)wsi->tsi];
-	unsigned long amount;
+	struct lws_process_html_args args;
+	unsigned long amount, poss;
+	unsigned char *p = pt->serv_buf;
 	int n, m;
 
 	while (wsi->http2_substream || !lws_send_pipe_choked(wsi)) {
@@ -583,31 +585,58 @@ LWS_VISIBLE int lws_serve_http_file_fragment(struct lws *wsi)
 		if (wsi->u.http.filepos == wsi->u.http.filelen)
 			goto all_sent;
 
-		if (lws_plat_file_read(wsi, wsi->u.http.fd, &amount,
-				       pt->serv_buf,
-				       context->pt_serv_buf_size) < 0)
+		poss = context->pt_serv_buf_size;
+
+		if (wsi->sending_chunked) {
+			/* we need to drop the chunk size in here */
+			p += 10;
+			/* allow for the chunk to grow by 128 in translation */
+			poss -= 10 + 128;
+		}
+
+		if (lws_plat_file_read(wsi, wsi->u.http.fd, &amount, p, poss) < 0)
 			return -1; /* caller will close */
 
 		n = (int)amount;
 		if (n) {
 			lws_set_timeout(wsi, PENDING_TIMEOUT_HTTP_CONTENT,
 					context->timeout_secs);
-			wsi->u.http.filepos += n;
-			m = lws_write(wsi, pt->serv_buf, n,
+
+			if (wsi->sending_chunked) {
+				args.p = (char *)p;
+				args.len = n;
+				args.max_len = poss + 128;
+				args.final = wsi->u.http.filepos + n ==
+					     wsi->u.http.filelen;
+				if (user_callback_handle_rxflow(
+				     wsi->vhost->protocols[(int)wsi->protocol_interpret_idx].callback, wsi,
+				     LWS_CALLBACK_PROCESS_HTML,
+				     wsi->user_space, &args, 0) < 0)
+					return -1;
+				n = args.len;
+				p = (unsigned char *)args.p;
+			}
+
+			m = lws_write(wsi, p, n,
 				      wsi->u.http.filepos == wsi->u.http.filelen ?
-					LWS_WRITE_HTTP_FINAL : LWS_WRITE_HTTP);
+					LWS_WRITE_HTTP_FINAL :
+					LWS_WRITE_HTTP
+				);
 			if (m < 0)
 				return -1;
 
-			if (m != n)
+			wsi->u.http.filepos += amount;
+			if (m != n) {
 				/* adjust for what was not sent */
 				if (lws_plat_file_seek_cur(wsi, wsi->u.http.fd,
 							   m - n) ==
 							     (unsigned long)-1)
 					return -1;
+			}
 		}
 all_sent:
-		if (!wsi->trunc_len && wsi->u.http.filepos == wsi->u.http.filelen) {
+		if (!wsi->trunc_len &&
+		    wsi->u.http.filepos == wsi->u.http.filelen) {
 			wsi->state = LWSS_HTTP;
 			/* we might be in keepalive, so close it off here */
 			lws_plat_file_close(wsi, wsi->u.http.fd);
@@ -620,11 +649,11 @@ all_sent:
 				     LWS_CALLBACK_HTTP_FILE_COMPLETION,
 				     wsi->user_space, NULL, 0) < 0)
 					return -1;
+
 			return 1;  /* >0 indicates completed */
 		}
 	}
 
-	lwsl_info("choked before able to send whole file (post)\n");
 	lws_callback_on_writable(wsi);
 
 	return 0; /* indicates further processing must be done */

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1257,6 +1257,7 @@ struct lws {
 	unsigned int cache_revalidate:1;
 	unsigned int cache_intermediaries:1;
 	unsigned int favoured_pollin:1;
+	unsigned int sending_chunked:1;
 #ifdef LWS_WITH_ACCESS_LOG
 	unsigned int access_log_pending:1;
 #endif
@@ -1295,6 +1296,7 @@ struct lws {
 	char pending_timeout; /* enum pending_timeout */
 	char pps; /* enum lws_pending_protocol_send */
 	char tsi; /* thread service index we belong to */
+	char protocol_interpret_idx;
 #ifdef LWS_WITH_CGI
 	char cgi_channel; /* which of stdin/out/err */
 	char hdr_state;

--- a/lib/server.c
+++ b/lib/server.c
@@ -206,6 +206,18 @@ lws_select_vhost(struct lws_context *context, int port, const char *servername)
 	return NULL;
 }
 
+static const struct lws_protocols *
+lws_vhost_name_to_protocol(struct lws_vhost *vh, const char *name)
+{
+	int n;
+
+	for (n = 0; n < vh->count_protocols; n++)
+		if (!strcmp(name, vh->protocols[n].name))
+			return &vh->protocols[n];
+
+	return NULL;
+}
+
 static const char *
 get_mimetype(const char *file, const struct lws_http_mount *m)
 {
@@ -271,11 +283,13 @@ static int
 lws_http_serve(struct lws *wsi, char *uri, const char *origin,
 	       const struct lws_http_mount *m)
 {
+	const struct lws_protocol_vhost_options *pvo = m->interpret;
+	struct lws_process_html_args args;
 	const char *mimetype;
 #ifndef _WIN32_WCE
 	struct stat st;
 #endif
-	char path[256], sym[256];
+	char path[256], sym[512];
 	unsigned char *p = (unsigned char *)sym + 32 + LWS_PRE, *start = p;
 	unsigned char *end = p + sizeof(sym) - 32 - LWS_PRE;
 #if !defined(WIN32)
@@ -342,7 +356,7 @@ lws_http_serve(struct lws *wsi, char *uri, const char *origin,
 				return -1;
 
 			n = lws_write(wsi, start, p - start,
-					LWS_WRITE_HTTP_HEADERS);
+				      LWS_WRITE_HTTP_HEADERS);
 			if (n != (p - start)) {
 				lwsl_err("_write returned %d from %d\n", n, p - start);
 				return -1;
@@ -363,6 +377,44 @@ lws_http_serve(struct lws *wsi, char *uri, const char *origin,
 		goto bail;
 	}
 
+	wsi->sending_chunked = 0;
+
+	/*
+	 * check if this is in the list of file suffixes to be interpreted by
+	 * a protocol
+	 */
+	while (pvo) {
+		n = strlen(path);
+		if (n > (int)strlen(pvo->name) &&
+		    !strcmp(&path[n - strlen(pvo->name)], pvo->name)) {
+			wsi->sending_chunked = 1;
+			wsi->protocol_interpret_idx = (char)(long)pvo->value;
+			lwsl_notice("want %s interpreted by %s\n",
+				    path,
+				    wsi->vhost->protocols[(int)(long)(pvo->value)].name);
+			wsi->protocol = &wsi->vhost->protocols[(int)(long)(pvo->value)];
+			if (lws_ensure_user_space(wsi))
+				return -1;
+			break;
+		}
+		pvo = pvo->next;
+	}
+
+	if (m->protocol) {
+		const struct lws_protocols *pp = lws_vhost_name_to_protocol(
+							wsi->vhost, m->protocol);
+
+		wsi->protocol = pp;
+		if (lws_ensure_user_space(wsi))
+			return -1;
+		args.p = (char *)p;
+		args.max_len = end - p;
+		if (pp->callback(wsi, LWS_CALLBACK_ADD_HEADERS,
+					  wsi->user_space, &args, 0))
+			return -1;
+		p = (unsigned char *)args.p;
+	}
+
 	n = lws_serve_http_file(wsi, path, mimetype, (char *)start, p - start);
 
 	if (n < 0 || ((n > 0) && lws_http_transaction_completed(wsi)))
@@ -381,6 +433,7 @@ lws_http_action(struct lws *wsi)
 	enum http_connection_type connection_type;
 	enum http_version request_version;
 	char content_length_str[32];
+	struct lws_process_html_args args;
 	const struct lws_http_mount *hm, *hit = NULL;
 	unsigned int n, count = 0;
 	char http_version_str[10];
@@ -409,6 +462,9 @@ lws_http_action(struct lws *wsi)
 #endif
 	};
 #endif
+	static const char * const oprot[] = {
+		"http://", "https://"
+	};
 
 	/* it's not websocket.... shall we accept it as http? */
 
@@ -614,7 +670,8 @@ lws_http_action(struct lws *wsi)
 		    ) {
 			if (hm->origin_protocol == LWSMPRO_CALLBACK ||
 			    ((hm->origin_protocol == LWSMPRO_CGI ||
-			     lws_hdr_total_length(wsi, WSI_TOKEN_GET_URI)) &&
+			     lws_hdr_total_length(wsi, WSI_TOKEN_GET_URI) ||
+			     hm->protocol) &&
 			    hm->mountpoint_len > best)) {
 				best = hm->mountpoint_len;
 				hit = hm;
@@ -627,6 +684,38 @@ lws_http_action(struct lws *wsi)
 
 		lwsl_debug("*** hit %d %d %s\n", hit->mountpoint_len,
 			   hit->origin_protocol , hit->origin);
+
+		if (hit->protocol) {
+			const struct lws_protocols *pp = lws_vhost_name_to_protocol(
+					wsi->vhost, hit->protocol);
+
+			if (!pp) {
+				lwsl_err("unknown protocol %s\n", hit->protocol);
+				return 1;
+			}
+
+			wsi->protocol = pp;
+			if (lws_ensure_user_space(wsi)) {
+				lwsl_err("Unable to allocate user space\n");
+				return 1;
+			}
+		}
+		lwsl_info("wsi %s protocol '%s'\n", uri_ptr, wsi->protocol->name);
+
+		args.p = uri_ptr;
+		args.len = uri_len;
+		args.max_len = hit->auth_mask;
+		args.final = 0; /* used to signal callback dealt with it */
+
+		n = wsi->protocol->callback(wsi, LWS_CALLBACK_CHECK_ACCESS_RIGHTS,
+					    wsi->user_space, &args, 0);
+		if (n) {
+			lws_return_http_status(wsi, HTTP_STATUS_UNAUTHORIZED,
+					       NULL);
+			goto bail_nuke_ah;
+		}
+		if (args.final) /* callback completely handled it well */
+			return 0;
 
 		/*
 		 * if we have a mountpoint like https://xxx.com/yyy
@@ -649,12 +738,12 @@ lws_http_action(struct lws *wsi)
 		    (*s != '/' ||
 		     (hit->origin_protocol == LWSMPRO_REDIR_HTTP ||
 		      hit->origin_protocol == LWSMPRO_REDIR_HTTPS)) &&
-		    (hit->origin_protocol != LWSMPRO_CGI && hit->origin_protocol != LWSMPRO_CALLBACK)) {
+		    (hit->origin_protocol != LWSMPRO_CGI &&
+		     hit->origin_protocol != LWSMPRO_CALLBACK //&&
+		     //hit->protocol == NULL
+		     )) {
 			unsigned char *start = pt->serv_buf + LWS_PRE,
 					      *p = start, *end = p + 512;
-			static const char *oprot[] = {
-				"http://", "https://"
-			};
 
 			lwsl_debug("Doing 301 '%s' org %s\n", s, hit->origin);
 
@@ -662,13 +751,14 @@ lws_http_action(struct lws *wsi)
 				goto bail_nuke_ah;
 
 			/* > at start indicates deal with by redirect */
-			if (hit->origin_protocol & 4)
+			if (hit->origin_protocol == LWSMPRO_REDIR_HTTP ||
+			    hit->origin_protocol == LWSMPRO_REDIR_HTTPS)
 				n = snprintf((char *)end, 256, "%s%s",
 					    oprot[hit->origin_protocol & 1],
 					    hit->origin);
 			else
 				n = snprintf((char *)end, 256,
-				    "https://%s/%s/",
+				    "%s%s%s/", oprot[lws_is_ssl(wsi)],
 				    lws_hdr_simple_ptr(wsi, WSI_TOKEN_HOST),
 				    uri_ptr);
 
@@ -686,32 +776,36 @@ lws_http_action(struct lws *wsi)
 		 * For the duration of this http transaction, bind us to the
 		 * associated protocol
 		 */
-		if (hit->origin_protocol == LWSMPRO_CALLBACK) {
 
-			for (n = 0; n < (unsigned int)wsi->vhost->count_protocols; n++)
-				if (!strcmp(wsi->vhost->protocols[n].name,
-					   hit->origin)) {
+		if (hit->origin_protocol == LWSMPRO_CALLBACK ||
+		    (hit->protocol && lws_hdr_total_length(wsi, WSI_TOKEN_POST_URI))) {
+			if (! hit->protocol) {
+				for (n = 0; n < (unsigned int)wsi->vhost->count_protocols; n++)
+					if (!strcmp(wsi->vhost->protocols[n].name,
+						   hit->origin)) {
 
-					if (wsi->protocol != &wsi->vhost->protocols[n])
-						if (!wsi->user_space_externally_allocated)
-							lws_free_set_NULL(wsi->user_space);
-					wsi->protocol = &wsi->vhost->protocols[n];
-					if (lws_ensure_user_space(wsi)) {
-						lwsl_err("Unable to allocate user space\n");
+						if (wsi->protocol != &wsi->vhost->protocols[n])
+							if (!wsi->user_space_externally_allocated)
+								lws_free_set_NULL(wsi->user_space);
+						wsi->protocol = &wsi->vhost->protocols[n];
+						if (lws_ensure_user_space(wsi)) {
+							lwsl_err("Unable to allocate user space\n");
 
-						return 1;
+							return 1;
+						}
+						break;
 					}
-					break;
+
+				if (n == wsi->vhost->count_protocols) {
+					n = -1;
+					lwsl_err("Unable to find plugin '%s'\n",
+						 hit->origin);
 				}
-
-			if (n == wsi->vhost->count_protocols) {
-				n = -1;
-				lwsl_err("Unable to find plugin '%s'\n",
-					 hit->origin);
 			}
-
 			n = wsi->protocol->callback(wsi, LWS_CALLBACK_HTTP,
-						    wsi->user_space, uri_ptr, uri_len);
+						    wsi->user_space,
+						    uri_ptr + hit->mountpoint_len,
+						    uri_len - hit->mountpoint_len);
 
 			goto after;
 		}
@@ -773,16 +867,34 @@ lws_http_action(struct lws *wsi)
 		wsi->cache_revalidate = hit->cache_revalidate;
 		wsi->cache_intermediaries = hit->cache_intermediaries;
 
+
 		n = lws_http_serve(wsi, s, hit->origin, hit);
 		if (n) {
 			/*
 			 * 	lws_return_http_status(wsi, HTTP_STATUS_NOT_FOUND, NULL);
 			 */
-			n = wsi->protocol->callback(wsi, LWS_CALLBACK_HTTP,
+			if (hit->protocol) {
+				const struct lws_protocols *pp = lws_vhost_name_to_protocol(
+						wsi->vhost, hit->protocol);
+
+				wsi->protocol = pp;
+				if (lws_ensure_user_space(wsi)) {
+					lwsl_err("Unable to allocate user space\n");
+					return 1;
+				}
+
+				n = pp->callback(wsi, LWS_CALLBACK_HTTP,
+						 wsi->user_space,
+						 uri_ptr + hit->mountpoint_len,
+						 uri_len - hit->mountpoint_len);
+			} else
+				n = wsi->protocol->callback(wsi, LWS_CALLBACK_HTTP,
 					    wsi->user_space, uri_ptr, uri_len);
 		}
 	} else {
 		/* deferred cleanup and reset to protocols[0] */
+
+		lwsl_notice("no hit\n");
 
 		if (wsi->protocol != &wsi->vhost->protocols[0])
 			if (!wsi->user_space_externally_allocated)
@@ -1814,8 +1926,16 @@ lws_serve_http_file(struct lws *wsi, const char *file, const char *content_type,
 					 (unsigned char *)content_type,
 					 strlen(content_type), &p, end))
 		return -1;
-	if (lws_add_http_header_content_length(wsi, wsi->u.http.filelen, &p, end))
-		return -1;
+
+	if (!wsi->sending_chunked) {
+		if (lws_add_http_header_content_length(wsi, wsi->u.http.filelen, &p, end))
+			return -1;
+	} else {
+		if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_TRANSFER_ENCODING,
+						 (unsigned char *)"chunked",
+						 7, &p, end))
+			return -1;
+	}
 
 	if (wsi->cache_secs && wsi->cache_reuse) {
 		if (wsi->cache_revalidate) {

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1,0 +1,239 @@
+/*
+ * SMTP support for libwebsockets
+ *
+ * Copyright (C) 2016 Andy Green <andy@warmcat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation:
+ * version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+
+#include "private-libwebsockets.h"
+
+static unsigned int
+lwsgs_now_secs(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	return tv.tv_sec;
+}
+
+static void
+ccb(uv_handle_t* handle)
+{
+
+}
+
+static void
+alloc_buffer(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf)
+{
+	struct lws_email *email = (struct lws_email *)handle->data;
+
+	*buf = uv_buf_init(email->email_buf, sizeof(email->email_buf) - 1);
+}
+
+static void
+on_write_end(uv_write_t *req, int status) {
+	lwsl_notice("%s\n", __func__);
+	if (status == -1) {
+		fprintf(stderr, "error on_write_end");
+		return;
+	}
+}
+
+static void
+lwsgs_email_read(struct uv_stream_s *s, ssize_t nread, const uv_buf_t *buf)
+{
+	struct lws_email *email = (struct lws_email *)s->data;
+	static const short retcodes[] = {
+		0,	/* idle */
+		0,	/* connecting */
+		220,	/* connected */
+		250,	/* helo */
+		250,	/* from */
+		250,	/* to */
+		354,	/* data */
+		250,	/* body */
+		221,	/* quit */
+	};
+	uv_write_t write_req;
+	uv_buf_t wbuf;
+	int n;
+
+	if (nread >= 0)
+		email->email_buf[nread] = '\0';
+	lwsl_notice("%s: %s\n", __func__, buf->base);
+	if (nread == -1) {
+		lwsl_err("%s: failed\n", __func__);
+		return;
+	}
+
+	n = atoi(buf->base);
+	if (n != retcodes[email->estate]) {
+		lwsl_err("%s: bad response from server\n", __func__);
+		goto close_conn;
+	}
+
+	switch (email->estate) {
+	case LGSSMTP_CONNECTED:
+		n = sprintf(email->content, "HELO %s\n", email->email_helo);
+		email->estate = LGSSMTP_SENT_HELO;
+		break;
+	case LGSSMTP_SENT_HELO:
+		n = sprintf(email->content, "MAIL FROM: <%s>\n", email->email_from);
+		email->estate = LGSSMTP_SENT_FROM;
+		break;
+	case LGSSMTP_SENT_FROM:
+		n = sprintf(email->content, "RCPT TO: <%s>\n", email->email_to);
+		email->estate = LGSSMTP_SENT_TO;
+		break;
+	case LGSSMTP_SENT_TO:
+		n = sprintf(email->content, "DATA\n");
+		email->estate = LGSSMTP_SENT_DATA;
+		break;
+	case LGSSMTP_SENT_DATA:
+		if (email->on_get_body(email, email->content, email->max_content_size))
+			return;
+		n = strlen(email->content);
+		email->estate = LGSSMTP_SENT_BODY;
+		break;
+	case LGSSMTP_SENT_BODY:
+		n = sprintf(email->content, "quit\n");
+		email->estate = LGSSMTP_SENT_QUIT;
+		break;
+	case LGSSMTP_SENT_QUIT:
+		lwsl_notice("%s: done\n", __func__);
+		email->on_sent(email);
+		email->estate = LGSSMTP_IDLE;
+		goto close_conn;
+	default:
+		return;
+	}
+
+	puts(email->content);
+	wbuf = uv_buf_init(email->content, n);
+	uv_write(&write_req, s, &wbuf, 1, on_write_end);
+
+	return;
+
+close_conn:
+
+	uv_close((uv_handle_t *)s, ccb);
+}
+
+static void
+lwsgs_email_on_connect(uv_connect_t *req, int status)
+{
+	struct lws_email *email = (struct lws_email *)req->data;
+
+	lwsl_notice("%s\n", __func__);
+
+	if (status == -1) {
+		lwsl_err("%s: failed\n", __func__);
+		return;
+	}
+
+	uv_read_start(req->handle, alloc_buffer, lwsgs_email_read);
+	email->estate = LGSSMTP_CONNECTED;
+}
+
+
+static void
+uv_timeout_cb_email(uv_timer_t *w
+#if UV_VERSION_MAJOR == 0
+		, int status
+#endif
+)
+{
+	struct lws_email *email = lws_container_of(w, struct lws_email,
+						   timeout_email);
+	time_t now = lwsgs_now_secs();
+	struct sockaddr_in req_addr;
+
+	switch (email->estate) {
+	case LGSSMTP_IDLE:
+
+		if (email->on_next(email))
+			break;
+
+		email->estate = LGSSMTP_CONNECTING;
+
+		uv_tcp_init(email->loop, &email->email_client);
+		if (uv_ip4_addr(email->email_smtp_ip, 25, &req_addr)) {
+			lwsl_err("Unable to convert mailserver ads\n");
+			return;
+		}
+
+		lwsl_notice("LGSSMTP_IDLE: connecting\n");
+
+		email->email_connect_started = now;
+		email->email_connect_req.data = email;
+		email->email_client.data = email;
+		uv_tcp_connect(&email->email_connect_req, &email->email_client,
+			       (struct sockaddr *)&req_addr,
+			       lwsgs_email_on_connect);
+
+		uv_timer_start(&email->timeout_email,
+			       uv_timeout_cb_email, 5000, 0);
+
+		break;
+
+	case LGSSMTP_CONNECTING:
+		if (email->email_connect_started - now > 5) {
+			lwsl_err("mail session timed out\n");
+			/* !!! kill the connection */
+			uv_close((uv_handle_t *) &email->email_connect_req, ccb);
+			email->estate = LGSSMTP_IDLE;
+		}
+		break;
+
+	default:
+		break;
+	}
+}
+
+LWS_VISIBLE LWS_EXTERN int
+lws_email_init(struct lws_email *email, uv_loop_t *loop, int max_content)
+{
+	email->content = lws_malloc(max_content);
+	if (!email->content)
+		return 1;
+	email->max_content_size = max_content;
+	uv_timer_init(loop, &email->timeout_email);
+
+	email->loop = loop;
+
+	/* trigger him one time in a bit */
+	uv_timer_start(&email->timeout_email, uv_timeout_cb_email, 2000, 0);
+
+	return 0;
+}
+
+LWS_VISIBLE LWS_EXTERN void
+lws_email_check(struct lws_email *email)
+{
+	uv_timer_start(&email->timeout_email, uv_timeout_cb_email, 1000, 0);
+}
+
+LWS_VISIBLE LWS_EXTERN void
+lws_email_destroy(struct lws_email *email)
+{
+	if (email->content)
+		lws_free_set_NULL(email->content);
+
+	uv_timer_stop(&email->timeout_email);
+}
+

--- a/lws_config.h.in
+++ b/lws_config.h.in
@@ -102,4 +102,7 @@
 /* Lightweight JSON Parser */
 #cmakedefine LWS_WITH_LEJP
 
+/* SMTP */
+#cmakedefine LWS_WITH_SMTP
+
 ${LWS_SIZEOFPTR_CODE}

--- a/plugins/admin-login.html
+++ b/plugins/admin-login.html
@@ -1,0 +1,5 @@
+<html>
+This is an example destination that will appear after successful Admin login.
+
+This URL cannot be served if you're not logged in as admin.
+</html>

--- a/plugins/failed-login.html
+++ b/plugins/failed-login.html
@@ -1,0 +1,3 @@
+<html>
+This is an example destination that will appear after a failed login
+</html>

--- a/plugins/generic-sessions-login-example.html
+++ b/plugins/generic-sessions-login-example.html
@@ -1,0 +1,176 @@
+<html>
+ <head>
+  <!-- This js is modified per-connection to contain session info.
+       it's just a read-only copy of the real session info which
+       is held strictly server-side.  Modifying these vars clientside
+       doesn't change any server state (eg, access rights) -->
+  <script src="lwsgs.js"></script>
+  </head>
+  <body>
+
+  <script>
+   function check_pw_match()
+   {
+	var en_login = 1, en_register = 1, en_forgot = 1;
+
+	if (document.getElementById('password').value == document.getElementById('password2').value) {
+		document.getElementById('match').innerHTML = "";
+		document.getElementById('pw2').innerHTML = "Password (again):";
+	} else {
+		if (document.getElementById('password2').value ||
+		    document.getElementById('email').value) { // ie, he is filling in "register" path and cares
+			document.getElementById('match').innerHTML =
+				"<span style=\"color: red\"><b>Passwords do not match</b></span>";
+			document.getElementById('pw2').innerHTML = "<b>Password (again):</b>";
+		} else {
+			document.getElementById('match').innerHTML = "<span style=\"color: gray\">Passwords do not match</span>";
+			document.getElementById('pw2').innerHTML = "Password (again):";
+		}
+
+		en_register = 0;
+	}
+
+	if (document.getElementById('password').value.length &&
+	    document.getElementById('password').value.length < 8) {
+		en_login = en_register = 0;
+		document.getElementById('pw1').innerHTML = "Need 8 chars";
+	} else
+		document.getElementById('pw1').innerHTML = "";
+
+	if (!document.getElementById('username').value ||
+	    !document.getElementById('password').value ||
+	    document.getElementById('password2').value ||
+	    document.getElementById('email').value)
+		en_login = 0;
+
+	if (!document.getElementById('password').value ||
+	    !document.getElementById('password2').value ||
+	    !document.getElementById('username').value ||
+	    !document.getElementById('email').value)
+		en_register = 0;
+
+	if (!document.getElementById('username').value &&
+	    !document.getElementById('email').value)
+		en_forgot = 0;
+
+	document.getElementById('login').disabled = !en_login;
+	document.getElementById('register').disabled = !en_register;
+ 	document.getElementById('forgot').disabled = !en_forgot;
+  }
+  </script>
+
+   <div id="dlogin" style="display:none">
+   <form action="login" method="post">
+    <!-- these control the URL the login action goes to
+        after a successful admin login, a successful
+        user login, and a failed login -->
+    <input type="hidden" name="admin" value="needadmin/admin-login.html">
+    <input type="hidden" name="good" value="needauth/successful-login.html">
+    <input type="hidden" name="bad" value="failed-login.html">
+    <input type="hidden" name="reg-good" value="post-register-ok.html">
+    <input type="hidden" name="reg-bad" value="post-register-fail.html">
+    <table>
+     <tr>
+      <td colspan=2 align=center>
+       <img src="lwsws-logo.png">
+      </td>
+     </tr>
+     <tr>
+      <td colspan=2 align=center>
+        This is a sample HTML file showing how<br>
+        to present and manage a login form for<br>
+        lws generic sessions.<br><br>
+	<span id="curuser"></span>
+<script>
+	if (lwsgs_user)
+		document.getElementById("curuser").innerHTML = "currently logged in as " + san(lwsgs_user) + "</br>";
+</script>
+       <b>Please enter your login credentials</b>:
+      </td>
+     </tr>
+    <tr><td colspan=2 align=center>
+	<table align=center style="background-color: #c0c040; margin: 8px; padding: 8px"><tr><td colspan=2 align=center>
+	<table align=center style="background-color: #e0e080; margin: 8px; padding: 8px">
+    <tr>
+     <td>User Name</td>
+     <td><input type="text" id="username" name="username" oninput="check_pw_match()"></td>
+    </tr>
+    <tr>
+     <td>Password</td>
+     <td><input type="password" id="password" name="password" oninput="check_pw_match()"><div id="pw1"></div></td>
+    </tr>
+    <tr>
+     <td colspan=2 align=center>
+      <input type="submit" id="login" name="login" value="Login" style="margin: 8px; padding: 8px; font-weight=bold;">
+      &nbsp;<input type="submit" id="forgot" name="forgot" value="Forgot password" style="margin: 4px; padding: 4px">
+
+     </td>
+    </tr>
+    </table></td></tr>
+    <tr>
+     <td colspan=2 align=center>
+	No account?  Fill in all the boxes and click Register,<br>
+	and get immediate access after email verification.
+     </td>
+    </tr>
+    <tr>
+     <td><span id="pw2">Password (again)</span></td>
+     <td><input type="password" id="password2" name="password2" oninput="check_pw_match()"><div id="match"></div></td>
+    </tr>
+    <tr>
+     <td>Email</td>
+     <td><input type="email" id="email" name="email" placeholder="me@example.com" oninput="check_pw_match()"></td>
+    </tr>
+    <tr>
+     <td colspan=2 align=center>
+      <input type="submit" id="register" name="register" value="Register" style="margin: 6px; padding: 6px">
+     </td>
+    </tr>
+    </table></td></tr>
+   </table>
+  </form>
+  </div>
+  <div id="dlogout" style="display:none">
+   <form action="logout" method="post">
+    <!-- this controls the URL the login action goes to
+        after the logout (in this case, back to login page) -->
+    <input type="hidden" name="good" value="generic-sessions-login-example.html">
+    <table>
+     <tr>
+      <td colspan=2 align=center>
+       <img src="lwsws-logo.png">
+      </td>
+     </tr>
+     <tr>
+      <td colspan=2 align=center>
+        This is a sample HTML file showing how<br>
+        to present and manage a login form for<br>
+        lws generic sessions.<br><br>
+	It's only showing the logout form<br>
+	because we know you are logged in<br><br>
+	<span id="out_curuser"></span>
+<script>
+	document.getElementById("out_curuser").innerHTML =
+		"currently logged in as " + san(lwsgs_user) + "</br>";
+</script>
+      </td>
+     </tr>
+     <tr>
+     <td colspan=2 align=center>
+      <input type="submit" name="logout" value="Logout" style="margin: 8px; padding: 8px">
+     </td>
+    </tr>
+   </table>
+  </form>
+  </div>
+
+<script>
+	check_pw_match();
+	if (lwsgs_user === "")
+		document.getElementById("dlogin").style.display = "inline";
+	else
+		document.getElementById("dlogout").style.display = "inline";	
+</script>
+ </body>
+</html>
+

--- a/plugins/generic-sessions-register-example.html
+++ b/plugins/generic-sessions-register-example.html
@@ -1,0 +1,181 @@
+<html>
+ <head>
+  <!-- This js is modified per-connection to contain session info.
+       it's just a read-only copy of the real session info which
+       is held strictly server-side.  Modifying these vars clientside
+       doesn't change any server state (eg, access rights) -->
+  <script src="lwsgs.js"></script>
+  </head>
+  <body>
+
+  <script>
+
+   var user_check = '0';
+   var email_check = '0';
+
+   function update()
+   {
+	var en_register = 1, en_forgot = 0;
+
+	if (document.getElementById('password').value == document.getElementById('password2').value) {
+		if (document.getElementById('password').value.length)
+			document.getElementById('match').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('match').innerHTML = "";
+		document.getElementById('pw2').style = "";
+	} else {
+		if (document.getElementById('password2').value ||
+		    document.getElementById('email').value) { // ie, he is filling in "register" path and cares
+			document.getElementById('match').innerHTML =
+				"<span style=\"color: red\">\u2718 <b>Passwords do not match</b></span>";
+		} else
+			document.getElementById('match').innerHTML = "<span style=\"color: gray\">\u2718 Passwords do not match</span>";
+
+		en_register = 0;
+	}
+
+	if (document.getElementById('password').value.length &&
+	    document.getElementById('password').value.length < 8) {
+		en_register = 0;
+		document.getElementById('pw1').innerHTML = "Need 8 chars";
+	} else
+		if (document.getElementById('password').value.length)
+			document.getElementById('pw1').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('pw1').innerHTML = "";
+
+	if (!document.getElementById('password').value ||
+	    !document.getElementById('password2').value ||
+	    !document.getElementById('username').value ||
+	    !document.getElementById('email').value ||
+	    email_check === '1'||
+	    user_check === '1')
+		en_register = 0;
+
+	document.getElementById('register').disabled = !en_register;
+	document.getElementById('password').disabled = user_check === '1';
+	document.getElementById('password2').disabled = user_check === '1';
+	document.getElementById('email').disabled = user_check === '1';
+
+	if (user_check === '0') {
+		if (document.getElementById('username').value)
+			document.getElementById('uchk').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('uchk').innerHTML = "";
+	} else {
+		document.getElementById('uchk').innerHTML = "<b style=\"color:red\">\u2718 Already registered</b>";
+		en_forgot = 1;
+	}
+
+	if (email_check === '0') {
+		if (document.getElementById('email').value)
+			document.getElementById('echk').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('echk').innerHTML = "";
+	} else {
+		document.getElementById('echk').innerHTML = "<b style=\"color:red\">\u2718 Already registered</b>";
+		en_forgot = 1;
+	}
+
+	if (en_forgot)
+		document.getElementById('forgot').style.display = "inline";
+	else
+		document.getElementById('forgot').style.display = "none";
+
+	if (user_check === '1')
+		op = '0.5';
+	else
+		op = '1.0';
+	document.getElementById('password').style.opacity = op;
+ 	document.getElementById('password2').style.opacity = op;
+	document.getElementById('email').style.opacity = op;
+ }
+
+  function check_user()
+  {
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function() { 
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+            user_check = xmlHttp.responseText;
+	    update();
+        }
+    }
+    xmlHttp.open("GET", "check?username="+document.getElementById('username').value, true);
+    xmlHttp.send(null);
+  }
+
+ function check_email()
+  {
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function() { 
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+            email_check = xmlHttp.responseText;
+	    update();
+        }
+    }
+    xmlHttp.open("GET", "check?email="+document.getElementById('email').value, true);
+    xmlHttp.send(null);
+  }
+
+  </script>
+
+   <div id="dlogin" style="display:none">
+   <form action="login" method="post">
+    <!-- these control the URL the login action goes to
+        after a successful admin login, a successful
+        user login, and a failed login -->
+    <input type="hidden" name="admin" value="needadmin/admin-login.html">
+    <input type="hidden" name="good" value="needauth/successful-login.html">
+    <input type="hidden" name="bad" value="failed-login.html">
+    <input type="hidden" name="reg-good" value="post-register-ok.html">
+    <input type="hidden" name="reg-bad" value="post-register-fail.html">
+    <table>
+     <tr>
+      <td colspan=2 align=center>
+       <img src="lwsws-logo.png">
+      </td>
+     </tr>
+     <tr>
+      <td colspan=2 align=center>
+	<span id="curuser"></span>
+<script>
+	if (lwsgs_user)
+		document.getElementById("curuser").innerHTML = "currently logged in as " + san(lwsgs_user) + "</br>";
+</script>
+       <b>Please enter your details to register</b>:
+      </td>
+     </tr>
+    <tr><td align=right>
+     User Name:</td>
+     <td><input type="text" size="10" id="username" name="username" oninput="update(); check_user();">&nbsp;<span id=uchk></span></td>
+    </tr>
+    <tr>
+     <td align=right>Password:</td>
+     <td><input type="password" size="10" id="password" name="password" oninput="update()">&nbsp;<span id="pw1"></span></td>
+    </tr>
+    <tr>
+    </tr>
+    <tr>
+     <td align=right><span id="pw2">Password (again)</span></td>
+     <td><input type="password" size="10" id="password2" name="password2" oninput="update()">&nbsp;<span id="match"></span></td>
+    </tr>
+    <tr>
+     <td align=right>Email:</td>
+     <td><input type="email" size="10" id="email" name="email" placeholder="me@example.com" oninput="update(); check_email()">&nbsp;<span id=echk></span></td>
+    </tr>
+    <tr>
+     <td colspan=2 align=center>
+      <input type="submit" id="register" name="register" value="Register" style="margin: 6px; padding: 6px">
+      <input type="submit" id="forgot" name="forgot" value="Forgot Password" style="margin: 6px; padding: 6px;display: none">
+     </td>
+    </tr>
+   </table>
+  </form>
+  </div>
+<script>
+	update();
+	document.getElementById("dlogin").style.display = "inline";
+</script>
+ </body>
+</html>
+

--- a/plugins/index.html
+++ b/plugins/index.html
@@ -1,0 +1,183 @@
+<html>
+ <head>
+  <script src="lwsgs.js"></script>
+  <style>
+     .body { font-size: 12 }
+     .gstitle { font-size: 18 }
+  </style>
+  </head>
+  <body>
+    <table width="100%">
+     <tr>
+      <td style="vertical-align:top;text-align:left" width=1%>
+       <img src="lwsws-logo.png">
+      </td>
+      <td style="vertical-align:top;text-align:left" width=20%>
+        Example website with top</br>session management ribbon
+      </td>
+      <td style="vertical-align:top;text-align:left">
+
+       <div id="dlogin" style="display:none">
+        <form action="login" method="post">
+         <input type="hidden" name="admin" value="needadmin/admin-login.html">
+         <input type="hidden" name="good" value="index.html">
+         <input type="hidden" name="bad" value="failed-login.html">
+         <input type="hidden" name="forgot-good" value="sent-forgot-ok.html">
+         <input type="hidden" name="forgot-bad" value="sent-forgot-fail.html">
+         <input type="hidden" name="forgot-post-good" value="post-forgot-ok.html">
+         <input type="hidden" name="forgot-post-bad" value="post-forgot-fail.html">
+	 <table style="vertical-align:top;text-align:left">
+          <tr>
+           <td>User Name</br>
+            <input type="text" size="10" id="username" name="username" oninput="lwsgs_update()"></td>
+           <td>Password</br>
+            <input type="password" id="password" size="10" name="password" oninput="lwsgs_update()" onchange="lwsgs_update()"><div id="pw1"></div></td>
+	   <td><input type="submit" id="login" name="login" value="Login" style="margin: 8px; padding: 8px; font-weight=bold;">
+      &nbsp;<input type="submit" id="forgot" name="forgot" value="Forgot password" style="margin: 4px; padding: 4px"></td>
+           <td><input type="button" onclick="lwsgs_open_registration()" value="Sign up"></td>
+          </tr>
+         </table>
+        </form>
+       </div>
+  
+       <div id="dlogout" style="display:none">
+        <form action="logout" method="post">
+         <input type="hidden" name="good" value="index.html">
+         <table style="vertical-align:top;text-align:left">
+          <tr>
+ 	   <td>Logged in as <a href="#" onclick="lwsgs_select_change(); event.preventDefault();"><span id="curuser"></span></a></td>
+           <td><input type="submit" name="logout" value="Logout" style="margin: 4px; padding: 4px"></td>
+          </tr>
+         </table>
+        </form>
+       </div>
+
+       <div id="dregister" style="display:none">
+        <form action="login" method="post">
+         <input type="hidden" name="admin" value="needadmin/admin-login.html">
+         <input type="hidden" name="good" value="successful-login.html">
+         <input type="hidden" name="bad" value="failed-login.html">
+         <input type="hidden" name="reg-good" value="post-register-ok.html">
+         <input type="hidden" name="reg-bad" value="post-register-fail.html">
+         <input type="hidden" name="forgot-good" value="sent-forgot-ok.html">
+         <input type="hidden" name="forgot-bad" value="sent-forgot-fail.html">
+         <input type="hidden" name="forgot-post-good" value="post-forgot-ok.html">
+         <input type="hidden" name="forgot-post-bad" value="post-forgot-fail.html">
+         <table style="vertical-align:top;text-align:left">
+	     <tr>
+	      <td colspan=2 align=center>
+		<span id="curuser"></span>
+	<script>
+		if (lwsgs_user)
+			document.getElementById("curuser").innerHTML = "currently logged in as " + lwsgs_san(lwsgs_user) + "</br>";
+	</script>
+	       <b>Please enter your details to register</b>:
+	      </td>
+	     </tr>
+	    <tr><td align=right>
+	     User Name:</td>
+	     <td><input type="text" size="10" id="rusername" name="username" oninput="lwsgs_rupdate(); lwsgs_check_user();">&nbsp;<span id=uchk></span></td>
+	    </tr>
+	    <tr>
+	     <td align=right>Password:</td>
+	     <td><input type="password" size="10" id="rpassword" name="password" oninput="lwsgs_rupdate()">&nbsp;<span id="rpw1"></span></td>
+	    </tr>
+	    <tr>
+	    </tr>
+	    <tr>
+	     <td align=right><span id="pw2">Password (again):</span></td>
+	     <td><input type="password" size="10" id="password2" name="password2" oninput="lwsgs_rupdate()">&nbsp;<span id="match"></span></td>
+	    </tr>
+	    <tr>
+	     <td align=right>Email:</td>
+	     <td><input type="email" size="10" id="email" name="email"
+	          placeholder="me@example.com" oninput="lwsgs_rupdate(); lwsgs_check_email('email')">&nbsp;
+	          <span id=echk></span></td>
+	    </tr>
+	    <tr>
+	     <td colspan=2 align=center>
+	      <input type="submit" id="register" name="register" value="Register" style="margin: 6px; padding: 6px">
+	      <input type="submit" id="rforgot" name="forgot" value="Forgot Password" style="margin: 6px; padding: 6px;display: none">
+	      <input type="button" id="cancel" name="cancel" value="Cancel" style="margin: 6px; padding: 6px;" onclick="lwsgs_cancel_registration()">
+	     </td>
+	    </tr>
+         </table>
+        </form>
+       </div>
+       
+       <div id="dchange" style="display:none">
+        <form action="change" method="post">
+         <input type="hidden" id="cusername" name="username">
+         <input type="hidden" name="admin" value="needadmin/admin-login.html">
+         <input type="hidden" name="good" value="index.html">
+         <input type="hidden" name="bad" value="failed-login.html">
+         <input type="hidden" name="reg-good" value="post-register-ok.html">
+         <input type="hidden" name="reg-bad" value="post-register-fail.html">
+         <input type="hidden" name="forgot-good" value="sent-forgot-ok.html">
+         <input type="hidden" name="forgot-bad" value="sent-forgot-fail.html">
+         <input type="hidden" name="forgot-post-good" value="post-forgot-ok.html">
+         <input type="hidden" name="forgot-post-bad" value="post-forgot-fail.html">
+         <table style="vertical-align:top;text-align:left">
+	     <tr>
+	      <td colspan=2 align=center>
+		<span id="ccuruser"></span>
+	<script>
+		if (lwsgs_user)
+			document.getElementById("ccuruser").innerHTML =
+			  "<span class=\"gstitle\">Login settings for " +
+			  lwsgs_san(lwsgs_user) + "</span></br>";
+	</script>
+	       <b>Please enter your details to change</b>:
+	      </td>
+	     </tr>
+	    <tr><td align=right id="ccurpw_name">
+	     Current Password:</td>
+	     <td><input type="password" size="10" id="ccurpw" name="curpw"
+	          oninput="lwsgs_cupdate();">&nbsp;<span id=cuchk></span></td>
+	    </tr>
+	    <tr>
+	     <td align=right>Password:</td>
+	     <td><input type="password" size="10" id="cpassword" name="password"
+	          oninput="lwsgs_cupdate()">&nbsp;<span id="cpw1"></span></td>
+	    </tr>
+	    <tr>
+	     <td align=right><span id="pw2">Password (again)</span></td>
+	     <td><input type="password" size="10" id="cpassword2" name="password2"
+	          oninput="lwsgs_cupdate()">&nbsp;<span id="cmatch"></span></td>
+	    </tr>
+	<!-- not supported yet
+	    <tr>
+	     <td align=right id="cemail_name">Email:</td>
+	     <td><input type="email" size="10" id="cemail" name="email"
+	     	  placeholder="?" oninput="lwsgs_cupdate(); lwsgs_check_email('cemail')">
+	     	  &nbsp;<span id=cechk></span></td>
+	    </tr> -->
+	    <tr>
+	     <td colspan=2 align=center>
+	      <input type="submit" id="change" name="change"
+	       value="Change" style="margin: 6px; padding: 6px">
+	      <input type="submit" id="cforgot" name="forgot"
+	       value="Forgot Password" style="margin: 6px; padding: 6px;display: none">
+	      <input type="button" id="cancel" name="cancel"
+	       value="Cancel" style="margin: 6px; padding: 6px;"
+	       onclick="lwsgs_cancel_registration()">
+	     </td>
+	    </tr>
+         </table>
+        </form>
+       </div>
+       
+       <div id="dadmin" style="display:none">
+         Admin settings TBD
+       </div>
+
+      </td>
+     </tr>
+    </table>
+   </form>
+   
+   <script>lwsgs_initial();</script>
+
+ </body>
+</html>
+

--- a/plugins/lwsgs.js
+++ b/plugins/lwsgs.js
@@ -1,0 +1,294 @@
+<!-- lwsgs rewrites the below $vars $v $v into the correct values on the fly -->
+
+var lwsgs_user = "$lwsgs_user";
+var lwsgs_auth = "$lwsgs_auth";
+var lwsgs_email = "$lwsgs_email";
+
+if (lwsgs_user.substring(0, 1) == "$") {
+	alert("lwsgs.js: lws generic sessions misconfigured and not providing vars");
+}
+function lwsgs_san(s)
+{
+	if (s.search("<") != -1)
+		return "invalid string";
+	
+	return s;
+}
+
+function lwsgs_update()
+{
+	var en_login = 1, en_forgot = 1;
+	
+	if (document.getElementById('password').value.length &&
+	    document.getElementById('password').value.length < 8)
+		en_login = 0;
+	
+	if (!document.getElementById('username').value ||
+	    !document.getElementById('password').value)
+		en_login = 0;
+	
+	if (!document.getElementById('username').value ||
+	     document.getElementById('password').value)
+		en_forgot = 0;
+	
+	document.getElementById('login').disabled = !en_login;
+	document.getElementById('forgot').disabled = !en_forgot;
+	
+	if (lwsgs_user)
+		document.getElementById("curuser").innerHTML = lwsgs_san(lwsgs_user);
+
+	if (lwsgs_user === "")
+		document.getElementById("dlogin").style.display = "inline";
+	else
+		document.getElementById("dlogout").style.display = "inline";
+ }
+
+function lwsgs_open_registration()
+{
+	document.getElementById("dadmin").style.display = "none";
+	document.getElementById("dlogin").style.display = "none";
+	document.getElementById("dlogout").style.display = "none";
+	document.getElementById("dchange").style.display = "none";
+	document.getElementById("dregister").style.display = "inline";
+}
+
+function lwsgs_cancel_registration()
+{
+	document.getElementById("dadmin").style.display = "none";
+	document.getElementById("dregister").style.display = "none";
+	document.getElementById("dchange").style.display = "none";
+
+	if (lwsgs_user === "")
+		document.getElementById("dlogin").style.display = "inline";
+	else
+		document.getElementById("dlogout").style.display = "inline";
+}
+
+function lwsgs_select_change()
+{
+	document.getElementById("dlogin").style.display = "none";
+	document.getElementById("dlogout").style.display = "none";
+	document.getElementById("dregister").style.display = "none";
+	if (lwsgs_auth & 2) {
+		document.getElementById("dadmin").style.display = "inline";
+		document.getElementById("dchange").style.display = "none";
+	} else {
+		document.getElementById("dadmin").style.display = "none";
+		document.getElementById("dchange").style.display = "inline";
+	}
+}
+
+var lwsgs_user_check = '0';
+var lwsgs_email_check = '0';
+
+function lwsgs_rupdate()
+{
+	var en_register = 1, en_forgot = 0;
+
+	if (document.getElementById('rpassword').value ==
+	    document.getElementById('password2').value) {
+		if (document.getElementById('rpassword').value.length)
+			document.getElementById('match').innerHTML = 
+				"<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('match').innerHTML = "";
+		document.getElementById('pw2').style = "";
+	} else {
+		if (document.getElementById('password2').value ||
+		    document.getElementById('email').value) { // ie, he is filling in "register" path and cares
+			document.getElementById('match').innerHTML =
+				"<span style=\"color: red\">\u2718 <b>Passwords do not match</b></span>";
+		} else
+			document.getElementById('match').innerHTML =
+				"<span style=\"color: gray\">\u2718 Passwords do not match</span>";
+
+		en_register = 0;
+	}
+
+	if (document.getElementById('rpassword').value.length &&
+	    document.getElementById('rpassword').value.length < 8) {
+		en_register = 0;
+		document.getElementById('rpw1').innerHTML = "Need 8 chars";
+	} else
+		if (document.getElementById('rpassword').value.length)
+			document.getElementById('rpw1').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('rpw1').innerHTML = "";
+
+	if (!document.getElementById('rpassword').value ||
+	    !document.getElementById('password2').value ||
+	    !document.getElementById('rusername').value ||
+	    !document.getElementById('email').value ||
+	    lwsgs_email_check === '1'||
+	    lwsgs_user_check === '1')
+		en_register = 0;
+
+	document.getElementById('register').disabled = !en_register;
+	document.getElementById('rpassword').disabled = lwsgs_user_check === '1';
+	document.getElementById('password2').disabled = lwsgs_user_check === '1';
+	document.getElementById('email').disabled = lwsgs_user_check === '1';
+
+	if (lwsgs_user_check === '0') {
+		if (document.getElementById('rusername').value)
+			document.getElementById('uchk').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('uchk').innerHTML = "";
+	} else {
+		document.getElementById('uchk').innerHTML = "<b style=\"color:red\">\u2718 Already registered</b>";
+		en_forgot = 1;
+	}
+
+	if (lwsgs_email_check === '0') {
+		if (document.getElementById('email').value)
+			document.getElementById('echk').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('echk').innerHTML = "";
+	} else {
+		document.getElementById('echk').innerHTML = "<b style=\"color:red\">\u2718 Already registered</b>";
+		en_forgot = 1;
+	}
+
+	if (en_forgot)
+		document.getElementById('rforgot').style.display = "inline";
+	else
+		document.getElementById('rforgot').style.display = "none";
+
+	if (lwsgs_user_check === '1')
+		op = '0.5';
+	else
+		op = '1.0';
+	document.getElementById('rpassword').style.opacity = op;
+ 	document.getElementById('password2').style.opacity = op;
+	document.getElementById('email').style.opacity = op;
+ }
+
+function lwsgs_cupdate()
+{
+	var en_change = 1, en_forgot = 1, pwok = 1;
+	
+	if (lwsgs_auth & 8) {
+		document.getElementById('ccurpw').style.display = "none";
+		document.getElementById('ccurpw_name').style.display = "none";
+	} else {
+		if (!document.getElementById('ccurpw').value ||
+		    document.getElementById('ccurpw').value.length < 8) {
+			en_change = 0;
+			pwok = 0;
+			document.getElementById('cuchk').innerHTML = "<b style=\"color:redn\">\u2718</b>";
+		} else {
+			en_forgot = 0;
+			document.getElementById('cuchk').innerHTML = "";
+		}
+		document.getElementById('ccurpw').style.display = "inline";
+		document.getElementById('ccurpw_name').style.display = "inline";
+	}
+
+	if (document.getElementById('cpassword').value ==
+	    document.getElementById('cpassword2').value) {
+		if (document.getElementById('cpassword').value.length)
+			document.getElementById('cmatch').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('cmatch').innerHTML = "";
+		document.getElementById('pw2').style = "";
+	} else {
+		if (document.getElementById('cpassword2').value //||
+		    //document.getElementById('cemail').value
+		) { // ie, he is filling in "register" path and cares
+			document.getElementById('cmatch').innerHTML =
+				"<span style=\"color: red\">\u2718 <b>Passwords do not match</b></span>";
+		} else
+			document.getElementById('cmatch').innerHTML = "<span style=\"color: gray\">\u2718 Passwords do not match</span>";
+
+		en_change = 0;
+	}
+
+	if (document.getElementById('cpassword').value.length &&
+	    document.getElementById('cpassword').value.length < 8) {
+		en_change = 0;
+		document.getElementById('cpw1').innerHTML = "Need 8 chars";
+	} else
+		if (document.getElementById('cpassword').value.length)
+			document.getElementById('cpw1').innerHTML = "<b style=\"color:green\">\u2713</b>";
+		else
+			document.getElementById('cpw1').innerHTML = "";
+
+	if (!document.getElementById('cpassword').value ||
+	    !document.getElementById('cpassword2').value ||
+	    pwok == 0)
+		en_change = 0;
+
+	document.getElementById('change').disabled = !en_change;
+	document.getElementById('cpassword').disabled = pwok === 0;
+	document.getElementById('cpassword2').disabled = pwok === 0;
+	//document.getElementById('cemail').disabled = pwok === 0;
+
+	/*
+	if (lwsgs_auth & 8) {
+		document.getElementById('cemail').style.display = "none";
+		document.getElementById('cemail_name').style.display = "none";
+	} else {
+		document.getElementById('cemail').style.display = "inline";
+		document.getElementById('cemail_name').style.display = "inline";
+		if (lwsgs_email_check === '0'  &&
+		    document.getElementById('cemail').value != lwsgs_email) {
+			if (document.getElementById('cemail').value)
+				document.getElementById('cechk').innerHTML = "<b style=\"color:green\">\u2713</b>";
+			else
+				document.getElementById('cechk').innerHTML = "";
+		} else {
+			document.getElementById('cechk').innerHTML = "<b style=\"color:red\">\u2718 Already registered</b>";
+			en_forgot = 1;
+		}
+	} */
+	
+	if (lwsgs_auth & 8)
+		en_forgot = 0;
+
+	if (en_forgot)
+		document.getElementById('cforgot').style.display = "inline";
+	else
+		document.getElementById('cforgot').style.display = "none";
+
+	if (pwok == 0)
+		op = '0.5';
+	else
+		op = '1.0';
+	document.getElementById('cpassword').style.opacity = op;
+ 	document.getElementById('cpassword2').style.opacity = op;
+	// document.getElementById('cemail').style.opacity = op;
+ }
+
+function lwsgs_check_user()
+{
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function() { 
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+            lwsgs_user_check = xmlHttp.responseText;
+	    lwsgs_rupdate();
+        }
+    }
+    xmlHttp.open("GET", "check?username="+document.getElementById('rusername').value, true);
+    xmlHttp.send(null);
+}
+
+function lwsgs_check_email(id)
+{
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function() { 
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+            lwsgs_email_check = xmlHttp.responseText;
+	    lwsgs_rupdate();
+        }
+    }
+    xmlHttp.open("GET", "check?email="+document.getElementById(id).value, true);
+    xmlHttp.send(null);
+}
+
+function lwsgs_initial()
+{
+	//if (lwsgs_email)
+		//document.getElementById('cemail').placeholder = lwsgs_email;
+		document.getElementById('cusername').value = lwsgs_user;
+	lwsgs_update();
+	lwsgs_cupdate();
+}

--- a/plugins/post-forgot-fail.html
+++ b/plugins/post-forgot-fail.html
@@ -1,0 +1,5 @@
+<html>
+Sorry, something went wrong.
+
+Click <a href="../">here</a> to continue.
+</html>

--- a/plugins/post-forgot-ok.html
+++ b/plugins/post-forgot-ok.html
@@ -1,0 +1,6 @@
+<html>
+This is a one-time password recovery login.
+
+Please click <a href="./">here</a> and click your username at the top to reset your password.
+</html>
+

--- a/plugins/post-register-fail.html
+++ b/plugins/post-register-fail.html
@@ -1,0 +1,1 @@
+Registration failed, sorry

--- a/plugins/post-register-ok.html
+++ b/plugins/post-register-ok.html
@@ -1,0 +1,27 @@
+<html>
+ <head>
+  <script src="lwsgs.js"></script>
+ </head>
+ <body>
+  <table>
+    <tr>
+     <td colspan=2 align=center>
+      <img src="lwsws-logo.png">
+     </td>
+    </tr>
+    <tr>
+     <td>
+      Your registration as <span id="u"></span> is accepted,<br>
+      you will receive an email shortly with instructions<br>
+      to verify and enable the account for normal use.<br><br>
+      The link is only valid for an hour, after that if it has<br>
+      not been verified your account will be deleted.
+     </td>
+    </tr>
+   </table>
+  </body>
+ <script>
+	document.getElementById('u').innerHTML = "<b>" + lwsgs_san(lwsgs_user) + "</b>";
+ </script>
+</html>
+

--- a/plugins/post-verify-fail.html
+++ b/plugins/post-verify-fail.html
@@ -1,0 +1,20 @@
+<html>
+ <head>
+  <script src="lwsgs.js"></script>
+ </head>
+ <body>
+  <table>
+    <tr>
+     <td colspan=2 align=center>
+      <img src="lwsws-logo.png">
+     </td>
+    </tr>
+    <tr>
+     <td>
+	Sorry, the link was invalid.
+     </td>
+    </tr>
+   </table>
+  </body>
+</html>
+

--- a/plugins/post-verify-ok.html
+++ b/plugins/post-verify-ok.html
@@ -1,0 +1,25 @@
+<html>
+ <head>
+  <script src="lwsgs.js"></script>
+ </head>
+ <body>
+  <table>
+    <tr>
+     <td colspan=2 align=center>
+      <img src="lwsws-logo.png">
+     </td>
+    </tr>
+    <tr>
+     <td>
+        Thanks for signing up, your registration as <span id="u"></span> is verified.<br>
+	<br>
+	Click <a href="/lwsgs">here</a> to continue.
+     </td>
+    </tr>
+   </table>
+  </body>
+ <script>
+	document.getElementById('u').innerHTML = "<b>" + san(lwsgs_user) + "</b>";
+ </script>
+</html>
+

--- a/plugins/protocol_generic_sessions.c
+++ b/plugins/protocol_generic_sessions.c
@@ -1,0 +1,2120 @@
+/*
+ * ws protocol handler plugin for "generic sessions"
+ *
+ * Copyright (C) 2010-2016 Andy Green <andy@warmcat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation:
+ * version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+
+#define LWS_DLL
+#define LWS_INTERNAL
+#include "../lib/libwebsockets.h"
+
+#include <sqlite3.h>
+#include <string.h>
+
+#define LWSGS_EMAIL_CONTENT_SIZE 16384
+#define LWSGS_VERIFIED_ACCEPTED 100
+
+/* SHA-1 binary and hexified versions */
+typedef struct { unsigned char bin[20]; } lwsgw_hash_bin;
+typedef struct { char id[41]; } lwsgw_hash;
+
+enum lwsgs_auth_bits {
+	LWSGS_AUTH_LOGGED_IN = 1,
+	LWSGS_AUTH_ADMIN = 2,
+	LWSGS_AUTH_VERIFIED = 4,
+	LWSGS_AUTH_FORGOT_FLOW = 8,
+};
+
+struct lwsgs_user {
+	char username[32];
+	char ip[16];
+	lwsgw_hash pwhash;
+	lwsgw_hash pwsalt;
+	lwsgw_hash token;
+	time_t created;
+	time_t last_forgot_validated;
+	char email[100];
+	int verified;
+};
+
+struct per_vhost_data__generic_sessions {
+	struct lws_email email;
+	struct lws_context *context;
+	char session_db[256];
+	char admin_user[32];
+	char confounder[32];
+	char email_contact_person[128];
+	char email_title[128];
+	char email_template[128];
+	char email_confirm_url[128];
+	lwsgw_hash admin_password_sha1;
+	sqlite3 *pdb;
+	int timeout_idle_secs;
+	int timeout_absolute_secs;
+	int timeout_anon_absolute_secs;
+	int timeout_email_secs;
+	time_t last_session_expire;
+	struct lwsgs_user u;
+};
+
+struct per_session_data__generic_sessions {
+	lwsgw_hash login_session;
+	lwsgw_hash delete_session;
+	unsigned int login_expires;
+	char onward[256];
+	char result[500 + LWS_PRE];
+	int result_len;
+	char *start;
+	char swallow[16];
+	char ip[46];
+	int pos;
+	int spos;
+
+	unsigned int logging_out:1;
+};
+
+static const char *
+sql_purify(const char *string, char *escaped, int len)
+{
+	const char *p = string;
+	char *q = escaped;
+
+	while (*p && len-- > 2) {
+		if (*p == '\'') {
+			*q++ = '\\';
+			*q++ = '\'';
+			len --;
+			p++;
+		} else
+			*q++ = *p++;
+	}
+	*q = '\0';
+
+	return escaped;
+}
+
+static signed char
+char_to_hex(const char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+
+	return -1;
+}
+
+static const char * const hex = "0123456789abcdef";
+
+static void
+sha1_to_lwsgw_hash(unsigned char *hash, lwsgw_hash *shash)
+{
+	char *p = shash->id;
+	int n;
+
+	for (n = 0; n < 20; n++) {
+		*p++ = hex[hash[n] >> 4];
+		*p++ = hex[hash[n] & 15];
+	}
+
+	*p = '\0';
+}
+
+static unsigned int
+lwsgs_now_secs(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	return tv.tv_sec;
+}
+#if 0
+static int
+strcmp_end(const char *a, const char *b)
+{
+	int n = strlen(a), m = strlen(b);
+
+	if (n < m)
+		return -1;
+
+	return strcmp(a + (n - m), b);
+}
+#endif
+
+static int
+strcpy_urldecode(char *a, int len, const char *b)
+{
+	int state = 0, n;
+	char sum = 0;
+
+	while (*b && len) {
+		switch (state) {
+		case 0:
+			if (*b == '%') {
+				state++;
+				b++;
+				continue;
+			}
+			if (*b == '+') {
+				b++;
+				*a++ = ' ';
+				continue;
+			}
+			*a++ = *b++;
+			len--;
+			break;
+		case 1:
+			n = char_to_hex(*b);
+			if (n < 0)
+				return -1;
+			b++;
+			sum = n << 4;
+			state++;
+			break;
+
+		case 2:
+			n = char_to_hex(*b);
+			if (n < 0)
+				return -1;
+			b++;
+			*a++ = sum | n;
+			len--;
+			state = 0;
+			break;
+		}
+
+	}
+	*a = '\0';
+
+	return 0;
+}
+
+static const char *
+urlencode(const char *string, char *escaped, int len)
+{
+	const char *p = string;
+	char *q = escaped;
+
+	while (*p && len-- > 3) {
+		if (*p == ' ') {
+			*q++ = '+';
+			p++;
+			continue;
+		}
+		if ((*p >= '0' && *p <= '9') ||
+		    (*p >= 'A' && *p <= 'Z') ||
+		    (*p >= 'a' && *p <= 'z')) {
+			*q++ = *p++;
+			continue;
+		}
+		*q++ = '%';
+		*q++ = hex[(*p >> 4) & 0xf];
+		*q++ = hex[*p & 0xf];
+
+		len -= 2;
+		p++;
+	}
+	*q = '\0';
+
+	return escaped;
+}
+
+static int
+lwsgw_check_admin(struct per_vhost_data__generic_sessions *vhd,
+		  const char *username, const char *password)
+{
+	lwsgw_hash_bin hash_bin;
+	lwsgw_hash pw_hash;
+
+	if (strcmp(vhd->admin_user, username))
+		return 0;
+
+	lws_SHA1((unsigned char *)password, strlen(password), hash_bin.bin);
+	sha1_to_lwsgw_hash(hash_bin.bin, &pw_hash);
+
+	return !strcmp(vhd->admin_password_sha1.id, pw_hash.id);
+}
+
+/*
+ * secure cookie: it can only be passed over https where it cannot be
+ *		  snooped in transit
+ * HttpOnly:	  it can only be accessed via http[s] transport, it cannot be
+ *		  gotten at by JS
+ */
+static void
+lwsgw_cookie_from_session(lwsgw_hash *sid, time_t expires,
+			  char **p, char *end)
+{
+	struct tm *tm = gmtime(&expires);
+	time_t n = lwsgs_now_secs();
+
+	*p += snprintf(*p, end - *p, "id=%s;Expires=", sid->id);
+#ifdef WIN32
+	*p += strftime(*p, end - *p, "%Y %H:%M %Z", tm);
+#else
+	*p += strftime(*p, end - *p, "%F %H:%M %Z", tm);
+#endif
+	*p += snprintf(*p, end - *p, ";path=/");
+	*p += snprintf(*p, end - *p, ";Max-Age=%lu", (unsigned long)(expires - n));
+//	*p += snprintf(*p, end - *p, ";secure");
+	*p += snprintf(*p, end - *p, ";HttpOnly");
+}
+
+static int
+lwsgw_expire_old_sessions(struct per_vhost_data__generic_sessions *vhd)
+{
+	time_t n = lwsgs_now_secs();
+	char s[200];
+
+	if (n - vhd->last_session_expire < 5)
+		return 0;
+
+	vhd->last_session_expire = n;
+
+	snprintf(s, sizeof(s) - 1,
+		 "delete from sessions where "
+		 "expire <= %lu;", (unsigned long)n);
+
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("Unable to expire sessions: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+		return 1;
+	}
+
+	return 0;
+}
+
+static int
+lwsgw_update_session(struct per_vhost_data__generic_sessions *vhd,
+		     lwsgw_hash *hash, const char *user)
+{
+	time_t n = lwsgs_now_secs();
+	char s[200], esc[50], esc1[50];
+
+	if (user[0])
+		n += vhd->timeout_absolute_secs;
+	else
+		n += vhd->timeout_anon_absolute_secs;
+
+	snprintf(s, sizeof(s) - 1,
+		 "update sessions set expire=%lu,username='%s' where name='%s';",
+		 (unsigned long)n,
+		 sql_purify(user, esc, sizeof(esc)),
+		 sql_purify(hash->id, esc1, sizeof(esc1)));
+
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("Unable to update session: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+		return 1;
+	}
+
+	return 0;
+}
+
+static int
+lwsgw_session_from_cookie(const char *cookie, lwsgw_hash *sid)
+{
+	const char *p = cookie;
+	int n;
+
+	while (*p) {
+		if (p[0] == 'i' && p[1] == 'd' && p[2] == '=') {
+			p += 3;
+			break;
+		}
+		p++;
+	}
+	if (!*p) {
+		lwsl_info("no id= in cookie\n");
+		return 1;
+	}
+
+	for (n = 0; n < sizeof(sid->id) - 1 && *p; n++) {
+		/* our SID we issue only has these chars */
+		if ((*p >= '0' && *p <= '9') ||
+		    (*p >= 'a' && *p <= 'f'))
+			sid->id[n] = *p++;
+		else {
+			lwsl_info("bad chars in cookie id %c\n", *p);
+			return 1;
+		}
+	}
+
+	if (n < sizeof(sid->id) - 1) {
+		lwsl_info("cookie id too short\n");
+		return 1;
+	}
+
+	sid->id[sizeof(sid->id) - 1] = '\0';
+
+	return 0;
+}
+
+static int
+lwsgs_get_sid_from_wsi(struct lws *wsi, lwsgw_hash *sid)
+{
+	char cookie[1024];
+
+	/* fail it on no cookie */
+	if (!lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_COOKIE)) {
+		lwsl_info("%s: no cookie\n", __func__);
+		return 1;
+	}
+	if (lws_hdr_copy(wsi, cookie, sizeof cookie, WSI_TOKEN_HTTP_COOKIE) < 0) {
+		lwsl_info("cookie copy failed\n");
+		return 1;
+	}
+	/* extract the sid from the cookie */
+	if (lwsgw_session_from_cookie(cookie, sid)) {
+		lwsl_info("session from cookie failed\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+struct lla {
+	char *username;
+	int len;
+	int results;
+};
+
+static int
+lwsgs_lookup_callback(void *priv, int cols, char **col_val, char **col_name)
+{
+	struct lla *lla = (struct lla *)priv;
+
+	//lwsl_err("%s: %d\n", __func__, cols);
+
+	if (cols)
+		lla->results = 0;
+	if (col_val && col_val[0]) {
+		strncpy(lla->username, col_val[0], lla->len);
+		lla->username[lla->len - 1] = '\0';
+		lwsl_info("%s: %s\n", __func__, lla->username);
+	}
+
+	return 0;
+}
+
+static int
+lwsgs_lookup_session(struct per_vhost_data__generic_sessions *vhd,
+		     const lwsgw_hash *sid, char *username, int len)
+{
+	struct lla lla = { username, len, 1 };
+	char s[150], esc[50];
+
+	lwsgw_expire_old_sessions(vhd);
+
+	snprintf(s, sizeof(s) - 1,
+		 "select username from sessions where name = '%s';",
+		 sql_purify(sid->id, esc, sizeof(esc) - 1));
+
+	if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback, &lla, NULL) != SQLITE_OK) {
+		lwsl_err("Unable to create user table: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+
+		return 1;
+	}
+
+	/* 0 if found */
+	return lla.results;
+}
+
+static int
+lwsgs_lookup_callback_user(void *priv, int cols, char **col_val, char **col_name)
+{
+	struct lwsgs_user *u = (struct lwsgs_user *)priv;
+	int n;
+
+	for (n = 0; n < cols; n++) {
+		if (!strcmp(col_name[n], "username")) {
+			strncpy(u->username, col_val[n], sizeof(u->username) - 1);
+			u->username[sizeof(u->username) - 1] = '\0';
+			continue;
+		}
+		if (!strcmp(col_name[n], "ip")) {
+			strncpy(u->ip, col_val[n], sizeof(u->ip) - 1);
+			u->ip[sizeof(u->ip) - 1] = '\0';
+			continue;
+		}
+		if (!strcmp(col_name[n], "creation_time")) {
+			u->created = atol(col_val[n]);
+			continue;
+		}
+		if (!strcmp(col_name[n], "last_forgot_validated")) {
+			if (col_val[n])
+				u->last_forgot_validated = atol(col_val[n]);
+			else
+				u->last_forgot_validated = 0;
+			continue;
+		}
+		if (!strcmp(col_name[n], "email")) {
+			strncpy(u->email, col_val[n], sizeof(u->email) - 1);
+			u->email[sizeof(u->email) - 1] = '\0';
+			continue;
+		}
+		if (!strcmp(col_name[n], "verified")) {
+			u->verified = atoi(col_val[n]);
+			continue;
+		}
+		if (!strcmp(col_name[n], "pwhash")) {
+			strncpy(u->pwhash.id, col_val[n], sizeof(u->pwhash.id) - 1);
+			u->pwhash.id[sizeof(u->pwhash.id) - 1] = '\0';
+			continue;
+		}
+		if (!strcmp(col_name[n], "pwsalt")) {
+			strncpy(u->pwsalt.id, col_val[n], sizeof(u->pwsalt.id) - 1);
+			u->pwsalt.id[sizeof(u->pwsalt.id) - 1] = '\0';
+			continue;
+		}
+		if (!strcmp(col_name[n], "token")) {
+			strncpy(u->token.id, col_val[n], sizeof(u->token.id) - 1);
+			u->token.id[sizeof(u->token.id) - 1] = '\0';
+			continue;
+		}
+	}
+	return 0;
+}
+
+static int
+lwsgs_lookup_user(struct per_vhost_data__generic_sessions *vhd,
+		  const char *username, struct lwsgs_user *u)
+{
+	char s[150], esc[50];
+
+	u->username[0] = '\0';
+	snprintf(s, sizeof(s) - 1,
+		 "select username,creation_time,ip,email,verified,pwhash,pwsalt,last_forgot_validated "
+		 "from users where username = '%s';",
+		 sql_purify(username, esc, sizeof(esc) - 1));
+
+	if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, u, NULL) !=
+	    SQLITE_OK) {
+		lwsl_err("Unable to lookup user: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+
+		return -1;
+	}
+
+	return !u->username[0];
+}
+
+static int
+lwsgs_new_session_id(struct per_vhost_data__generic_sessions *vhd,
+		     lwsgw_hash *sid, char *username, int exp)
+{
+	unsigned char sid_rand[20];
+	char *u;
+	char s[300], esc[50], esc1[50];
+
+	if (username)
+		u = username;
+	else
+		u = "";
+
+	if (!sid)
+		return 1;
+
+	memset(sid, 0, sizeof(*sid));
+
+	if (lws_get_random(vhd->context, sid_rand, sizeof(sid_rand)) !=
+			   sizeof(sid_rand))
+		return 1;
+
+	sha1_to_lwsgw_hash(sid_rand, sid);
+
+	snprintf(s, sizeof(s) - 1,
+		 "insert into sessions(name, username, expire) "
+		 "values ('%s', '%s', %u);",
+		 sql_purify(sid->id, esc, sizeof(esc) - 1),
+		 sql_purify(u, esc1, sizeof(esc1) - 1), exp);
+
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("Unable to insert session: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+
+		return 1;
+	}
+
+	return 0;
+}
+
+static int
+lwsgs_get_auth_level(struct per_vhost_data__generic_sessions *vhd,
+		     const char *username)
+{
+	struct lwsgs_user u;
+	int n = 0;
+
+	/* we are logged in as some kind of user */
+	if (username[0]) {
+		n |= LWSGS_AUTH_LOGGED_IN;
+		/* we are logged in as admin */
+		if (!strcmp(username, vhd->admin_user))
+			n |= LWSGS_AUTH_VERIFIED | LWSGS_AUTH_ADMIN; /* automatically verified */
+	}
+
+	if (!lwsgs_lookup_user(vhd, username, &u)) {
+		if ((u.verified & 0xff) == LWSGS_VERIFIED_ACCEPTED)
+			n |= LWSGS_AUTH_VERIFIED;
+
+		if (u.last_forgot_validated > lwsgs_now_secs() - 300)
+			n |= LWSGS_AUTH_FORGOT_FLOW;
+	}
+
+	return n;
+}
+
+struct lwsgs_fill_args {
+	char *buf;
+	int len;
+};
+
+static int
+lwsgs_lookup_callback_email(void *priv, int cols, char **col_val, char **col_name)
+{
+	struct lwsgs_fill_args *a = (struct lwsgs_fill_args *)priv;
+	int n;
+
+	for (n = 0; n < cols; n++) {
+		if (!strcmp(col_name[n], "content")) {
+			strncpy(a->buf, col_val[n], a->len - 1);
+			a->buf[a->len - 1] = '\0';
+			continue;
+		}
+	}
+	return 0;
+}
+
+static int
+lwsgs_email_cb_get_body(struct lws_email *email, char *buf, int len)
+{
+	struct per_vhost_data__generic_sessions *vhd =
+		(struct per_vhost_data__generic_sessions *)email->data;
+	struct lwsgs_fill_args a;
+	char ss[150], esc[50];
+
+	a.buf = buf;
+	a.len = len;
+
+	snprintf(ss, sizeof(ss) - 1,
+		 "select content from email where username='%s';",
+		 sql_purify(vhd->u.username, esc, sizeof(esc) - 1));
+
+	strncpy(buf, "failed", len);
+	if (sqlite3_exec(vhd->pdb, ss, lwsgs_lookup_callback_email, &a,
+			 NULL) != SQLITE_OK) {
+		lwsl_err("Unable to lookup email: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+
+		return 1;
+	}
+
+	return 0;
+}
+
+static int
+lwsgs_email_cb_sent(struct lws_email *email)
+{
+	struct per_vhost_data__generic_sessions *vhd =
+		(struct per_vhost_data__generic_sessions *)email->data;
+	char s[200], esc[50];
+
+	/* mark the user as having sent the verification email */
+	snprintf(s, sizeof(s) - 1,
+		 "update users set verified=1 where username='%s' and verified==0;",
+		 sql_purify(vhd->u.username, esc, sizeof(esc) - 1));
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("%s: Unable to update user: %s\n", __func__,
+			 sqlite3_errmsg(vhd->pdb));
+		return 1;
+	}
+	snprintf(s, sizeof(s) - 1,
+		 "delete from email where username='%s';",
+		 sql_purify(vhd->u.username, esc, sizeof(esc) - 1));
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("%s: Unable to delete email text: %s\n", __func__,
+			 sqlite3_errmsg(vhd->pdb));
+		return 1;
+	}
+
+	return 0;
+}
+
+static int
+lwsgs_email_cb_on_next(struct lws_email *email)
+{
+	struct per_vhost_data__generic_sessions *vhd = lws_container_of(email,
+			struct per_vhost_data__generic_sessions, email);
+	char s[LWSGS_EMAIL_CONTENT_SIZE];
+	time_t now = lwsgs_now_secs();
+
+	/*
+	 * users not verified in 24h get deleted
+	 */
+	snprintf(s, sizeof(s) - 1,
+		 "delete from users where ((verified != %d) and "
+		 "(creation_time <= %lu));", LWSGS_VERIFIED_ACCEPTED,
+		 (unsigned long)now - vhd->timeout_email_secs);
+
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("Unable to expire users: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+		return 1;
+	}
+
+	snprintf(s, sizeof(s) - 1,
+		 "update users set token_time=0 where "
+		 "(token_time <= %lu);",
+		 (unsigned long)now - vhd->timeout_email_secs);
+
+	if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) != SQLITE_OK) {
+		lwsl_err("Unable to expire users: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+		return 1;
+	}
+
+	vhd->u.username[0] = '\0';
+	snprintf(s, sizeof(s) - 1,
+		 "select username from email limit 1;");
+
+	if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &vhd->u,
+			 NULL) != SQLITE_OK) {
+		lwsl_err("Unable to lookup user: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+
+		return 1;
+	}
+	snprintf(s, sizeof(s) - 1,
+		 "select username, creation_time, email, ip, verified, token"
+		 " from users where username='%s' limit 1;",
+		 vhd->u.username);
+
+	if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &vhd->u,
+			 NULL) != SQLITE_OK) {
+		lwsl_err("Unable to lookup user: %s\n",
+			 sqlite3_errmsg(vhd->pdb));
+
+		return 1;
+	}
+
+	if (!vhd->u.username[0])
+		/*
+		 * nothing to do, we are idle and no suitable
+		 * accounts waiting for verification.  When a new user
+		 * is added we will get kicked to try again.
+		 */
+		return 1;
+
+	strncpy(email->email_to, vhd->u.email, sizeof(email->email_to) - 1);
+
+	return 0;
+}
+
+
+static int
+lwsgs_check_credentials(struct per_vhost_data__generic_sessions *vhd,
+			const char *username, const char *password)
+{
+	unsigned char buffer[300];
+	lwsgw_hash_bin hash_bin;
+	struct lwsgs_user u;
+	lwsgw_hash hash;
+	int n;
+
+	if (lwsgs_lookup_user(vhd, username, &u))
+		return -1;
+
+	lwsl_info("user %s found, salt '%s'\n", username, u.pwsalt.id);
+
+	/* [password in ascii][salt] */
+	n = snprintf((char *)buffer, sizeof(buffer) - 1,
+		     "%s-%s-%s", password, vhd->confounder, u.pwsalt.id);
+
+	/* sha1sum of password + salt */
+	lws_SHA1(buffer, n, hash_bin.bin);
+	sha1_to_lwsgw_hash(&hash_bin.bin[0], &hash);
+
+	return !!strcmp(hash.id, u.pwhash.id);
+}
+
+/* sets u->pwsalt and u->pwhash */
+
+static int
+lwsgs_hash_password(struct per_vhost_data__generic_sessions *vhd,
+		    const char *password, struct lwsgs_user *u)
+{
+	lwsgw_hash_bin hash_bin;
+	lwsgw_hash hash;
+	unsigned char sid_rand[20];
+	unsigned char buffer[150];
+	int n;
+
+	/* create a random salt as big as the hash */
+
+	if (lws_get_random(vhd->context, sid_rand,
+			   sizeof(sid_rand)) !=
+			   sizeof(sid_rand)) {
+		lwsl_err("Problem getting random for salt\n");
+		return 1;
+	}
+	sha1_to_lwsgw_hash(sid_rand, &u->pwsalt);
+
+	if (lws_get_random(vhd->context, sid_rand,
+			   sizeof(sid_rand)) !=
+			   sizeof(sid_rand)) {
+		lwsl_err("Problem getting random for token\n");
+		return 1;
+	}
+	sha1_to_lwsgw_hash(sid_rand, &hash);
+
+	/* [password in ascii][salt] */
+	n = snprintf((char *)buffer, sizeof(buffer) - 1,
+		    "%s-%s-%s", password, vhd->confounder, u->pwsalt.id);
+
+	/* sha1sum of password + salt */
+	lws_SHA1(buffer, n, hash_bin.bin);
+	sha1_to_lwsgw_hash(&hash_bin.bin[0], &u->pwhash);
+
+	return 0;
+}
+
+static int
+callback_generic_sessions(struct lws *wsi, enum lws_callback_reasons reason,
+			  void *user, void *in, size_t len)
+{
+	struct per_session_data__generic_sessions *pss =
+			(struct per_session_data__generic_sessions *)user;
+	const struct lws_protocol_vhost_options *pvo;
+	struct per_vhost_data__generic_sessions *vhd =
+			(struct per_vhost_data__generic_sessions *)
+			lws_protocol_vh_priv_get(lws_get_vhost(wsi),
+					lws_get_protocol(wsi));
+	static const char * const formnames[] = {
+		"username=",
+		"password=",
+		"password2=",
+		"email=",
+		"register=",
+		"good=",
+		"bad=",
+		"reg-good=",
+		"reg-bad=",
+		"admin=",
+		"forgot=",
+		"forgot-good=",
+		"forgot-bad=",
+		"forgot-post-good=",
+		"forgot-post-bad=",
+		"change=",
+		"curpw="
+	};
+	enum {
+		FGS_USERNAME,
+		FGS_PASSWORD,
+		FGS_PASSWORD2,
+		FGS_EMAIL,
+		FGS_REGISTER,
+		FGS_GOOD,
+		FGS_BAD,
+		FGS_REG_GOOD,
+		FGS_REG_BAD,
+		FGS_ADMIN,
+		FGS_FORGOT,
+		FGS_FORGOT_GOOD,
+		FGS_FORGOT_BAD,
+		FGS_FORGOT_POST_GOOD,
+		FGS_FORGOT_POST_BAD,
+		FGS_CHANGE,
+		FGS_CURPW,
+
+		FGS_COUNT
+	};
+	char *formvals[FGS_COUNT], *cp;
+	unsigned char buffer[LWS_PRE + LWSGS_EMAIL_CONTENT_SIZE];
+	char cookie[1024], username[32], *pc = cookie, *sp;
+	char esc[50], esc1[50], esc2[50], esc3[50], esc4[50];
+	struct lws_process_html_args *args;
+	unsigned char *p, *start, *end;
+	sqlite3_stmt *sm;
+	lwsgw_hash sid;
+	int n, old_len;
+	struct lwsgs_user u;
+	char s[LWSGS_EMAIL_CONTENT_SIZE];
+
+	switch (reason) {
+	case LWS_CALLBACK_PROTOCOL_INIT: /* per vhost */
+		vhd = lws_protocol_vh_priv_zalloc(lws_get_vhost(wsi),
+						  lws_get_protocol(wsi),
+				sizeof(struct per_vhost_data__generic_sessions));
+		vhd->context = lws_get_context(wsi);
+
+		/* defaults */
+
+		vhd->timeout_idle_secs = 600;
+		vhd->timeout_absolute_secs = 36000;
+		vhd->timeout_anon_absolute_secs = 1200;
+		vhd->timeout_email_secs = 24 * 3600;
+		strcpy(vhd->email.email_helo, "unconfigured.com");
+		strcpy(vhd->email.email_from, "noreply@unconfigured.com");
+		strcpy(vhd->email_title, "Registration Email from unconfigured");
+		strcpy(vhd->email.email_smtp_ip, "127.0.0.1");
+
+		vhd->email.on_next = lwsgs_email_cb_on_next;
+		vhd->email.on_get_body = lwsgs_email_cb_get_body;
+		vhd->email.on_sent = lwsgs_email_cb_sent;
+		vhd->email.max_content_size = LWSGS_EMAIL_CONTENT_SIZE;
+		vhd->email.data = (void *)vhd;
+
+		pvo = (const struct lws_protocol_vhost_options *)in;
+		while (pvo) {
+			if (!strcmp(pvo->name, "admin-user"))
+				strncpy(vhd->admin_user, pvo->value,
+					sizeof(vhd->admin_user) - 1);
+			if (!strcmp(pvo->name, "admin-password-sha1"))
+				strncpy(vhd->admin_password_sha1.id, pvo->value,
+					sizeof(vhd->admin_password_sha1.id) - 1);
+			if (!strcmp(pvo->name, "session-db"))
+				strncpy(vhd->session_db, pvo->value,
+					sizeof(vhd->session_db) - 1);
+			if (!strcmp(pvo->name, "confounder"))
+				strncpy(vhd->confounder, pvo->value,
+					sizeof(vhd->confounder) - 1);
+			if (!strcmp(pvo->name, "email-from"))
+				strncpy(vhd->email.email_from, pvo->value,
+					sizeof(vhd->email.email_from) - 1);
+			if (!strcmp(pvo->name, "email-helo"))
+				strncpy(vhd->email.email_helo, pvo->value,
+					sizeof(vhd->email.email_helo) - 1);
+			if (!strcmp(pvo->name, "email-template"))
+				strncpy(vhd->email_template, pvo->value,
+					sizeof(vhd->email_template) - 1);
+			if (!strcmp(pvo->name, "email-title"))
+				strncpy(vhd->email_title, pvo->value,
+					sizeof(vhd->email_title) - 1);
+			if (!strcmp(pvo->name, "email-contact-person"))
+				strncpy(vhd->email_contact_person, pvo->value,
+					sizeof(vhd->email_contact_person) - 1);
+			if (!strcmp(pvo->name, "email-confirm-url-base"))
+				strncpy(vhd->email_confirm_url, pvo->value,
+					sizeof(vhd->email_confirm_url) - 1);
+			if (!strcmp(pvo->name, "email-server-ip"))
+				strncpy(vhd->email.email_smtp_ip, pvo->value,
+					sizeof(vhd->email.email_smtp_ip) - 1);
+
+			if (!strcmp(pvo->name, "timeout-idle-secs"))
+				vhd->timeout_idle_secs = atoi(pvo->value);
+			if (!strcmp(pvo->name, "timeout-absolute-secs"))
+				vhd->timeout_absolute_secs = atoi(pvo->value);
+			if (!strcmp(pvo->name, "timeout-anon-absolute-secs"))
+				vhd->timeout_anon_absolute_secs = atoi(pvo->value);
+			if (!strcmp(pvo->name, "email-expire"))
+				vhd->timeout_email_secs = atoi(pvo->value);
+			pvo = pvo->next;
+		}
+		if (!vhd->admin_user[0] ||
+		    !vhd->admin_password_sha1.id[0] ||
+		    !vhd->session_db[0]) {
+			lwsl_err("generic-sessions: "
+				 "You must give \"admin-user\", "
+				 "\"admin-password-sha1\", "
+				 "and \"session_db\" per-vhost options\n");
+			return 1;
+		}
+
+		if (sqlite3_open_v2(vhd->session_db, &vhd->pdb,
+				    SQLITE_OPEN_READWRITE |
+				    SQLITE_OPEN_CREATE, NULL) != SQLITE_OK) {
+			lwsl_err("Unable to open session db %s: %s\n",
+				 vhd->session_db, sqlite3_errmsg(vhd->pdb));
+
+			return 1;
+		}
+
+		if (sqlite3_prepare(vhd->pdb,
+				    "create table if not exists sessions ("
+				    " name char(40),"
+				    " username varchar(32),"
+				    " expire integer"
+				    ");",
+				    -1, &sm, NULL) != SQLITE_OK) {
+			lwsl_err("Unable to prepare session table init: %s\n",
+				 sqlite3_errmsg(vhd->pdb));
+
+			return 1;
+		}
+
+		if (sqlite3_step(sm) != SQLITE_DONE) {
+			lwsl_err("Unable to run session table init: %s\n",
+				 sqlite3_errmsg(vhd->pdb));
+
+			return 1;
+		}
+		sqlite3_finalize(sm);
+
+		if (sqlite3_exec(vhd->pdb,
+				 "create table if not exists users ("
+				 " username varchar(32),"
+				 " creation_time integer,"
+				 " ip varchar(46),"
+				 " email varchar(100),"
+				 " pwhash varchar(42),"
+				 " pwsalt varchar(42),"
+				 " pwchange_time integer,"
+				 " token varchar(42),"
+				 " verified integer,"
+				 " token_time integer,"
+				 " last_forgot_validated integer,"
+				 " primary key (username)"
+				 ");",
+				 NULL, NULL, NULL) != SQLITE_OK) {
+			lwsl_err("Unable to create user table: %s\n",
+				 sqlite3_errmsg(vhd->pdb));
+
+			return 1;
+		}
+
+		sprintf(s, "create table if not exists email ("
+				 " username varchar(32),"
+				 " content blob,"
+				 " primary key (username)"
+				 ");");
+		if (sqlite3_exec(vhd->pdb, s,
+				 NULL, NULL, NULL) != SQLITE_OK) {
+			lwsl_err("Unable to create user table: %s\n",
+				 sqlite3_errmsg(vhd->pdb));
+
+			return 1;
+		}
+
+		lws_email_init(&vhd->email, lws_uv_getloop(vhd->context, 0),
+				LWSGS_EMAIL_CONTENT_SIZE);
+		break;
+
+	case LWS_CALLBACK_PROTOCOL_DESTROY:
+		if (vhd->pdb) {
+			sqlite3_close(vhd->pdb);
+			vhd->pdb = NULL;
+		}
+		lws_email_destroy(&vhd->email);
+		break;
+
+	case LWS_CALLBACK_HTTP:
+		lwsl_notice("LWS_CALLBACK_HTTP: %s\n", in);
+
+		pss->login_session.id[0] = '\0';
+		pss->pos = 0;
+		strncpy(pss->onward, (char *)in, sizeof(pss->onward));
+
+		if (!strcmp((const char *)in, "/forgot")) {
+			const char *a;
+
+			a = lws_get_urlarg_by_name(wsi, "token=", cookie,
+						     sizeof(cookie));
+			if (!a)
+				goto forgot_fail;
+
+			u.username[0] = '\0';
+			snprintf(s, sizeof(s) - 1,
+				 "select username,verified "
+				 "from users where verified=%d and "
+				 "token = '%s' and token_time != 0;",
+				 LWSGS_VERIFIED_ACCEPTED,
+				 sql_purify(&cookie[6], esc, sizeof(esc) - 1));
+			if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &u, NULL) !=
+			    SQLITE_OK) {
+				lwsl_err("Unable to lookup token: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+
+				goto forgot_fail;
+			}
+
+			if (!u.username[0]) {
+				puts(s);
+				lwsl_notice("forgot token doesn't map to verified user\n");
+				goto forgot_fail;
+			}
+
+			/* mark user as having validated forgot flow just now */
+
+			snprintf(s, sizeof(s) - 1,
+				 "update users set token_time=0,last_forgot_validated=%lu  where username='%s';",
+				 (unsigned long)lwsgs_now_secs(), sql_purify(u.username, esc, sizeof(esc) - 1));
+
+			if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &u, NULL) !=
+			    SQLITE_OK) {
+				lwsl_err("Unable to lookup token: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+
+				goto forgot_fail;
+			}
+
+			a = lws_get_urlarg_by_name(wsi, "good=", cookie,
+						     sizeof(cookie));
+			if (!a)
+				a = "broken-forget-post-good-url";
+
+			snprintf(pss->onward, sizeof(pss->onward),
+				 "%s/%s", vhd->email_confirm_url, a);
+
+			pss->login_expires = lwsgs_now_secs() +
+					     vhd->timeout_absolute_secs;
+
+			pss->delete_session.id[0] = '\0';
+			lwsgs_get_sid_from_wsi(wsi, &pss->delete_session);
+
+			/* we need to create a new, authorized session */
+			if (lwsgs_new_session_id(vhd, &pss->login_session,
+						 u.username,
+						 pss->login_expires))
+				goto forgot_fail;
+
+			lwsl_notice("Creating new session: %s, redir to %s\n",
+				    pss->login_session.id, pss->onward);
+
+			goto redirect_with_cookie;
+
+forgot_fail:
+			pss->delete_session.id[0] = '\0';
+			lwsgs_get_sid_from_wsi(wsi, &pss->delete_session);
+			pss->login_expires = 0;
+
+			a = lws_get_urlarg_by_name(wsi, "bad=", cookie,
+						     sizeof(cookie));
+			if (!a)
+				a = "broken-forget-post-bad-url";
+
+			snprintf(pss->onward, sizeof(pss->onward),
+				 "%s/%s", vhd->email_confirm_url, a);
+
+			goto redirect_with_cookie;
+		}
+
+		if (!strcmp((const char *)in, "/confirm")) {
+
+			if (lws_hdr_copy_fragment(wsi, cookie, sizeof(cookie),
+						  WSI_TOKEN_HTTP_URI_ARGS, 0) < 0) {
+				lwsl_notice("copy failed\n");
+				goto verf_fail;
+			}
+
+			if (strncmp(cookie, "token=", 6)) {
+				lwsl_notice("not token=\n");
+				goto verf_fail;
+			}
+
+			u.username[0] = '\0';
+			snprintf(s, sizeof(s) - 1,
+				 "select username,verified "
+				 "from users where token = '%s';",
+				 sql_purify(&cookie[6], esc, sizeof(esc) - 1));
+			if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &u, NULL) !=
+			    SQLITE_OK) {
+				lwsl_err("Unable to lookup token: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+
+				goto verf_fail;
+			}
+
+			if (!u.username[0] || u.verified != 1) {
+				lwsl_notice("verify token doesn't map to unverified user\n");
+				goto verf_fail;
+			}
+
+			lwsl_notice("Verifying %s\n", u.username);
+			snprintf(s, sizeof(s) - 1,
+				 "update users set verified=%d where username='%s';",
+				 LWSGS_VERIFIED_ACCEPTED,
+				 sql_purify(u.username, esc, sizeof(esc) - 1));
+			if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &u, NULL) !=
+			    SQLITE_OK) {
+				lwsl_err("Unable to lookup token: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+
+				goto verf_fail;
+			}
+
+			snprintf(pss->onward, sizeof(pss->onward),
+				 "%s/post-verify-ok.html",
+				 vhd->email_confirm_url);
+
+			pss->login_expires = lwsgs_now_secs() +
+					     vhd->timeout_absolute_secs;
+
+			pss->delete_session.id[0] = '\0';
+			lwsgs_get_sid_from_wsi(wsi, &pss->delete_session);
+
+			/* we need to create a new, authorized session */
+
+			if (lwsgs_new_session_id(vhd, &pss->login_session,
+						 u.username,
+						 pss->login_expires))
+				goto verf_fail;
+
+			lwsl_notice("Creating new session: %s, redir to %s\n",
+				    pss->login_session.id, pss->onward);
+
+			goto redirect_with_cookie;
+
+verf_fail:
+			pss->delete_session.id[0] = '\0';
+			lwsgs_get_sid_from_wsi(wsi, &pss->delete_session);
+			pss->login_expires = 0;
+
+			snprintf(pss->onward, sizeof(pss->onward),
+				 "%s/post-verify-fail.html",
+				  vhd->email_confirm_url);
+
+			goto redirect_with_cookie;
+		}
+		if (!strcmp((const char *)in, "/check")) {
+			/*
+			 * either /check?email=xxx@yyy
+			 *
+			 * or, /check?username=xxx
+			 *
+			 * returns '0' if not already registered, else '1'
+			 */
+
+			static const char * const colname[] = {
+				"username", "email"
+			};
+
+			u.username[0] = '\0';
+			if (lws_hdr_copy_fragment(wsi, cookie, sizeof(cookie),
+						  WSI_TOKEN_HTTP_URI_ARGS, 0) < 0)
+				goto nope;
+
+			n = !strncmp(cookie, "email=", 6);
+			pc = strchr(cookie, '=');
+			if (!pc) {
+				lwsl_notice("cookie has no =\n");
+				goto nope;
+			}
+			pc++;
+
+			snprintf(s, sizeof(s) - 1,
+				 "select username, email "
+				 "from users where %s = '%s';",
+				 colname[n],
+				 sql_purify(pc, esc, sizeof(esc) - 1));
+
+			puts(s);
+
+			if (sqlite3_exec(vhd->pdb, s,
+					 lwsgs_lookup_callback_user, &u, NULL) !=
+			    SQLITE_OK) {
+				lwsl_err("Unable to lookup token: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+				n = FGS_REG_BAD;
+				goto reg_done;
+			}
+nope:
+			s[0] = '0' + !!u.username[0];
+			p = buffer + LWS_PRE;
+			start = p;
+			end = p + sizeof(buffer) - LWS_PRE;
+
+			if (lws_add_http_header_status(wsi, 200, &p, end))
+				return -1;
+			if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_CONTENT_TYPE,
+							 (unsigned char *)"text/plain", 10,
+							 &p, end))
+				return -1;
+
+			if (lws_add_http_header_content_length(wsi, 1, &p, end))
+					return -1;
+
+			if (lws_finalize_http_header(wsi, &p, end))
+				return -1;
+
+			n = lws_write(wsi, start, p - start, LWS_WRITE_HTTP_HEADERS);
+			if (n != (p - start)) {
+				lwsl_err("_write returned %d from %d\n",
+					 n, (p - start));
+				return -1;
+			}
+			n = lws_write(wsi, (unsigned char *)s, 1, LWS_WRITE_HTTP);
+			if (n != 1)
+				return -1;
+			break;
+		}
+
+		if (!strcmp((const char *)in, "/login"))
+			break;
+		if (!strcmp((const char *)in, "/logout"))
+			break;
+		if (!strcmp((const char *)in, "/forgot"))
+			break;
+		if (!strcmp((const char *)in, "/change"))
+			break;
+
+		lwsl_err("http doing 404 on %s\n", in);
+		lws_return_http_status(wsi, HTTP_STATUS_NOT_FOUND, NULL);
+		break;
+
+	case LWS_CALLBACK_CHECK_ACCESS_RIGHTS:
+		n = 0;
+		username[0] = '\0';
+		sid.id[0] = '\0';
+		args = (struct lws_process_html_args *)in;
+		lwsl_debug("LWS_CALLBACK_CHECK_ACCESS_RIGHTS\n");
+		if (!lwsgs_get_sid_from_wsi(wsi, &sid)) {
+			if (lwsgs_lookup_session(vhd, &sid, username, sizeof(username))) {
+				static const char * const oprot[] = {
+					"http://", "https://"
+				};
+				lwsl_notice("session lookup for %s failed, probably expired\n", sid.id);
+				pss->delete_session = sid;
+				args->final = 1; /* signal we dealt with it */
+				if (lws_hdr_copy(wsi, cookie, sizeof(cookie) - 1,
+					     WSI_TOKEN_HOST) < 0)
+					return 1;
+				snprintf(pss->onward, sizeof(pss->onward) - 1,
+					 "%s%s%s", oprot[lws_is_ssl(wsi)],
+					    cookie, args->p);
+				lwsl_notice("redirecting to ourselves with cookie refresh\n");
+				/* we need a redirect to ourselves, session cookie is expired */
+				goto redirect_with_cookie;
+			}
+		} else
+			lwsl_notice("failed to get sid from wsi\n");
+
+		n = lwsgs_get_auth_level(vhd, username);
+
+		if ((args->max_len & n) != args->max_len) {
+			lwsl_notice("Access rights fail 0x%X vs 0x%X (cookie %s)\n",
+					args->max_len, n, sid.id);
+			return 1;
+		}
+		lwsl_debug("Access rights OK\n");
+		break;
+
+	case LWS_CALLBACK_PROCESS_HTML:
+		/*
+		 * replace placeholders with session data and prepare the
+		 * preamble to send chunked, p is already at +10 from the
+		 * real buffer start to allow us to add the chunk header
+		 *
+		 * struct lws_process_html_args {
+		 *	char *p;
+		 *	int len;
+		 *	int max_len;
+		 *	int final;
+		 * };
+		 */
+
+		args = (struct lws_process_html_args *)in;
+
+		username[0] = '\0';
+		u.email[0] = '\0';
+		if (!lwsgs_get_sid_from_wsi(wsi, &sid)) {
+			if (lwsgs_lookup_session(vhd, &sid, username,
+						 sizeof(username))) {
+				lwsl_notice("sid lookup for %s failed\n", sid.id);
+				pss->delete_session = sid;
+				return 1;
+			}
+			snprintf(s, sizeof(s) - 1,
+				 "select username,email "
+				 "from users where username = '%s';",
+				 sql_purify(username, esc, sizeof(esc) - 1));
+
+			if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user,
+					 &u, NULL) != SQLITE_OK) {
+				lwsl_err("Unable to lookup token: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+				pss->delete_session = sid;
+				return 1;
+			}
+		} else
+			lwsl_notice("no sid\n");
+
+		/* do replacements */
+		sp = args->p;
+		old_len = args->len;
+		args->len = 0;
+		pss->start = sp;
+		while (sp < args->p + old_len) {
+
+			if (args->len + 7 >= args->max_len) {
+				lwsl_err("Used up interpret padding\n");
+				return -1;
+			}
+
+			if ((!pss->pos && *sp == '$') ||
+			    pss->pos) {
+				static const char * const vars[] = {
+					"$lwsgs_user",
+					"$lwsgs_auth",
+					"$lwsgs_email"
+				};
+				int hits = 0, hit;
+
+				if (!pss->pos)
+					pss->start = sp;
+				pss->swallow[pss->pos++] = *sp;
+				if (pss->pos == sizeof(pss->swallow))
+					goto skip;
+				for (n = 0; n < ARRAY_SIZE(vars); n++)
+					if (!strncmp(pss->swallow, vars[n], pss->pos)) {
+						hits++;
+						hit = n;
+					}
+				if (!hits) {
+skip:
+					pss->swallow[pss->pos] = '\0';
+					memcpy(pss->start, pss->swallow, pss->pos);
+					args->len++;
+					pss->pos = 0;
+					sp = pss->start + 1;
+					continue;
+				}
+				if (hits == 1 && pss->pos == strlen(vars[hit])) {
+					switch (hit) {
+					case 0:
+						pc = username;
+						break;
+					case 1:
+						pc = cookie;
+						n = lwsgs_get_auth_level(vhd, username);
+						sprintf(cookie, "%d", n);
+						break;
+					case 2:
+						pc = u.email;
+						break;
+					}
+
+					n = strlen(pc);
+					pss->swallow[pss->pos] = '\0';
+					if (n != pss->pos) {
+						memmove(pss->start + n,
+							pss->start + pss->pos,
+							old_len -
+							   (sp - args->p));
+						old_len += (n - pss->pos) + 1;
+					}
+					memcpy(pss->start, pc, n);
+					args->len++;
+					sp = pss->start + 1;
+
+					pss->pos = 0;
+				}
+				sp++;
+				continue;
+			}
+
+			args->len++;
+			sp++;
+		}
+
+		/* no space left for final chunk trailer */
+		if (args->final && args->len + 7 >= args->max_len)
+			return -1;
+
+		n = sprintf((char *)buffer, "%X\x0d\x0a", args->len);
+
+		args->p -= n;
+		memcpy(args->p, buffer, n);
+		args->len += n;
+
+		if (args->final) {
+			sp = args->p + args->len;
+			*sp++ = '\x0d';
+			*sp++ = '\x0a';
+			*sp++ = '0';
+			*sp++ = '\x0d';
+			*sp++ = '\x0a';
+			*sp++ = '\x0d';
+			*sp++ = '\x0a';
+			args->len += 7;
+		} else {
+			sp = args->p + args->len;
+			*sp++ = '\x0d';
+			*sp++ = '\x0a';
+			args->len += 2;
+		}
+		break;
+
+	case LWS_CALLBACK_HTTP_BODY:
+		lwsl_notice("LWS_CALLBACK_HTTP_BODY: %s\n", pss->onward);
+
+		/* we will get something like this
+		 *
+		 * username=admin&password=xyz
+		 */
+
+		if (len < 20)
+			return 1;
+
+		memset(formvals, 0, sizeof(formvals));
+		sp = (char *)in;
+		sp[len]='\0';
+
+		/*
+		 * Whatever we're here for, we will need the POST args
+		 * processing...
+		 */
+
+		while (sp < ((char *)in + len)) {
+			for (n = 0; n < ARRAY_SIZE(formnames); n++)
+				if (!strncmp(sp, formnames[n],
+					     strlen(formnames[n])))
+					break;
+			if (n < ARRAY_SIZE(formnames)) {
+				sp += strlen(formnames[n]);
+				formvals[n] = sp;
+			}
+
+			sp = strchr(sp, '&');
+			if (!sp) {
+				if (n < ARRAY_SIZE(formnames) && formvals[n]) {
+					if (strcpy_urldecode(formvals[n],
+							     strlen(formvals[n]),
+							     formvals[n]))
+						return -1;
+					lwsl_debug("%d: %s\n", n, formvals[n]);
+				}
+				break;
+			}
+			*(sp++) = '\0';
+			if (formvals[n])
+				if (strcpy_urldecode(formvals[n], sp - formvals[n],
+						formvals[n]))
+					return -1;
+			lwsl_debug("%d: %s\n", n, formvals[n]);
+		}
+
+		/*
+		 * change password
+		 */
+
+		if (!strcmp((char *)pss->onward, "/change")) {
+			n = 0;
+
+			/* see if he's logged in */
+			username[0] = '\0';
+			if (!lwsgs_get_sid_from_wsi(wsi, &sid)) {
+				u.username[0] = '\0';
+				if (!lwsgs_lookup_session(vhd, &sid, username, sizeof(username))) {
+					n = 1; /* yes, logged in */
+					if (lwsgs_lookup_user(vhd, username, &u))
+						goto change_fail;
+
+					/* did a forgot pw ? */
+					if (u.last_forgot_validated >
+					    lwsgs_now_secs() - 300)
+						n |= LWSGS_AUTH_FORGOT_FLOW;
+				}
+			}
+
+			/* if he just did forgot pw flow, don't need old pw */
+			if (!(n & (LWSGS_AUTH_FORGOT_FLOW | 1))) {
+				/* otherwise user:pass must be right */
+				if (lwsgs_check_credentials(vhd,
+							    formvals[FGS_USERNAME],
+							    formvals[FGS_CURPW])) {
+					lwsl_notice("credentials bad\n");
+					goto change_fail;
+				}
+
+				strcpy(u.username, formvals[FGS_USERNAME]);
+			}
+
+			if (lwsgs_hash_password(vhd, formvals[FGS_PASSWORD],
+					        &u)) {
+				lwsl_err("Password hash failed\n");
+				goto change_fail;
+			}
+
+			lwsl_notice("updating password hash\n");
+
+			snprintf(s, sizeof(s) - 1,
+				 "update users set pwhash='%s', pwsalt='%s', "
+				 "last_forgot_validated=0 where username='%s';",
+				 u.pwhash.id, u.pwsalt.id,
+				 sql_purify(u.username, esc, sizeof(esc) - 1));
+			if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) !=
+			    SQLITE_OK) {
+				lwsl_err("Unable to update pw hash: %s\n",
+					 sqlite3_errmsg(vhd->pdb));
+
+				goto change_fail;
+			}
+
+			cp = formvals[FGS_GOOD];
+			goto pass;
+change_fail:
+			cp = formvals[FGS_BAD];
+			lwsl_notice("user/password no good %s\n",
+					formvals[FGS_USERNAME]);
+			strncpy(pss->onward, cp, sizeof(pss->onward) - 1);
+			pss->onward[sizeof(pss->onward) - 1] = '\0';
+			break;
+		}
+
+		if (!strcmp((char *)pss->onward, "/login")) {
+			lwsgw_hash hash;
+			unsigned char sid_rand[20];
+
+			if (formvals[FGS_FORGOT] && formvals[FGS_FORGOT][0]) {
+
+				lwsl_notice("FORGOT %s %s\n",
+					    formvals[FGS_USERNAME],
+					    formvals[FGS_EMAIL]);
+
+				if (!formvals[FGS_USERNAME] &&
+				    !formvals[FGS_EMAIL]) {
+					lwsl_err("Form must provide either "
+						  "username or email\n");
+					return -1;
+				}
+
+				if (!formvals[FGS_FORGOT_GOOD] ||
+				    !formvals[FGS_FORGOT_BAD] ||
+				    !formvals[FGS_FORGOT_POST_GOOD] ||
+				    !formvals[FGS_FORGOT_POST_BAD]) {
+					lwsl_err("Form must provide reg-good "
+						  "and reg-bad (and post-*)"
+						  "targets\n");
+					return -1;
+				}
+
+				u.username[0] = '\0';
+				if (formvals[FGS_USERNAME])
+					snprintf(s, sizeof(s) - 1,
+					 "select username,email "
+					 "from users where username = '%s';",
+					 sql_purify(formvals[FGS_USERNAME], esc, sizeof(esc) - 1));
+				else
+					snprintf(s, sizeof(s) - 1,
+					 "select username,email "
+					 "from users where email = '%s';",
+					 sql_purify(formvals[FGS_EMAIL], esc, sizeof(esc) - 1));
+				if (sqlite3_exec(vhd->pdb, s, lwsgs_lookup_callback_user, &u, NULL) !=
+				    SQLITE_OK) {
+					lwsl_err("Unable to lookup token: %s\n",
+						 sqlite3_errmsg(vhd->pdb));
+
+					n = FGS_FORGOT_BAD;
+					goto reg_done;
+				}
+				if (!u.username[0]) {
+					lwsl_err("No match found %s\n", s);
+					n = FGS_FORGOT_BAD;
+					goto reg_done;
+				}
+
+				lws_get_peer_simple(wsi, pss->ip, sizeof(pss->ip));
+				if (lws_get_random(vhd->context, sid_rand,
+						   sizeof(sid_rand)) !=
+						   sizeof(sid_rand)) {
+					lwsl_err("Problem getting random for token\n");
+					n = FGS_BAD;
+					goto reg_done;
+				}
+				sha1_to_lwsgw_hash(sid_rand, &hash);
+				n = snprintf(s, sizeof(s),
+					"From: Forgot Password Assistant Noreply <%s>\n"
+					"To: %s <%s>\n"
+					  "Subject: Password reset request\n"
+					  "\n"
+					  "Hello, %s\n\n"
+					  "We received a password reset request from IP %s for this email,\n"
+					  "to confirm you want to do that, please click the link below.\n\n",
+					sql_purify(vhd->email.email_from, esc, sizeof(esc) - 1),
+					sql_purify(u.username, esc1, sizeof(esc1) - 1),
+					sql_purify(u.email, esc2, sizeof(esc2) - 1),
+					sql_purify(u.username, esc3, sizeof(esc3) - 1),
+					sql_purify(pss->ip, esc4, sizeof(esc4) - 1));
+				snprintf(s + n, sizeof(s) -n,
+					  "%s/forgot?token=%s"
+					   "&good=%s"
+					   "&bad=%s\n\n"
+					  "If this request is unexpected, please ignore it and\n"
+					  "no further action will be taken.\n\n"
+					"If you have any questions or concerns about this\n"
+					"automated email, you can contact a real person at\n"
+					"%s.\n"
+					"\n.\n",
+					vhd->email_confirm_url, hash.id,
+					urlencode(formvals[FGS_FORGOT_POST_GOOD],
+						  esc1, sizeof(esc1) - 1),
+					urlencode(formvals[FGS_FORGOT_POST_BAD],
+						  esc3, sizeof(esc3) - 1),
+					vhd->email_contact_person);
+
+				snprintf((char *)buffer, sizeof(buffer) - 1,
+					 "insert into email(username, content)"
+					 " values ('%s', '%s');",
+					sql_purify(u.username, esc, sizeof(esc) - 1), s);
+				if (sqlite3_exec(vhd->pdb, (char *)buffer, NULL,
+						 NULL, NULL) != SQLITE_OK) {
+					lwsl_err("Unable to insert email: %s\n",
+						 sqlite3_errmsg(vhd->pdb));
+
+					n = FGS_FORGOT_BAD;
+					goto reg_done;
+				}
+
+				snprintf(s, sizeof(s) - 1,
+					 "update users set token='%s',token_time='%ld' where username='%s';",
+					 hash.id, (long)lwsgs_now_secs(),
+					 sql_purify(u.username, esc, sizeof(esc) - 1));
+				if (sqlite3_exec(vhd->pdb, s, NULL, NULL, NULL) !=
+				    SQLITE_OK) {
+					lwsl_err("Unable to set token: %s\n",
+						 sqlite3_errmsg(vhd->pdb));
+
+					n = FGS_FORGOT_BAD;
+					goto reg_done;
+				}
+
+				/* get the email monitor to take a look */
+				lws_email_check(&vhd->email);
+
+				n = FGS_FORGOT_GOOD;
+				goto reg_done;
+			}
+
+			if (!formvals[FGS_USERNAME] ||
+			    !formvals[FGS_PASSWORD])
+				return -1;
+
+			if (formvals[FGS_REGISTER] && formvals[FGS_REGISTER][0]) {
+				unsigned char sid_rand[20];
+
+				lwsl_notice("REGISTER %s %s %s\n",
+						formvals[FGS_USERNAME],
+						formvals[FGS_PASSWORD],
+						formvals[FGS_EMAIL]);
+				if (lwsgs_get_sid_from_wsi(wsi,
+				    &pss->login_session))
+					return 1;
+
+				lws_get_peer_simple(wsi, pss->ip, sizeof(pss->ip));
+				lwsl_notice("IP=%s\n", pss->ip);
+
+				if (!formvals[FGS_REG_GOOD] ||
+				    !formvals[FGS_REG_BAD]) {
+					lwsl_info("Form must provide reg-good "
+						  "and reg-bad targets\n");
+					return -1;
+				}
+
+				/* admin user cannot be registered in user db */
+				if (!strcmp(vhd->admin_user, formvals[FGS_USERNAME])) {
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				if (!lwsgs_lookup_user(vhd,
+						formvals[FGS_USERNAME], &u)) {
+					lwsl_notice("user %s already registered\n",
+							formvals[FGS_USERNAME]);
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				u.username[0] = '\0';
+				snprintf(s, sizeof(s) - 1,
+					 "select username, email "
+					 "from users where email = '%s';",
+					 sql_purify(formvals[FGS_EMAIL], esc,
+					 sizeof(esc) - 1));
+
+				if (sqlite3_exec(vhd->pdb, s,
+						 lwsgs_lookup_callback_user, &u, NULL) !=
+				    SQLITE_OK) {
+					lwsl_err("Unable to lookup token: %s\n",
+						 sqlite3_errmsg(vhd->pdb));
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				if (u.username[0]) {
+					lwsl_notice("email %s already in use\n",
+						    formvals[FGS_USERNAME]);
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				if (lwsgs_hash_password(vhd,
+						        formvals[FGS_PASSWORD],
+						        &u)) {
+					lwsl_err("Password hash failed\n");
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				if (lws_get_random(vhd->context, sid_rand,
+						   sizeof(sid_rand)) !=
+						   sizeof(sid_rand)) {
+					lwsl_err("Problem getting random for token\n");
+					return 1;
+				}
+				sha1_to_lwsgw_hash(sid_rand, &hash);
+
+				snprintf((char *)buffer, sizeof(buffer) - 1,
+					 "insert into users(username,"
+					 " creation_time, ip, email, verified,"
+					 " pwhash, pwsalt, token, last_forgot_validated)"
+					 " values ('%s', %lu, '%s', '%s', 0,"
+					 " '%s', '%s', '%s', 0);",
+					sql_purify(formvals[FGS_USERNAME], esc, sizeof(esc) - 1),
+					(unsigned long)lwsgs_now_secs(),
+					sql_purify(pss->ip, esc1, sizeof(esc1) - 1),
+					sql_purify(formvals[FGS_EMAIL], esc2, sizeof(esc2) - 1),
+					u.pwhash.id, u.pwsalt.id, hash.id);
+
+				n = FGS_REG_GOOD;
+				if (sqlite3_exec(vhd->pdb, (char *)buffer, NULL,
+						 NULL, NULL) != SQLITE_OK) {
+					lwsl_err("Unable to insert user: %s\n",
+						 sqlite3_errmsg(vhd->pdb));
+
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				snprintf(s, sizeof(s),
+					"From: Noreply <%s>\n"
+					"To: %s <%s>\n"
+					  "Subject: Registration verification\n"
+					  "\n"
+					  "Hello, %s\n\n"
+					  "We received a registration from IP %s using this email,\n"
+					  "to confirm it is legitimate, please click the link below.\n\n"
+					  "%s/confirm?token=%s\n\n"
+					  "If this request is unexpected, please ignore it and\n"
+					  "no further action will be taken.\n\n"
+					"If you have any questions or concerns about this\n"
+					"automated email, you can contact a real person at\n"
+					"%s.\n"
+					"\n.\n",
+					sql_purify(vhd->email.email_from, esc, sizeof(esc) - 1),
+					sql_purify(formvals[FGS_USERNAME], esc1, sizeof(esc1) - 1),
+					sql_purify(formvals[FGS_EMAIL], esc2, sizeof(esc2) - 1),
+					sql_purify(formvals[FGS_USERNAME], esc3, sizeof(esc3) - 1),
+					sql_purify(pss->ip, esc4, sizeof(esc4) - 1),
+					vhd->email_confirm_url, hash.id,
+					vhd->email_contact_person);
+
+				snprintf((char *)buffer, sizeof(buffer) - 1,
+					 "insert into email(username, content)"
+					 " values ('%s', '%s');",
+					sql_purify(formvals[FGS_USERNAME], esc, sizeof(esc) - 1), s);
+
+				if (sqlite3_exec(vhd->pdb, (char *)buffer, NULL,
+						 NULL, NULL) != SQLITE_OK) {
+					lwsl_err("Unable to insert email: %s\n",
+						 sqlite3_errmsg(vhd->pdb));
+
+					n = FGS_REG_BAD;
+					goto reg_done;
+				}
+
+				/* get the email monitor to take a look */
+				lws_email_check(&vhd->email);
+
+reg_done:
+				strncpy(pss->onward, formvals[n],
+					sizeof(pss->onward) - 1);
+				pss->onward[sizeof(pss->onward) - 1] = '\0';
+
+				pss->login_expires = 0;
+				pss->logging_out = 1;
+				break;
+			}
+
+			/* we have the username and password... check if admin */
+			if (lwsgw_check_admin(vhd, formvals[FGS_USERNAME],
+					      formvals[FGS_PASSWORD])) {
+				if (formvals[FGS_ADMIN])
+					cp = formvals[FGS_ADMIN];
+				else
+					if (formvals[FGS_GOOD])
+						cp = formvals[FGS_GOOD];
+					else {
+						lwsl_info("No admin or good target url in form\n");
+						return -1;
+					}
+				lwsl_debug("admin\n");
+				goto pass;
+			}
+
+			/* check users in database */
+
+			if (!lwsgs_check_credentials(vhd, formvals[FGS_USERNAME],
+						     formvals[FGS_PASSWORD])) {
+				lwsl_info("pw hash check met\n");
+				cp = formvals[FGS_GOOD];
+				goto pass;
+			} else
+				lwsl_notice("user/password no good %s\n",
+						formvals[FGS_USERNAME]);
+
+			if (!formvals[FGS_BAD]) {
+				lwsl_info("No admin or good target url in form\n");
+				return -1;
+			}
+
+			strncpy(pss->onward, formvals[FGS_BAD],
+				sizeof(pss->onward) - 1);
+			pss->onward[sizeof(pss->onward) - 1] = '\0';
+			lwsl_debug("failed\n");
+
+			break;
+		}
+
+		if (!strcmp((char *)pss->onward, "/logout")) {
+
+			lwsl_notice("/logout\n");
+
+			if (lwsgs_get_sid_from_wsi(wsi, &pss->login_session)) {
+				lwsl_notice("not logged in...\n");
+				return 1;
+			}
+
+			lwsgw_update_session(vhd, &pss->login_session, "");
+
+			if (!formvals[FGS_GOOD]) {
+				lwsl_info("No admin or good target url in form\n");
+				return -1;
+			}
+
+			strncpy(pss->onward, formvals[FGS_GOOD], sizeof(pss->onward) - 1);
+			pss->onward[sizeof(pss->onward) - 1] = '\0';
+
+			pss->login_expires = 0;
+			pss->logging_out = 1;
+
+			break;
+		}
+
+		break;
+
+pass:
+		strncpy(pss->onward, cp, sizeof(pss->onward) - 1);
+		pss->onward[sizeof(pss->onward) - 1] = '\0';
+
+		if (lwsgs_get_sid_from_wsi(wsi, &sid))
+			sid.id[0] = '\0';
+
+		pss->login_expires = lwsgs_now_secs() +
+				     vhd->timeout_absolute_secs;
+
+		if (!sid.id[0]) {
+			/* we need to create a new, authorized session */
+
+			if (lwsgs_new_session_id(vhd, &pss->login_session,
+						 formvals[FGS_USERNAME],
+						 pss->login_expires))
+				goto try_to_reuse;
+
+			lwsl_notice("Creating new session: %s\n",
+				    pss->login_session.id);
+		} else {
+			/*
+			 * we can just update the existing session to be
+			 * authorized
+			 */
+			lwsl_notice("Authorizing current session %s", sid.id);
+			lwsgw_update_session(vhd, &sid, formvals[FGS_USERNAME]);
+			pss->login_session = sid;
+		}
+		break;
+
+	case LWS_CALLBACK_HTTP_WRITEABLE:
+		break;
+
+	case LWS_CALLBACK_HTTP_BODY_COMPLETION:
+		lwsl_notice("LWS_CALLBACK_HTTP_BODY_COMPLETION: onward=%s\n", pss->onward);
+
+		lwsgw_expire_old_sessions(vhd);
+
+redirect_with_cookie:
+		p = buffer + LWS_PRE;
+		start = p;
+		end = p + sizeof(buffer) - LWS_PRE;
+
+		if (lws_add_http_header_status(wsi, HTTP_STATUS_SEE_OTHER, &p, end))
+			return 1;
+
+		if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_LOCATION,
+				(unsigned char *)pss->onward,
+				strlen(pss->onward), &p, end))
+			return 1;
+
+		if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_CONTENT_TYPE,
+				(unsigned char *)"text/html", 9, &p, end))
+			return 1;
+		if (lws_add_http_header_content_length(wsi, 0, &p, end))
+			return 1;
+
+		lwsl_notice("x\n");
+
+		if (pss->delete_session.id[0]) {
+			lwsgw_cookie_from_session(&pss->delete_session, 0, &pc,
+						  cookie + sizeof(cookie) - 1);
+
+			lwsl_notice("deleting cookie '%s'\n", cookie);
+
+			if (lws_add_http_header_by_name(wsi,
+					(unsigned char *)"set-cookie:",
+					(unsigned char *)cookie, pc - cookie,
+					&p, end))
+				return 1;
+		}
+
+		if (!pss->login_session.id[0]) {
+			pss->login_expires = lwsgs_now_secs() +
+					     vhd->timeout_anon_absolute_secs;
+			if (lwsgs_new_session_id(vhd, &pss->login_session, "",
+						 pss->login_expires))
+				return 1;
+		} else
+			pss->login_expires = lwsgs_now_secs() +
+					     vhd->timeout_absolute_secs;
+
+		if (pss->login_session.id[0] || pss->logging_out) {
+			/*
+			 * we succeeded to login, we must issue a login
+			 * cookie with the prepared data
+			 */
+			pc = cookie;
+
+			lwsgw_cookie_from_session(&pss->login_session,
+						  pss->login_expires, &pc,
+						  cookie + sizeof(cookie) - 1);
+
+			lwsl_notice("setting cookie '%s'\n", cookie);
+
+			pss->logging_out = 0;
+
+			if (lws_add_http_header_by_name(wsi,
+					(unsigned char *)"set-cookie:",
+					(unsigned char *)cookie, pc - cookie,
+					&p, end))
+				return 1;
+		}
+
+		if (lws_finalize_http_header(wsi, &p, end))
+			return 1;
+
+		n = lws_write(wsi, start, p - start, LWS_WRITE_HTTP_HEADERS);
+		if (n < 0)
+			return 1;
+		goto try_to_reuse;
+
+	case LWS_CALLBACK_ADD_HEADERS:
+		lwsgw_expire_old_sessions(vhd);
+
+		args = (struct lws_process_html_args *)in;
+
+		if (pss->delete_session.id[0]) {
+			pc = cookie;
+			lwsgw_cookie_from_session(&pss->delete_session, 0, &pc,
+						  cookie + sizeof(cookie) - 1);
+
+			lwsl_notice("deleting cookie '%s'\n", cookie);
+
+			if (lws_add_http_header_by_name(wsi,
+					(unsigned char *)"set-cookie:",
+					(unsigned char *)cookie, pc - cookie,
+					(unsigned char **)&args->p,
+					(unsigned char *)args->p + args->max_len))
+				return 1;
+		}
+
+		if (!pss->login_session.id[0])
+			lwsgs_get_sid_from_wsi(wsi, &pss->login_session);
+
+		if (!pss->login_session.id[0] && !pss->logging_out) {
+
+			pss->login_expires = lwsgs_now_secs() +
+					     vhd->timeout_anon_absolute_secs;
+			if (lwsgs_new_session_id(vhd, &pss->login_session, "",
+						 pss->login_expires))
+				goto try_to_reuse;
+			pc = cookie;
+			lwsgw_cookie_from_session(&pss->login_session,
+						  pss->login_expires, &pc,
+						  cookie + sizeof(cookie) - 1);
+
+			lwsl_notice("LWS_CALLBACK_ADD_HEADERS: setting cookie '%s'\n", cookie);
+			if (lws_add_http_header_by_name(wsi,
+					(unsigned char *)"set-cookie:",
+					(unsigned char *)cookie, pc - cookie,
+					(unsigned char **)&args->p,
+					(unsigned char *)args->p + args->max_len))
+				return 1;
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+
+try_to_reuse:
+	if (lws_http_transaction_completed(wsi))
+		return -1;
+
+	return 0;
+}
+
+static const struct lws_protocols protocols[] = {
+	{
+		"protocol-generic-sessions",
+		callback_generic_sessions,
+		sizeof(struct per_session_data__generic_sessions),
+		1024,
+	},
+};
+
+LWS_EXTERN LWS_VISIBLE int
+init_protocol_generic_sessions(struct lws_context *context,
+			struct lws_plugin_capability *c)
+{
+	if (c->api_magic != LWS_PLUGIN_API_MAGIC) {
+		lwsl_err("Plugin API %d, library API %d", LWS_PLUGIN_API_MAGIC,
+			 c->api_magic);
+		return 1;
+	}
+
+	c->protocols = protocols;
+	c->count_protocols = ARRAY_SIZE(protocols);
+	c->extensions = NULL;
+	c->count_extensions = 0;
+
+	return 0;
+}
+
+LWS_EXTERN LWS_VISIBLE int
+destroy_protocol_generic_sessions(struct lws_context *context)
+{
+	return 0;
+}

--- a/plugins/sent-forgot-fail.html
+++ b/plugins/sent-forgot-fail.html
@@ -1,0 +1,5 @@
+<html>
+Sorry, something went wrong.
+
+Click <a href="../">here</a> to continue.
+</html>

--- a/plugins/sent-forgot-ok.html
+++ b/plugins/sent-forgot-ok.html
@@ -1,0 +1,4 @@
+An email has been sent to your registered address.
+
+Please follow the instructions to reset your password.
+

--- a/plugins/successful-login.html
+++ b/plugins/successful-login.html
@@ -1,0 +1,4 @@
+<html>
+This is an example destination that will appear after successful non-Admin login
+</html>
+

--- a/test-server/android/app/src/main/jni/NativeLibs.mk
+++ b/test-server/android/app/src/main/jni/NativeLibs.mk
@@ -78,7 +78,7 @@ ifeq ($(APP_PLATFORM),)
 APP_PLATFORM = android-21
 endif
 
-NDK_MAKE_TOOLCHAIN := $(NDK_ROOT)/build/tools/make-standalone-toolchain.sh
+NDK_MAKE_TOOLCHAIN := $(NDK_ROOT)/build/tools/make_standalone_toolchain.py
 
 #
 # The source packages we want/need
@@ -141,14 +141,14 @@ TARGET_MIPS64 := mips64
 # libraries compiled for android-21 and upwards are incompatible with devices below that version!
 # http://stackoverflow.com/questions/28740315/android-ndk-getting-java-lang-unsatisfiedlinkerror-dlopen-failed-cannot-loca
 #
-TARGET_X86_NDK_API := $(APP_PLATFORM)
-TARGET_X86_64_NDK_API := $(APP_PLATFORM)
-TARGET_ARM_NDK_API := $(APP_PLATFORM)
-TARGET_ARM_V7A_NDK_API := $(APP_PLATFORM)
-TARGET_ARM_V7A_HARD_NDK_API := $(APP_PLATFORM)
-TARGET_ARM64_V8A_NDK_API := $(APP_PLATFORM)
-TARGET_MIPS_NDK_API := $(APP_PLATFORM)
-TARGET_MIPS64_NDK_API := $(APP_PLATFORM)
+TARGET_X86_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_X86_64_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_ARM_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_ARM_V7A_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_ARM_V7A_HARD_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_ARM64_V8A_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_MIPS_NDK_API := $(subst android-,,$(APP_PLATFORM))
+TARGET_MIPS64_NDK_API := $(subst android-,,$(APP_PLATFORM))
 
 # The configure arguments to pass to the OpenSSL Configure script
 # (--prefix and --openssldir are added automaticaly).
@@ -317,71 +317,74 @@ TOOLCHAIN_ARM64_V8A := toolchains/arm64-v8a
 TOOLCHAIN_MIPS := toolchains/mips
 TOOLCHAIN_MIPS64 := toolchains/mips64
 
-# The arch names for the different toolchains
-TOOLCHAIN_X86_ARCH := x86
-TOOLCHAIN_X86_64_ARCH := x86_64
-TOOLCHAIN_ARM_ARCH := arm-linux-androideabi
-TOOLCHAIN_ARM_V7A_ARCH := arm-linux-androideabi
-TOOLCHAIN_ARM_V7A_HARD_ARCH := arm-linux-androideabi
-TOOLCHAIN_ARM64_V8A_ARCH := aarch64-linux-android
-TOOLCHAIN_MIPS_ARCH := mipsel-linux-android
-TOOLCHAIN_MIPS64_ARCH := mips64el-linux-android
-
-# Other (global) toolchain settings
-TOOLCHAIN_GCC_VERSION := 4.9
+# Use APP_STL to determine what STL to use.
+#
+ifeq ($(APP_STL),stlport_static)
+TOOLCHAIN_STL := stlport
+else ifeq ($(APP_STL),stlport_shared)
+TOOLCHAIN_STL := stlport
+else ifeq ($(APP_STL),gnustl_static)
+TOOLCHAIN_STL := gnustl
+else ifeq ($(APP_STL),gnustl_shared)
+TOOLCHAIN_STL := gnustl
+else ifeq ($(APP_STL),c++_static)
+TOOLCHAIN_STL := libc++
+else ifeq ($(APP_STL),c++_shared)
+TOOLCHAIN_STL := libc++
+endif
 
 # The settings to use for the individual toolchains:
 # x86
-TOOLCHAIN_X86_PLATFORM := $(TARGET_X86_NDK_API)
+TOOLCHAIN_X86_API := $(TARGET_X86_NDK_API)
 TOOLCHAIN_X86_PREFIX := i686-linux-android
 TOOLCHAIN_X86_FLAGS := -march=i686 -msse3 -mstackrealign -mfpmath=sse
 TOOLCHAIN_X86_LINK :=
 TOOLCHAIN_X86_PLATFORM_HEADERS := $(shell pwd)/$(TOOLCHAIN_X86)/sysroot/usr/include
 TOOLCHAIN_X86_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_X86)/sysroot/usr/lib
 # x86_64
-TOOLCHAIN_X86_64_PLATFORM := $(TARGET_X86_64_NDK_API)
+TOOLCHAIN_X86_64_API := $(TARGET_X86_64_NDK_API)
 TOOLCHAIN_X86_64_PREFIX := x86_64-linux-android
 TOOLCHAIN_X86_64_FLAGS :=
 TOOLCHAIN_X86_64_LINK :=
 TOOLCHAIN_X86_64_PLATFORM_HEADERS := $(shell pwd)/$(TOOLCHAIN_X86_64)/sysroot/usr/include
 TOOLCHAIN_X86_64_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_X86_64)/sysroot/usr/lib
 # arm
-TOOLCHAIN_ARM_PLATFORM := $(TARGET_ARM_NDK_API)
+TOOLCHAIN_ARM_API := $(TARGET_ARM_NDK_API)
 TOOLCHAIN_ARM_PREFIX := arm-linux-androideabi
 TOOLCHAIN_ARM_FLAGS := -mthumb
 TOOLCHAIN_ARM_LINK :=
 TOOLCHAIN_ARM_PLATFORM_HEADERS := $(shell pwd)/$(TOOLCHAIN_ARM)/sysroot/usr/include
 TOOLCHAIN_ARM_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_ARM)/sysroot/usr/lib
 # arm-v7a
-TOOLCHAIN_ARM_V7A_PLATFORM := $(TARGET_ARM_V7A_NDK_API)
+TOOLCHAIN_ARM_V7A_API := $(TARGET_ARM_V7A_NDK_API)
 TOOLCHAIN_ARM_V7A_PREFIX := arm-linux-androideabi
 TOOLCHAIN_ARM_V7A_FLAGS := -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
 TOOLCHAIN_ARM_V7A_LINK := -march=armv7-a -Wl,--fix-cortex-a8
 TOOLCHAIN_ARM_V7A_PLATFORM_HEADERS :=  $(shell pwd)/$(TOOLCHAIN_ARM_V7A)/sysroot/usr/include
 TOOLCHAIN_ARM_V7A_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_ARM_V7A)/sysroot/usr/lib
 # arm-v7a-hard
-TOOLCHAIN_ARM_V7A_HARD_PLATFORM := $(TARGET_ARM_V7A_HARD_NDK_API)
+TOOLCHAIN_ARM_V7A_HARD_API := $(TARGET_ARM_V7A_HARD_NDK_API)
 TOOLCHAIN_ARM_V7A_HARD_PREFIX := arm-linux-androideabi
 TOOLCHAIN_ARM_V7A_HARD_FLAGS := -march=armv7-a -mfpu=vfpv3-d16 -mhard-float -mfloat-abi=hard -D_NDK_MATH_NO_SOFTFP=1
 TOOLCHAIN_ARM_V7A_HARD_LINK := -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-warn-mismatch -lm_hard
 TOOLCHAIN_ARM_V7A_HARD_PLATFORM_HEADERS :=  $(shell pwd)/$(TOOLCHAIN_ARM_V7A_HARD)/sysroot/usr/include
 TOOLCHAIN_ARM_V7A_HARD_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_ARM_V7A_HARD)/sysroot/usr/lib
 # arm64-v8a
-TOOLCHAIN_ARM64_V8A_PLATFORM := $(TARGET_ARM64_V8A_NDK_API)
+TOOLCHAIN_ARM64_V8A_API := $(TARGET_ARM64_V8A_NDK_API)
 TOOLCHAIN_ARM64_V8A_PREFIX := aarch64-linux-android
 TOOLCHAIN_ARM64_V8A_FLAGS :=
 TOOLCHAIN_ARM64_V8A_LINK :=
 TOOLCHAIN_ARM64_V8A_PLATFORM_HEADERS := $(shell pwd)/$(TOOLCHAIN_ARM64_V8A)/sysroot/usr/include
 TOOLCHAIN_ARM64_V8A_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_ARM64_V8A)/sysroot/usr/lib
 # mips
-TOOLCHAIN_MIPS_PLATFORM := $(TARGET_MIPS_NDK_API)
+TOOLCHAIN_MIPS_API := $(TARGET_MIPS_NDK_API)
 TOOLCHAIN_MIPS_PREFIX := mipsel-linux-android
 TOOLCHAIN_MIPS_FLAGS :=
 TOOLCHAIN_MIPS_LINK :=
 TOOLCHAIN_MIPS_PLATFORM_HEADERS := $(shell pwd)/$(TOOLCHAIN_MIPS)/sysroot/usr/include
 TOOLCHAIN_MIPS_PLATFORM_LIBS := $(shell pwd)/$(TOOLCHAIN_MIPS)/sysroot/usr/lib
 # mips64
-TOOLCHAIN_MIPS64_PLATFORM := $(TARGET_MIPS64_NDK_API)
+TOOLCHAIN_MIPS64_API := $(TARGET_MIPS64_NDK_API)
 TOOLCHAIN_MIPS64_PREFIX := mips64el-linux-android
 TOOLCHAIN_MIPS64_FLAGS :=
 TOOLCHAIN_MIPS64_LINK :=
@@ -703,52 +706,116 @@ toolchain-mips: $(TOOLCHAIN_MIPS)
 toolchain-mips64: $(TOOLCHAIN_MIPS64)
 
 $(TOOLCHAIN_X86):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_X86_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_X86_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_X86)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_X86_API) \
+	  --arch x86 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_X86)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_X86_API) \
+	  --arch x86 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_X86)
+endif
 
 $(TOOLCHAIN_X86_64):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_X86_64_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_X86_64_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_X86_64)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_X86_64_API) \
+	  --arch x86_64 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_X86_64)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_X86_64_API) \
+	  --arch x86_64 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_X86_64)
+endif
 
 $(TOOLCHAIN_ARM):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_ARM_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_ARM_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_ARM)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_ARM_API) \
+	  --arch arm \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_ARM_API) \
+	  --arch arm \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM)
+endif
 
 $(TOOLCHAIN_ARM_V7A):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_ARM_V7A_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_ARM_V7A_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_ARM_V7A)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_ARM_V7A_API) \
+	  --arch arm \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM_V7A)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_ARM_V7A_API) \
+	  --arch arm \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM_V7A)
+endif
 
 $(TOOLCHAIN_ARM_V7A_HARD):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_ARM_V7A_HARD_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_ARM_V7A_HARD_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_ARM_V7A_HARD)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_ARM_V7A_HARD_API) \
+	  --arch arm \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM_V7A_HARD)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_ARM_V7A_HARD_API) \
+	  --arch arm \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM_V7A_HARD)
+endif
 
 $(TOOLCHAIN_ARM64_V8A):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_ARM64_V8A_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_ARM64_V8A_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_ARM64_V8A)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_ARM64_V8A_API) \
+	  --arch arm64 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM64_V8A)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_ARM64_V8A_API) \
+	  --arch arm64 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_ARM64_V8A)
+endif
 
 $(TOOLCHAIN_MIPS):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_MIPS_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_MIPS_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_MIPS)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_MIPS_API) \
+	  --arch mips \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_MIPS)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_MIPS_API) \
+	  --arch mips \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_MIPS)
+endif
 
 $(TOOLCHAIN_MIPS64):
+ifneq ($(TOOLCHAIN_STL),)
 	$(NDK_MAKE_TOOLCHAIN) \
-	  --platform=$(TOOLCHAIN_MIPS64_PLATFORM) \
-	  --toolchain=$(TOOLCHAIN_MIPS64_ARCH)-$(TOOLCHAIN_GCC_VERSION) \
-	  --install-dir=$(shell pwd)/$(TOOLCHAIN_MIPS64)
+	  --stl $(TOOLCHAIN_STL) \
+	  --api $(TOOLCHAIN_MIPS64_API) \
+	  --arch mips64 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_MIPS64)
+else
+	$(NDK_MAKE_TOOLCHAIN) \
+	  --api $(TOOLCHAIN_MIPS64_API) \
+	  --arch mips64 \
+	  --install-dir $(shell pwd)/$(TOOLCHAIN_MIPS64)
+endif
 
 #
 # Rules to build zlib

--- a/test-server/test-server-v2.0.c
+++ b/test-server/test-server-v2.0.c
@@ -82,6 +82,9 @@ static const struct lws_http_mount mount_post = {
 	NULL,	/* default filename if none given */
 	NULL,
 	NULL,
+	NULL,
+	NULL,
+	0,
 	0,
 	0,
 	0,
@@ -104,6 +107,9 @@ static const struct lws_http_mount mount = {
 	"test.html",	/* default filename if none given */
 	NULL,
 	NULL,
+	NULL,
+	NULL,
+	0,
 	0,
 	0,
 	0,


### PR DESCRIPTION
The latest Android SDK updates deprecate the shell script used to create a standalone toolchain. This patch updates the Makefile for the Android test-client to use the new ~~Perl~~ Python script to create the standalone toolchains.