### PR TITLE
gcc format strings: one more

### DIFF
--- a/lib/extension-permessage-deflate.c
+++ b/lib/extension-permessage-deflate.c
@@ -303,9 +303,10 @@ lws_extension_callback_pm_deflate(struct lws_context *context,
 		priv->count_rx_between_fin += eff_buf->token_len;
 
 		lwsl_ext("  %s: RX leaving with new effbuff len %d, "
-			 "ret %d, rx.avail_in=%d, TOTAL RX since FIN %ld\n",
+			 "ret %d, rx.avail_in=%d, TOTAL RX since FIN %lu\n",
 			 __func__, eff_buf->token_len, priv->rx_held_valid,
-			 priv->rx.avail_in, priv->count_rx_between_fin);
+			 priv->rx.avail_in,
+			 (unsigned long)priv->count_rx_between_fin);
 
 		if (was_fin) {
 			priv->count_rx_between_fin = 0;


### PR DESCRIPTION
Found with gcc-4.7 on mipsel.