### PR TITLE
SSL expose as public API

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -1235,6 +1235,14 @@ lws_is_ssl(struct lws *wsi)
 #endif
 }
 
+#ifdef LWS_OPENSSL_SUPPORT
+LWS_VISIBLE SSL*
+lws_get_ssl(struct lws *wsi)
+{
+	return wsi->ssl;
+}
+#endif
+
 LWS_VISIBLE int
 lws_partial_buffered(struct lws *wsi)
 {

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -3947,6 +3947,17 @@ lws_is_ssl(struct lws *wsi);
  */
 LWS_VISIBLE LWS_EXTERN int
 lws_is_cgi(struct lws *wsi);
+
+#ifdef LWS_OPENSSL_SUPPORT
+/**
+ * lws_get_ssl() - Return wsi's SSL context structure
+ * \param wsi:	websocket connection
+ *
+ * Returns pointer to the SSL library's context structure
+ */
+LWS_VISIBLE LWS_EXTERN SSL*
+lws_get_ssl(struct lws *wsi);
+#endif
 ///@}
 
 

--- a/lib/ssl-server.c
+++ b/lib/ssl-server.c
@@ -37,8 +37,7 @@ OpenSSL_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
 {
 	SSL *ssl;
 	int n;
-	struct lws_vhost *vh;
-	struct lws wsi;
+	struct lws *wsi;
 
 	ssl = X509_STORE_CTX_get_ex_data(x509_ctx,
 		SSL_get_ex_data_X509_STORE_CTX_idx());
@@ -47,17 +46,9 @@ OpenSSL_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
 	 * !!! nasty openssl requires the index to come as a library-scope
 	 * static
 	 */
-	vh = SSL_get_ex_data(ssl, openssl_websocket_private_data_index);
+	wsi = SSL_get_ex_data(ssl, openssl_websocket_private_data_index);
 
-	/*
-	 * give him a fake wsi with context set, so he can use lws_get_context()
-	 * in the callback
-	 */
-	memset(&wsi, 0, sizeof(wsi));
-	wsi.vhost = vh;
-	wsi.context = vh->context;
-
-	n = vh->protocols[0].callback(&wsi,
+	n = wsi->vhost->protocols[0].callback(wsi,
 			LWS_CALLBACK_OPENSSL_PERFORM_CLIENT_CERT_VERIFICATION,
 					   x509_ctx, ssl, preverify_ok);
 

--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -523,7 +523,7 @@ lws_server_socket_service_ssl(struct lws *wsi, lws_sockfd_type accept_fd)
 		}
 
 		SSL_set_ex_data(wsi->ssl,
-			openssl_websocket_private_data_index, wsi->vhost);
+			openssl_websocket_private_data_index, wsi);
 
 		SSL_set_fd(wsi->ssl, accept_fd);
 #endif


### PR DESCRIPTION
Some programs may want to use SSL-related capabilities that libwebsockets doesn't implement yet, or that it may never implement or expose. Rather than implement all possible SSL features into lws, this might be the easier route by just exposing it to applications and let them deal with the implementation specifics themselves.