### PR TITLE
Added option to build the static library with PIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.9)
 
 if(NOT DEFINED CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
@@ -87,6 +87,7 @@ option(LWS_IPV6 "Compile with support for ipv6" OFF)
 option(LWS_WITH_HTTP2 "Compile with support for http2" OFF)
 option(LWS_MBED3 "Platform is MBED3" OFF)
 option(LWS_SSL_SERVER_WITH_ECDH_CERT "Include SSL server use ECDH certificate" OFF)
+option(LWS_STATIC_PIC "Build the static version of the library with position-independent code" OFF)
 
 if (DEFINED YOTTA_WEBSOCKETS_VERSION_STRING)
 
@@ -543,6 +544,9 @@ source_group("Sources"          FILES ${SOURCES})
 set(LWS_LIBRARIES)
 
 if (LWS_WITH_STATIC)
+    if (LWS_STATIC_PIC)
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    endif()
 	add_library(websockets STATIC
 				${HDR_PRIVATE}
 				${HDR_PUBLIC}
@@ -1224,6 +1228,7 @@ message(" LWS_MBED3 = ${LWS_MBED3}")
 message(" LWS_SSL_SERVER_WITH_ECDH_CERT = ${LWS_SSL_SERVER_WITH_ECDH_CERT}")
 message(" LWS_MAX_SMP = ${LWS_MAX_SMP}")
 message(" LWS_HAVE_OPENSSL_ECDH_H = ${LWS_HAVE_OPENSSL_ECDH_H}")
+message(" LWS_STATIC_PIC = ${LWS_STATIC_PIC}")
 message("---------------------------------------------------------------------")
 
 # These will be available to parent projects including libwebsockets using add_subdirectory()


### PR DESCRIPTION
I needed PIC in the static library for building a shared object plugin.

Of course, this adds some dependencies on the version of the loader (and perhaps other tools in the chain). I'm sure that it should be "OFF" by default and only "ON" if the user knows his/her build environment.

I'd be happy to port this to other versions as well. My project is still on 1.7 for now.