### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,7 +1047,9 @@ if (NOT LWS_WITHOUT_TESTAPPS)
 
 	if (UNIX AND LWS_WITH_PLUGINS)
 		set(CMAKE_C_FLAGS "-fPIC ${CMAKE_C_FLAGS}")
-		target_link_libraries(websockets dl)
+		if(NOT(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD"))
+			target_link_libraries(websockets dl)
+		endif()
 	endif()
 
 	if (NOT LWS_WITHOUT_SERVER)


### PR DESCRIPTION
Fixing build failure of libwebsockets-test-fraggle  on FreeBSD when LWS_WITH_PLUGINS. 
Solution: FreeBSD has no libdl