### PR TITLE
ssl: more cleanup when context destroyed on Linux

### DIFF
--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -835,6 +835,7 @@ lws_ssl_context_destroy(struct lws_context *context)
 	ERR_remove_thread_state(NULL);
 #endif
 #endif
+	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
 	ERR_free_strings();
 	EVP_cleanup();
 	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
Valgrind shows 2 still reachable blocks after an application
exits with Openssl 1.0.1j. The patch fixed this by more cleanup
as context destroyed.

This is the summary when an application exit. The "definitely
lost" is in the application, but the "still reachable" is in
libwebsockets.

==23137== LEAK SUMMARY:
==23137==    definitely lost: 64 bytes in 1 blocks
==23137==    indirectly lost: 0 bytes in 0 blocks
==23137==      possibly lost: 0 bytes in 0 blocks
==23137==    still reachable: 64 bytes in 2 blocks
==23137==         suppressed: 0 bytes in 0 blocks

Signed-off-by: Andy Ning <andy.ning@windriver.com>