### PR TITLE
Correct the library name of LIBHUBBUB_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -914,7 +914,7 @@ endif()
 
 
 if (LWS_WITH_HTTP_PROXY)
-	find_library(LIBHUBBUB_LIBRARIES NAMES libhubbub)
+	find_library(LIBHUBBUB_LIBRARIES NAMES hubbub)
 	list(APPEND LIB_LIST ${LIBHUBBUB_LIBRARIES} )
 endif()
 


### PR DESCRIPTION
It should be `hubbub` in `find_library` to make the function work.