### PR TITLE
Fixes a conversion error in the test client

### DIFF
--- a/test-server/test-client.c
+++ b/test-server/test-client.c
@@ -131,13 +131,13 @@ callback_dumb_increment(struct lws *wsi, enum lws_callback_reasons reason,
 		break;
 
 	case LWS_CALLBACK_CLIENT_CONFIRM_EXTENSION_SUPPORTED:
-		if ((strcmp(in, "deflate-stream") == 0) && deny_deflate) {
+		if ((strcmp((char *)in, "deflate-stream") == 0) && deny_deflate) {
 			lwsl_notice("denied deflate-stream extension\n");
 			return 1;
 		}
-		if ((strcmp(in, "x-webkit-deflate-frame") == 0))
+		if ((strcmp((char *)in, "x-webkit-deflate-frame") == 0))
 			return 1;
-		if ((strcmp(in, "deflate-frame") == 0))
+		if ((strcmp((char *)in, "deflate-frame") == 0))
 			return 1;
 		break;
 


### PR DESCRIPTION
This fixes a conversion error from a void pointer to a string, hope I'm not wrong here or didn't set something up in the project settings since I'm migrating this code file to a smaller test project.