### PR TITLE
Added flag to allow expired certificates.

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1983,7 +1983,8 @@ struct lws_http_mount {
 enum lws_client_connect_ssl_connection_flags {
 	LCCSCF_USE_SSL 				= (1 << 0),
 	LCCSCF_ALLOW_SELFSIGNED			= (1 << 1),
-	LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK	= (1 << 2)
+	LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK	= (1 << 2),
+	LCCSCF_ALLOW_EXPIRED			= (1 << 3)
 };
 
 /** struct lws_client_connect_info - parameters to connect with when using

--- a/lib/ssl-client.c
+++ b/lib/ssl-client.c
@@ -296,6 +296,10 @@ lws_ssl_client_connect2(struct lws *wsi)
 		     n == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN) &&
 		     wsi->use_ssl & LCCSCF_ALLOW_SELFSIGNED) {
 			lwsl_notice("accepting self-signed certificate\n");
+		} else if ((n == X509_V_ERR_CERT_NOT_YET_VALID ||
+		            n == X509_V_ERR_CERT_HAS_EXPIRED) &&
+		     wsi->use_ssl & LCCSCF_ALLOW_EXPIRED) {
+			lwsl_notice("accepting expired certificate\n");
 		} else {
 			lwsl_err("server's cert didn't look good, X509_V_ERR = %d: %s\n",
 				 n, ERR_error_string(n, sb));


### PR DESCRIPTION
I have a use case where I'm connecting to a device which on first boot creates a certificate and might have a wrong clock at that time, so the certificate might not yet / no longer be valid when checked with a "correct" clock.
So I need to accept expired certificates until the certificate has been replaced with a valid one.