### PR TITLE
added missing file to %files section of spec file

### DIFF
--- a/libwebsockets.spec
+++ b/libwebsockets.spec
@@ -60,6 +60,8 @@ rm -rf $RPM_BUILD_ROOT
 /%{_libdir}/cmake/libwebsockets/LibwebsocketsConfig.cmake
 /%{_libdir}/cmake/libwebsockets/LibwebsocketsConfigVersion.cmake
 /%{_libdir}/cmake/libwebsockets/LibwebsocketsTargets.cmake
+/%{_libdir}/cmake/libwebsockets/LibwebsocketsTargets-release.cmake
+
 /usr/share/libwebsockets-test-server
 %doc
 %files devel


### PR DESCRIPTION
The .spec file is missing a file in the %files section.

The causes rpmbuild to fail.