### PR TITLE
Make GCC check format strings

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -816,7 +816,7 @@ check_extensions:
 				      wsi->act_ext_user[wsi->count_act_ext],
 				      NULL, 0)) {
 				lwsl_err("%s: ext %s rejects server options %s",
-					 ext->name, a);
+					 __func__, ext->name, a);
 				cce = "HS: EXT: Rejects server options";
 				goto bail2;
 			}

--- a/lib/context.c
+++ b/lib/context.c
@@ -793,8 +793,8 @@ lws_create_context(struct lws_context_creation_info *info)
 
 	lws_context_init_extensions(info, context);
 
-	lwsl_notice(" mem: per-conn:        %5u bytes + protocol rx buf\n",
-		    sizeof(struct lws));
+	lwsl_notice(" mem: per-conn:        %5lu bytes + protocol rx buf\n",
+		    (unsigned long)sizeof(struct lws));
 
 	strcpy(context->canonical_hostname, "unknown");
 	lws_server_get_canonical_hostname(context, info);

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -186,10 +186,12 @@ struct sockaddr_in;
 
 #define LWS_VISIBLE __attribute__((visibility("default")))
 #define LWS_WARN_DEPRECATED __attribute__ ((deprecated))
+#define LWS_FORMAT(string_index) __attribute__ ((format(printf, string_index, string_index+1)))
 #else
 #define LWS_VISIBLE
 #define LWS_WARN_UNUSED_RESULT
 #define LWS_WARN_DEPRECATED
+#define LWS_FORMAT
 #endif
 
 #if defined(__ANDROID__)
@@ -285,7 +287,7 @@ enum lws_log_levels {
 	LLL_COUNT = 11 /* set to count of valid flags */
 };
 
-LWS_VISIBLE LWS_EXTERN void _lws_log(int filter, const char *format, ...);
+LWS_VISIBLE LWS_EXTERN void _lws_log(int filter, const char *format, ...) LWS_FORMAT(2);
 LWS_VISIBLE LWS_EXTERN void _lws_logv(int filter, const char *format, va_list vl);
 /**
  * lwsl_timestamp: generate logging timestamp string
@@ -481,7 +483,7 @@ void esp8266_tcp_stream_accept(lws_sockfd_type fd, struct lws *wsi);
 #include <osapi.h>
 #include "ets_sys.h"
 
-int ets_snprintf(char *str, size_t size, const char *format, ...);
+int ets_snprintf(char *str, size_t size, const char *format, ...) LWS_FORMAT(3);
 #define snprintf  ets_snprintf
 
 typedef os_timer_t uv_timer_t;
@@ -3787,7 +3789,7 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
  * reach the limit the reported length doesn't exceed the limit.
  */
 LWS_VISIBLE LWS_EXTERN int
-lws_snprintf(char *str, size_t size, const char *format, ...);
+lws_snprintf(char *str, size_t size, const char *format, ...) LWS_FORMAT(3);
 
 /**
  * lws_get_random(): fill a buffer with platform random data

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -3803,7 +3803,7 @@ lws_snprintf(char *str, size_t size, const char *format, ...);
 LWS_VISIBLE LWS_EXTERN int
 lws_get_random(struct lws_context *context, void *buf, int len);
 /**
- * lws_daemonize(): fill a buffer with platform random data
+ * lws_daemonize(): make current process run in the background
  *
  * \param _lock_path: the filepath to write the lock file
  *

--- a/lib/lws-plat-unix.c
+++ b/lib/lws-plat-unix.c
@@ -690,8 +690,8 @@ lws_plat_init(struct lws_context *context,
 		return 1;
 	}
 
-	lwsl_notice(" mem: platform fd map: %5u bytes\n",
-		    sizeof(struct lws *) * context->max_fds);
+	lwsl_notice(" mem: platform fd map: %5lu bytes\n",
+		    (unsigned long)(sizeof(struct lws *) * context->max_fds));
 	fd = open(SYSTEM_RANDOM_FILEPATH, O_RDONLY);
 
 	context->fd_random = fd;

--- a/lib/output.c
+++ b/lib/output.c
@@ -112,13 +112,13 @@ int lws_issue_raw(struct lws *wsi, unsigned char *buf, size_t len)
 		strncpy(dump, (char *)buf, sizeof(dump) - 1);
 		dump[sizeof(dump) - 1] = '\0';
 #if defined(LWS_WITH_ESP8266)
-		lwsl_err("****** %p: Sending new %d (%s), pending truncated ...\n",
-			 wsi, len, dump);
+		lwsl_err("****** %p: Sending new %lu (%s), pending truncated ...\n",
+			 wsi, (unsigned long)len, dump);
 #else
-		lwsl_err("****** %p: Sending new %d (%s), pending truncated ...\n"
+		lwsl_err("****** %p: Sending new %lu (%s), pending truncated ...\n"
 			 "       It's illegal to do an lws_write outside of\n"
 			 "       the writable callback: fix your code",
-			 wsi, len, dump);
+			 wsi, (unsigned long)len, dump);
 #endif
 		assert(0);
 
@@ -198,7 +198,8 @@ handle_truncated_send:
 	 * Newly truncated send.  Buffer the remainder (it will get
 	 * first priority next time the socket is writable)
 	 */
-	lwsl_notice("%p new partial sent %d from %d total\n", wsi, n, real_len);
+	lwsl_notice("%p new partial sent %d from %lu total\n", wsi, n,
+		    (unsigned long)real_len);
 
 	/*
 	 *  - if we still have a suitable malloc lying around, use it
@@ -211,8 +212,8 @@ handle_truncated_send:
 		wsi->trunc_alloc_len = real_len - n;
 		wsi->trunc_alloc = lws_malloc(real_len - n);
 		if (!wsi->trunc_alloc) {
-			lwsl_err("truncated send: unable to malloc %d\n",
-				 real_len - n);
+			lwsl_err("truncated send: unable to malloc %lu\n",
+				 (unsigned long)(real_len - n));
 			return -1;
 		}
 	}

--- a/lib/server.c
+++ b/lib/server.c
@@ -419,7 +419,8 @@ lws_http_serve(struct lws *wsi, char *uri, const char *origin,
 			n = lws_write(wsi, start, p - start,
 				      LWS_WRITE_HTTP_HEADERS);
 			if (n != (p - start)) {
-				lwsl_err("_write returned %d from %d\n", n, p - start);
+				lwsl_err("_write returned %d from %ld\n", n,
+					 (long)(p - start));
 				return -1;
 			}
 
@@ -2295,7 +2296,7 @@ lws_serve_http_file(struct lws *wsi, const char *file, const char *content_type,
 
 	ret = lws_write(wsi, response, p - response, LWS_WRITE_HTTP_HEADERS);
 	if (ret != (p - response)) {
-		lwsl_err("_write returned %d from %d\n", ret, (p - response));
+		lwsl_err("_write returned %d from %ld\n", ret, (long)(p - response));
 		return -1;
 	}
 
@@ -2866,7 +2867,7 @@ LWS_VISIBLE LWS_EXTERN int
 lws_spa_process(struct lws_spa *ludspa, const char *in, int len)
 {
 	if (!ludspa) {
-		lwsl_err("%s: NULL spa\n");
+		lwsl_err("%s: NULL spa\n", __func__);
 		return -1;
 	}
 	return lws_urldecode_s_process(ludspa->s, in, len);

--- a/lib/service.c
+++ b/lib/service.c
@@ -232,7 +232,7 @@ lws_handle_POLLOUT_event(struct lws *wsi, struct lws_pollfd *pollfd)
 			 * Keep amount spilled small to minimize chance of this
 			 */
 			if (n != eff_buf.token_len) {
-				lwsl_err("Unable to spill ext %d vs %s\n",
+				lwsl_err("Unable to spill ext %d vs %d\n",
 							  eff_buf.token_len, n);
 				return -1;
 			}

--- a/lib/ssl-client.c
+++ b/lib/ssl-client.c
@@ -269,14 +269,14 @@ some_wait:
 #else
 #if defined(LWS_USE_MBEDTLS)
 #else
-		n = ERR_get_error();
+		unsigned long error = ERR_get_error();
 
-		if (n != SSL_ERROR_NONE) {
+		if (error != SSL_ERROR_NONE) {
 			struct lws_context_per_thread *pt = &context->pt[(int)wsi->tsi];
 			char *p = (char *)&pt->serv_buf[0];
 			char *sb = p;
 			lwsl_err("SSL connect error %lu: %s\n",
-				n, ERR_error_string(n, sb));
+				error, ERR_error_string(error, sb));
 			return -1;
 		}
 #endif
@@ -359,10 +359,10 @@ lws_ssl_client_connect2(struct lws *wsi)
 #else
 #if defined(LWS_USE_MBEDTLS)
 #else
-			n = ERR_get_error();
-			if (n != SSL_ERROR_NONE) {
+			unsigned long error = ERR_get_error();
+			if (error != SSL_ERROR_NONE) {
 				lwsl_err("SSL connect error %lu: %s\n",
-					 n, ERR_error_string(n, sb));
+					 error, ERR_error_string(error, sb));
 				return -1;
 			}
 #endif
@@ -421,7 +421,7 @@ int lws_context_init_client_ssl(struct lws_context_creation_info *info,
 #else
 	SSL_METHOD *method;
 	struct lws wsi;
-	int error;
+	unsigned long error;
 	int n;
 
 	if (!lws_check_opt(info->options, LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT))

--- a/lib/ssl-server.c
+++ b/lib/ssl-server.c
@@ -195,7 +195,7 @@ lws_context_init_server_ssl(struct lws_context_creation_info *info,
 {
 	struct lws_context *context = vhost->context;
 	struct lws wsi;
-	int error;
+	unsigned long error;
 	int n;
 
 	if (!lws_check_opt(info->options, LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT)) {

--- a/test-server/test-client.c
+++ b/test-server/test-client.c
@@ -126,7 +126,8 @@ callback_dumb_increment(struct lws *wsi, enum lws_callback_reasons reason,
 				wsi_multi[n] = NULL;
 			}
 
-		lwsl_err("CLIENT_CONNECTION_ERROR: %s: %s %p\n", which, in);
+		lwsl_err("CLIENT_CONNECTION_ERROR: %s: %s\n", which,
+			 in ? (char *)in : "(null)");
 		break;
 
 	case LWS_CALLBACK_CLIENT_CONFIRM_EXTENSION_SUPPORTED:

--- a/test-server/test-server-dumb-increment.c
+++ b/test-server/test-server-dumb-increment.c
@@ -79,8 +79,8 @@ callback_dumb_increment(struct lws *wsi, enum lws_callback_reasons reason,
 	 * have a use for this.
 	 */
 	case LWS_CALLBACK_WS_PEER_INITIATED_CLOSE:
-		lwsl_notice("LWS_CALLBACK_WS_PEER_INITIATED_CLOSE: len %d\n",
-			    len);
+		lwsl_notice("LWS_CALLBACK_WS_PEER_INITIATED_CLOSE: len %lu\n",
+			    (unsigned long)len);
 		for (n = 0; n < (int)len; n++)
 			lwsl_notice(" %d: 0x%02X\n", n,
 				    ((unsigned char *)in)[n]);

--- a/test-server/test-server-echogen.c
+++ b/test-server/test-server-echogen.c
@@ -107,8 +107,8 @@ callback_lws_echogen(struct lws *wsi, enum lws_callback_reasons reason,
 		break;
 
 	case LWS_CALLBACK_WS_PEER_INITIATED_CLOSE:
-		lwsl_notice("LWS_CALLBACK_WS_PEER_INITIATED_CLOSE: len %d\n",
-			    len);
+		lwsl_notice("LWS_CALLBACK_WS_PEER_INITIATED_CLOSE: len %lu\n",
+			    (unsigned long)len);
 		for (n = 0; n < (int)len; n++)
 			lwsl_notice(" %d: 0x%02X\n", n,
 				    ((unsigned char *)in)[n]);

--- a/test-server/test-server-pthreads.c
+++ b/test-server/test-server-pthreads.c
@@ -229,8 +229,8 @@ int main(int argc, char **argv)
 		case 'j':
 			threads = atoi(optarg);
 			if (threads > ARRAY_SIZE(pthread_service)) {
-				lwsl_err("Max threads %d\n",
-					 ARRAY_SIZE(pthread_service));
+				lwsl_err("Max threads %lu\n",
+					 (unsigned long)ARRAY_SIZE(pthread_service));
 				return 1;
 			}
 			break;


### PR DESCRIPTION
Adds the `format` [function attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html) when compiled by gcc and fixes whatever it found on my system.

* I'm assuming not all platforms the library supports have `%z` so I casted `size_t` to `(unsigned long)` where needed.
* `ERR_get_error` seems to return `unsigned long` so the commit changes the type of couple of variables.

There's also small docstring fix.