### PR TITLE
wsi remove unused 'upgraded' boolean field

### DIFF
--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1479,7 +1479,6 @@ struct lws {
 #endif
 #ifdef LWS_OPENSSL_SUPPORT
 	unsigned int use_ssl:3;
-	unsigned int upgraded:1;
 #endif
 #ifdef _WIN32
 	unsigned int sock_send_blocking:1;


### PR DESCRIPTION
While grepping something I ran into this field that seems unused. Please double check, but I don't see this used anywhere. Perhaps it was meant to be used / checked somewhere and removing it is a fix in the wrong direction?