### PR TITLE
Remove context from lws_context_per_thread for non-libuv builds

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -650,7 +650,9 @@ lws_create_context(struct lws_context_creation_info *info)
 			return NULL;
 		}
 
+#ifdef LWS_USE_LIBUV
 		context->pt[n].context = context;
+#endif
 		context->pt[n].tid = n;
 		context->pt[n].http_header_data = lws_malloc(context->max_http_header_data *
 						       context->max_http_header_pool);

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -660,7 +660,9 @@ struct lws_context_per_thread {
 	struct lws *rx_draining_ext_list;
 	struct lws *tx_draining_ext_list;
 	struct lws *timeout_list;
+#ifdef LWS_USE_LIBUV
 	struct lws_context *context;
+#endif
 #ifdef LWS_WITH_CGI
 	struct lws_cgi *cgi_list;
 #endif


### PR DESCRIPTION
The variable is never read when built without libuv.