### PR TITLE
report back http errors >= 400 with HTTP: prefix

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -765,6 +765,7 @@ enum lws_callback_reasons {
 	 *     	"lws_ssl_client_connect2 failed"
 	 *     	"Peer hung up"
 	 *     	"read failed"
+	 *  	"HTTP: <http response code>"
 	 *     	"HS: URI missing"
 	 *     	"HS: Redirect code but no Location"
 	 *     	"HS: URI did not parse"


### PR DESCRIPTION
If server returns HTTP error code before WS upgrade, call back LWS_CALLBACK_CLIENT_CONNECTION_ERROR will only report an indicative "HS: no accept". In most cases the client would need to know the HTTP error. For example in case of 403.

This patch adds an early check for HTTP error codes and reports the error with prefix HTTP: so client can differentiate it and parse it out.
