### PR TITLE
Buffer index protection in the case where client does not receive length

### DIFF
--- a/lib/service.c
+++ b/lib/service.c
@@ -665,7 +665,10 @@ spin_chunks:
 	if (wsi->chunked)
 		return 0;
 
-	wsi->u.http.content_remain -= n;
+	/* if we know the content length, decrement the content remaining */
+	if (wsi->u.http.content_length > 0)
+		wsi->u.http.content_remain -= n;
+
 	if (wsi->u.http.content_remain || !wsi->u.http.content_length)
 		return 0;
 


### PR DESCRIPTION
Minor client buffer fix when server does not provide content length

----

Hello Andy.

I am having to deal with a noncompliant server that does not appear to provide a content length header.  

Libwebsockets detects this and drops into connection-close mode (HTTP_CONNECTION_CLOSE), in client.c ln~591.  All good so far.

When processing the http buffer in service.c ln~668, lws decrements the content remaining:
    wsi->u.http.content_remain -= n;
Because wsi->u.http.content_length was zero, this kicks buffer indexing into negative numbers.

I added a simple check before decrementing, to avoid it if the content length is unknown.  Then my client can force a completion of the HTTP GET in LWS_CALLBACK_RECEIVE_CLIENT_HTTP by returning non-zero.

I have a patch to submit, but I wasn't sure if you were interested, because it is solely for noncompliant server behavior.  It "seems safe" heh but you never know.  If you want to pull it, it's here.  If not let me know and I'll remove the request.

Thanks again for a great library.
Michael