### PR TITLE
V2.1 stable aconway adopt ssl

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -3514,6 +3514,7 @@ lws_remaining_packet_payload(struct lws *wsi);
 
 /**
  * lws_adopt_socket() - adopt foreign socket as if listen socket accepted it
+ * for the default vhost of context.
  * \param context: lws context
  * \param accept_fd: fd of already-accepted socket to adopt
  *
@@ -3526,7 +3527,22 @@ lws_remaining_packet_payload(struct lws *wsi);
 LWS_VISIBLE LWS_EXTERN struct lws *
 lws_adopt_socket(struct lws_context *context, lws_sockfd_type accept_fd);
 /**
+ * lws_adopt_socket_vhost() - adopt foreign socket as if listen socket accepted it
+ * for vhost
+ * \param vhost: lws vhost
+ * \param accept_fd: fd of already-accepted socket to adopt
+ *
+ * Either returns new wsi bound to accept_fd, or closes accept_fd and
+ * returns NULL, having cleaned up any new wsi pieces.
+ *
+ * LWS adopts the socket in http serving mode, it's ready to accept an upgrade
+ * to ws or just serve http.
+ */
+LWS_VISIBLE LWS_EXTERN struct lws *
+lws_adopt_socket_vhost(struct lws_vhost *vh, lws_sockfd_type accept_fd);
+/**
  * lws_adopt_socket_readbuf() - adopt foreign socket and first rx as if listen socket accepted it
+ * for the default vhost of context.
  * \param context:	lws context
  * \param accept_fd:	fd of already-accepted socket to adopt
  * \param readbuf:	NULL or pointer to data that must be drained before reading from
@@ -3549,7 +3565,33 @@ lws_adopt_socket(struct lws_context *context, lws_sockfd_type accept_fd);
  */
 LWS_VISIBLE LWS_EXTERN struct lws *
 lws_adopt_socket_readbuf(struct lws_context *context, lws_sockfd_type accept_fd,
-		const char *readbuf, size_t len);
+                         const char *readbuf, size_t len);
+/**
+ * lws_adopt_socket_vhost_readbuf() - adopt foreign socket and first rx as if listen socket
+ * accepted it for vhost.
+ * \param vhost:	lws vhost
+ * \param accept_fd:	fd of already-accepted socket to adopt
+ * \param readbuf:	NULL or pointer to data that must be drained before reading from
+ *			accept_fd
+ * \param len:		The length of the data held at \param readbuf
+ *
+ * Either returns new wsi bound to accept_fd, or closes accept_fd and
+ * returns NULL, having cleaned up any new wsi pieces.
+ *
+ * LWS adopts the socket in http serving mode, it's ready to accept an upgrade
+ * to ws or just serve http.
+ *
+ * If your external code did not already read from the socket, you can use
+ * lws_adopt_socket() instead.
+ *
+ * This api is guaranteed to use the data at \param readbuf first, before reading from
+ * the socket.
+ *
+ * readbuf is limited to the size of the ah rx buf, currently 2048 bytes.
+ */
+LWS_VISIBLE LWS_EXTERN struct lws *
+lws_adopt_socket_vhost_readbuf(struct lws_vhost *vhost, lws_sockfd_type accept_fd,
+                               const char *readbuf, size_t len);
 ///@}
 
 /** \defgroup net Network related helper APIs

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -253,6 +253,7 @@ typedef ssl_context SSL;
 
 
 #define CONTEXT_PORT_NO_LISTEN -1
+#define CONTEXT_PORT_NO_LISTEN_SERVER -2
 
 /** \defgroup log Logging
  *
@@ -1560,10 +1561,10 @@ enum lws_context_options {
  */
 struct lws_context_creation_info {
 	int port;
-	/**< VHOST: Port to listen on... you can use CONTEXT_PORT_NO_LISTEN to
-	 * suppress listening on any port, that's what you want if you are
-	 * not running a websocket server at all but just using it as a
-	 * client */
+	/**< VHOST: Port to listen on. Use CONTEXT_PORT_NO_LISTEN to suppress
+	 * listening for a client. Use CONTEXT_PORT_NO_LISTEN_SERVER if you are
+	 * writing a server but you are using \ref sock-adopt instead of the
+	 * built-in listener */
 	const char *iface;
 	/**< VHOST: NULL to bind the listen socket to all interfaces, or the
 	 * interface name, eg, "eth2"

--- a/lib/server.c
+++ b/lib/server.c
@@ -44,7 +44,7 @@ lws_context_init_server(struct lws_context_creation_info *info,
 
 	/* set up our external listening socket we serve on */
 
-	if (info->port == CONTEXT_PORT_NO_LISTEN)
+	if (info->port == CONTEXT_PORT_NO_LISTEN || info->port == CONTEXT_PORT_NO_LISTEN_SERVER)
 		return 0;
 
 	vh = vhost->context->vhost_list;

--- a/lib/server.c
+++ b/lib/server.c
@@ -1524,7 +1524,7 @@ lws_http_transaction_completed(struct lws *wsi)
 	return 0;
 }
 
-struct lws *
+LWS_VISIBLE struct lws *
 lws_adopt_socket_vhost(struct lws_vhost *vh, lws_sockfd_type accept_fd)
 {
 	struct lws_context *context = vh->context;
@@ -1597,11 +1597,10 @@ lws_adopt_socket(struct lws_context *context, lws_sockfd_type accept_fd)
 	return lws_adopt_socket_vhost(context->vhost_list, accept_fd);
 }
 
-LWS_VISIBLE LWS_EXTERN struct lws *
-lws_adopt_socket_readbuf(struct lws_context *context, lws_sockfd_type accept_fd,
-			 const char *readbuf, size_t len)
+/* Common read-buffer adoption for lws_adopt_*_readbuf */
+static struct lws*
+adopt_socket_readbuf(struct lws *wsi, const char *readbuf, size_t len)
 {
-	struct lws *wsi = lws_adopt_socket(context, accept_fd);
 	struct lws_context_per_thread *pt;
 	struct allocated_headers *ah;
 	struct lws_pollfd *pfd;
@@ -1609,7 +1608,7 @@ lws_adopt_socket_readbuf(struct lws_context *context, lws_sockfd_type accept_fd,
 	if (!wsi)
 		return NULL;
 
-	if (!readbuf)
+	if (!readbuf || len == 0)
 		return wsi;
 
 	if (len > sizeof(ah->rx)) {
@@ -1634,7 +1633,7 @@ lws_adopt_socket_readbuf(struct lws_context *context, lws_sockfd_type accept_fd,
 		ah->rxlen = len;
 
 		lwsl_notice("%s: calling service on readbuf ah\n", __func__);
-		pt = &context->pt[(int)wsi->tsi];
+		pt = &wsi->context->pt[(int)wsi->tsi];
 
 		/* unlike a normal connect, we have the headers already
 		 * (or the first part of them anyway).
@@ -1644,7 +1643,7 @@ lws_adopt_socket_readbuf(struct lws_context *context, lws_sockfd_type accept_fd,
 		pfd = &pt->fds[wsi->position_in_fds_table];
 		pfd->revents |= LWS_POLLIN;
 		lwsl_err("%s: calling service\n", __func__);
-		if (lws_service_fd_tsi(context, pfd, wsi->tsi))
+		if (lws_service_fd_tsi(wsi->context, pfd, wsi->tsi))
 			/* service closed us */
 			return NULL;
 
@@ -1672,6 +1671,20 @@ bail:
 	lws_close_free_wsi(wsi, LWS_CLOSE_STATUS_NOSTATUS);
 
 	return NULL;
+}
+
+LWS_VISIBLE struct lws *
+lws_adopt_socket_readbuf(struct lws_context *context, lws_sockfd_type accept_fd,
+			 const char *readbuf, size_t len)
+{
+        return adopt_socket_readbuf(lws_adopt_socket(context, accept_fd), readbuf, len);
+}
+
+LWS_VISIBLE struct lws *
+lws_adopt_socket_vhost_readbuf(struct lws_vhost *vhost, lws_sockfd_type accept_fd,
+			 const char *readbuf, size_t len)
+{
+        return adopt_socket_readbuf(lws_adopt_socket_vhost(vhost, accept_fd), readbuf, len);
 }
 
 LWS_VISIBLE int

--- a/lib/ssl-server.c
+++ b/lib/ssl-server.c
@@ -211,7 +211,6 @@ lws_context_init_server_ssl(struct lws_context_creation_info *info,
 		vhost->use_ssl = 0;
 		return 0;
 	}
-
 	if (info->port != CONTEXT_PORT_NO_LISTEN) {
 
 		vhost->use_ssl = info->ssl_cert_filepath != NULL;

--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -70,6 +70,46 @@ int lws_ssl_get_error(struct lws *wsi, int n)
 #endif
 }
 
+/* Copies a string describing the code returned by lws_ssl_get_error(),
+ * which may also contain system error information in the case of SSL_ERROR_SYSCALL,
+ * into buf up to len.
+ * Returns a pointer to buf.
+ *
+ * Note: the lws_ssl_get_error() code is *not* an error code that can be passed
+ * to ERR_error_string(),
+ *
+ * ret is the return value originally passed to lws_ssl_get_error(), needed to disambiguate
+ * SYS_ERROR_SYSCALL.
+ *
+ * See man page for SSL_get_error().
+ *
+ * Not thread safe, uses strerror()
+ */
+char* lws_ssl_get_error_string(int status, int ret, char *buf, size_t len) {
+	switch (status) {
+	case SSL_ERROR_NONE: return strncpy(buf, "SSL_ERROR_NONE", len);
+	case SSL_ERROR_ZERO_RETURN: return strncpy(buf, "SSL_ERROR_ZERO_RETURN", len);
+	case SSL_ERROR_WANT_READ: return strncpy(buf, "SSL_ERROR_WANT_READ", len);
+	case SSL_ERROR_WANT_WRITE: return strncpy(buf, "SSL_ERROR_WANT_WRITE", len);
+	case SSL_ERROR_WANT_CONNECT: return strncpy(buf, "SSL_ERROR_WANT_CONNECT", len);
+	case SSL_ERROR_WANT_ACCEPT: return strncpy(buf, "SSL_ERROR_WANT_ACCEPT", len);
+	case SSL_ERROR_WANT_X509_LOOKUP: return strncpy(buf, "SSL_ERROR_WANT_X509_LOOKUP", len);
+	case SSL_ERROR_SYSCALL:
+		switch (ret) {
+                case 0:
+                        snprintf(buf, len, "SSL_ERROR_SYSCALL: EOF");
+                        return buf;
+                case -1:
+                        snprintf(buf, len, "SSL_ERROR_SYSCALL: %s", strerror(errno));
+                        return buf;
+                default:
+                        return strncpy(buf, "SSL_ERROR_SYSCALL", len);
+	}
+	case SSL_ERROR_SSL: return "SSL_ERROR_SSL";
+	default: return "SSL_ERROR_UNKNOWN";
+	}
+}
+
 void
 lws_ssl_elaborate_error(void)
 {
@@ -615,8 +655,6 @@ lws_server_socket_service_ssl(struct lws *wsi, lws_sockfd_type accept_fd)
 			goto accepted;
 
 		m = lws_ssl_get_error(wsi, n);
-		lwsl_debug("SSL_accept failed %d / %s\n",
-			   m, ERR_error_string(m, NULL));
 go_again:
 		if (m == SSL_ERROR_WANT_READ) {
 			if (lws_change_pollfd(wsi, 0, LWS_POLLIN)) {
@@ -635,9 +673,9 @@ go_again:
 
 			break;
 		}
-		lwsl_err("SSL_accept failed skt %u: %s\n",
-			   wsi->sock, ERR_error_string(m, NULL));
-
+                char buf[256];
+                lwsl_err("SSL_accept failed socket %u: %s\n", wsi->sock,
+                         lws_ssl_get_error_string(m, n, buf, sizeof(buf)));
 		lws_ssl_elaborate_error();
 		goto fail;
 


### PR DESCRIPTION
These 3 commits enable SSL for a server that uses external polling and socket adoption. All minor, no new functionality, just exposing features that were already there but not accessible via public API. 

Testing: test-server, manual test via browser with/without SSL, test-client, autobhan.sh script. All reported OK.
