### PR TITLE
Remove unused context from lws_context_per_thread

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -650,7 +650,6 @@ lws_create_context(struct lws_context_creation_info *info)
 			return NULL;
 		}
 
-		context->pt[n].context = context;
 		context->pt[n].tid = n;
 		context->pt[n].http_header_data = lws_malloc(context->max_http_header_data *
 						       context->max_http_header_pool);

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -660,7 +660,6 @@ struct lws_context_per_thread {
 	struct lws *rx_draining_ext_list;
 	struct lws *tx_draining_ext_list;
 	struct lws *timeout_list;
-	struct lws_context *context;
 #ifdef LWS_WITH_CGI
 	struct lws_cgi *cgi_list;
 #endif


### PR DESCRIPTION
The variable is never read. So it's safe to remove it.