### PR TITLE
Modified CMakeLists.txt to fix issue when used as a cmake subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -773,13 +773,13 @@ if (LWS_WITH_STATIC)
 	endif()
 	add_custom_command(
 		      TARGET websockets
-		      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/lib/libwebsockets.h
-		     					 ${CMAKE_BINARY_DIR}/include/libwebsockets.h
+		      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/lib/libwebsockets.h
+		     					 ${PROJECT_BINARY_DIR}/include/libwebsockets.h
 	)
 	add_custom_command(
 		      TARGET websockets
-		      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/lws_config.h
-		     					 ${CMAKE_BINARY_DIR}/include/lws_config.h
+		      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/lws_config.h
+		     					 ${PROJECT_BINARY_DIR}/include/lws_config.h
 	)
 
 endif()


### PR DESCRIPTION
Hi, I'm trying to include libwebsockets in my cmake build process, by cloning the repository and then adding it as a subdirectory in my cmakelists. Currently I can't do this, as it fails when copying libwebsockets.h and lws_config.h into the include folder.

It seems changing the paths shown here fixes the issue, and has no negative effects when building the project by itself.