### PR TITLE
Spinning on poll() when closing SSL connection

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -510,14 +510,28 @@ just_kill_connection:
 	    !wsi->socket_is_permanently_unusable) {
 #ifdef LWS_OPENSSL_SUPPORT
 		if (lws_is_ssl(wsi) && wsi->ssl)
-               {
-                       lwsl_info("%s: shutting down SSL connection: %p (ssl %p, sock %d, state %d)\n", __func__, wsi, wsi->ssl, (int)(long)wsi->desc.sockfd, wsi->state);
+		{
+			lwsl_info("%s: shutting down SSL connection: %p (ssl %p, sock %d, state %d)\n", __func__, wsi, wsi->ssl, (int)(long)wsi->desc.sockfd, wsi->state);
 			n = SSL_shutdown(wsi->ssl);
-                       if (n == 1) /* If finished the SSL shutdown, then do socket shutdown, else need to retry SSL shutdown */
-                               n = shutdown(wsi->desc.sockfd, SHUT_WR);
-                       else
-                               lws_change_pollfd(wsi, LWS_POLLOUT, LWS_POLLIN);
-               }
+			if (n == 1) /* If finished the SSL shutdown, then do socket shutdown, else need to retry SSL shutdown */
+				n = shutdown(wsi->desc.sockfd, SHUT_WR);
+			else if (n == 0)
+				lws_change_pollfd(wsi, LWS_POLLOUT, LWS_POLLIN);
+			else /* n < 0 */
+			{
+				int shutdown_error = SSL_get_error(wsi->ssl, n);
+				lwsl_debug("SSL_shutdown returned %d, SSL_get_error: %d\n", n, shutdown_error);
+				if (shutdown_error == SSL_ERROR_WANT_READ) {
+					lws_change_pollfd(wsi, LWS_POLLOUT, LWS_POLLIN);
+					n = 0;
+				} else if (shutdown_error == SSL_ERROR_WANT_WRITE) {
+					lws_change_pollfd(wsi, LWS_POLLOUT, LWS_POLLOUT);
+					n = 0;
+				} else { // actual error occurred, just close the connection
+					n = shutdown(wsi->desc.sockfd, SHUT_WR);
+				}
+			}
+		}
 		else
 #endif
 		{


### PR DESCRIPTION
Unfortunately the commit 4198c20 that is supposed to fix #831 actually causes the poll() spinning issue in my use case. What seems to be happening is that LWS sends connection close notification in the SSL layer and the other side closes the connection immediately without sending a reply (`SSL_shutdown` [returns -1](https://wiki.openssl.org/index.php/Manual:SSL_shutdown(3)#RETURN_VALUES) with `SSL_get_error` returning `SSL_ERROR_SYSCALL`). Using strace I can see these two syscalls alternating in a busy loop (until 20s timeout):
```
poll([{fd=6, events=POLLIN}], 1, 500) = 1 ([{fd=6, revents=POLLIN}])
read(6, "", 5)                        = 0
```

Here's a helpful explanation how `SSL_shutdown` should be used in non-blocking mode: http://stackoverflow.com/questions/28056056/handling-ssl-shutdown-correctly/28056464#28056464

This pull request improves the behavior in my use case but I think the code is still not correct wrt the post above and probably shouldn't be merged as it is now. I don't really understand the high-level control flow inside of LWS so I'll appreciate any hints in this direction.