### PR TITLE
Fix capturing of HTTP errors for WS clients before upgrade

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -431,10 +431,10 @@ lws_client_interpret_server_handshake(struct lws *wsi)
 	void *v;
 #endif
 
+	ah = wsi->u.hdr.ah;
 	if (!wsi->do_ws) {
 		/* we are being an http client...
 		 */
-		ah = wsi->u.hdr.ah;
 		lws_union_transition(wsi, LWSCM_HTTP_CLIENT_ACCEPTED);
 		wsi->state = LWSS_CLIENT_HTTP_ESTABLISHED;
 		wsi->u.http.ah = ah;


### PR DESCRIPTION
Save copy of ah pointer even with WS client so that HTTP error can be captured by calling lws_http_client_http_response.