### PR TITLE
ability to creating vhosts after libuv loop started

### DIFF
--- a/lib/libuv.c
+++ b/lib/libuv.c
@@ -143,7 +143,7 @@ lws_uv_timeout_cb(uv_timer_t *timer
 
 static const int sigs[] = { SIGINT, SIGTERM, SIGSEGV, SIGFPE };
 
-LWS_VISIBLE int
+int
 lws_uv_initvhost(struct lws_vhost* vh, struct lws* wsi)
 {
 	int n;

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -965,6 +965,8 @@ LWS_EXTERN void
 lws_libuv_run(const struct lws_context *context, int tsi);
 LWS_EXTERN void
 lws_libuv_destroyloop(struct lws_context *context, int tsi);
+LWS_EXTERN int
+lws_uv_initvhost(struct lws_vhost* vh, struct lws*);
 #define LWS_LIBUV_ENABLED(context) lws_check_opt(context->options, LWS_SERVER_OPTION_LIBUV)
 LWS_EXTERN void lws_feature_status_libuv(struct lws_context_creation_info *info);
 #else

--- a/lib/server-handshake.c
+++ b/lib/server-handshake.c
@@ -214,12 +214,9 @@ handshake_0405(struct lws_context *context, struct lws *wsi)
 	strcpy(p, (char *)pt->serv_buf);
 	p += accept_len;
 
-	if (lws_hdr_total_length(wsi, WSI_TOKEN_PROTOCOL)) {
+	if (wsi->protocol->name && wsi->protocol->name[0]) {
 		LWS_CPYAPP(p, "\x0d\x0aSec-WebSocket-Protocol: ");
-		n = lws_hdr_copy(wsi, p, 128, WSI_TOKEN_PROTOCOL);
-		if (n < 0)
-			goto bail;
-		p += n;
+		p += lws_snprintf(p, 128, "%s", wsi->protocol->name);
 	}
 
 #ifndef LWS_NO_EXTENSIONS


### PR DESCRIPTION
I added private function int lws_uv_initvhost(struct lws_vhost* vh, struct lws* wsi) to libuv.c that makes initialization of vhost (from lws_uv_initloow - while( vh ) {...}) when libuv loop already started only. It called for every vhost creation and for each created vhost in lws_uv_initloop. When libuv loop is not started does nothing. Check if initialization on vhost already done.
