### PR TITLE
Add error handling for SSL_new() of clients

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -155,8 +155,10 @@ lws_client_socket_service(struct lws_context *context, struct lws *wsi,
 #ifdef LWS_OPENSSL_SUPPORT
 		/* we can retry this... just cook the SSL BIO the first time */
 
-		if (wsi->use_ssl && !wsi->ssl)
-			lws_ssl_client_bio_create(wsi);
+		if (wsi->use_ssl && !wsi->ssl) {
+			if (lws_ssl_client_bio_create(wsi))
+				return -1;
+		}
 
 		if (wsi->use_ssl) {
 			n = lws_ssl_client_connect1(wsi);

--- a/lib/ssl-client.c
+++ b/lib/ssl-client.c
@@ -45,6 +45,12 @@ lws_ssl_client_bio_create(struct lws *wsi)
 	(void)param;
 
 	wsi->ssl = SSL_new(wsi->vhost->ssl_client_ctx);
+	if (!wsi->ssl) {
+		lwsl_err("SSL_new failed: %s\n",
+		         ERR_error_string(lws_ssl_get_error(wsi, 0), NULL));
+		lws_decode_ssl_error();
+		return -1;
+	}
 
 #if defined LWS_HAVE_X509_VERIFY_PARAM_set1_host
 	if (!(wsi->use_ssl & LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK)) {


### PR DESCRIPTION
Do not access wsi->ssl if SSL_new() failed and log the error.