### PR TITLE
server: portable option for `setsockopt`

### DIFF
--- a/lib/server.c
+++ b/lib/server.c
@@ -110,7 +110,7 @@ lws_context_init_server(struct lws_context_creation_info *info,
 	if (LWS_IPV6_ENABLED(vhost)) {
 		if (vhost->options & LWS_SERVER_OPTION_IPV6_V6ONLY_MODIFY) {
 			int value = (vhost->options & LWS_SERVER_OPTION_IPV6_V6ONLY_VALUE) ? 1 : 0;
-			if (setsockopt(sockfd, SOL_IPV6, IPV6_V6ONLY,
+			if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY,
 					(const void*)&value, sizeof(value)) < 0) {
 				compatible_close(sockfd);
 				return 1;


### PR DESCRIPTION
Hi, I am a FreeBSD user and got compile error about `SOL_IPV6` undefined.
```
└─[iblis@abeing]% uname -a
FreeBSD abeing 12.0-CURRENT FreeBSD 12.0-CURRENT #1 r307549: Tue Oct 18 16:30:16 CST 2016     root@abeing:/usr/obj/usr/src/sys/GENERIC  amd64
```
----

From linux ipv6(7) manual (section `Note`):

        SOL_IP, SOL_IPV6, SOL_ICMPV6 and other SOL_* socket options are
        nonportable variants of IPPROTO_*.  See also ip(7).

Ref: http://man7.org/linux/man-pages/man7/ipv6.7.html