### PR TITLE
libuv: Fix closing handle multiple times

### DIFF
--- a/lib/libuv.c
+++ b/lib/libuv.c
@@ -258,7 +258,8 @@ static void lws_uv_close_cb(uv_handle_t *handle)
 
 static void lws_uv_walk_cb(uv_handle_t *handle, void *arg)
 {
-	uv_close(handle, lws_uv_close_cb);
+	if (!uv_is_closing(handle))
+		uv_close(handle, lws_uv_close_cb);
 }
 
 void


### PR DESCRIPTION
Sometimes "Assertion failed: !uv__is_closing(handle)" happens because
handle is being closed multiple times. To fix this, "uv_is_closing"
is added before calling "uv_close".

Signed-off-by: Petar Paradzik <petar.paradzik@sartura.hr>