### PR TITLE
Fix compile error in GCC 4.1.2

### DIFF
--- a/test-server/fuzxy.c
+++ b/test-server/fuzxy.c
@@ -263,19 +263,19 @@ static const struct test tests[] = {
 	  }, { 0, 4 }, 1 },
 };
 
-static const int ring_size(struct ring *r)
+static int ring_size(struct ring *r)
 {
 	return sizeof(r->buf);
 }
-static const int ring_used(struct ring *r)
+static int ring_used(struct ring *r)
 {
 	return (r->head - r->tail) & (ring_size(r) - 1);
 }
-static const int ring_free(struct ring *r)
+static int ring_free(struct ring *r)
 {
 	return (ring_size(r) - 1) - ring_used(r);
 }
-static const int ring_get_one(struct ring *r)
+static int ring_get_one(struct ring *r)
 {
 	int n = r->buf[r->tail] & 255;
 


### PR DESCRIPTION
$ make
[ 33%] Built target websockets
[ 35%] Built target test-client
[ 36%] Built target test-echo
[ 38%] Built target test-fraggle
[ 39%] Building C object CMakeFiles/test-fuzxy.dir/test-server/fuzxy.c.o
cc1: warnings being treated as errors
/root/libwebsockets/test-server/fuzxy.c:267: warning: type qualifiers ignored on function return type
/root/libwebsockets/test-server/fuzxy.c:271: warning: type qualifiers ignored on function return type
/root/libwebsockets/test-server/fuzxy.c:275: warning: type qualifiers ignored on function return type
/root/libwebsockets/test-server/fuzxy.c:279: warning: type qualifiers ignored on function return type
make[2]: *** [CMakeFiles/test-fuzxy.dir/test-server/fuzxy.c.o] Error 1
make[1]: *** [CMakeFiles/test-fuzxy.dir/all] Error 2
make: *** [all] Error 2

$ gcc --version
gcc (GCC) 4.1.2 20080704 (Red Hat 4.1.2-46)