### PR TITLE
Reduce memory size when client context is created. V1.7 stable

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -290,16 +290,20 @@ lws_create_context(struct lws_context_creation_info *info)
 			lws_set_proxy(context, p);
 #endif
 	}
-
-	if (lws_context_init_server_ssl(info, context))
-		goto bail;
-
+	
+	if (info->port != CONTEXT_PORT_NO_LISTEN) {
+		if (lws_context_init_server_ssl(info, context))
+			goto bail;
+	}
+	
 	if (lws_context_init_client_ssl(info, context))
 		goto bail;
-
-	if (lws_context_init_server(info, context))
-		goto bail;
-
+	
+	if (info->port != CONTEXT_PORT_NO_LISTEN) {
+		if (lws_context_init_server(info, context))
+			goto bail;
+	}
+	
 	/*
 	 * drop any root privs for this process
 	 * to listen on port < 1023 we would have needed root, but now we are

--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -223,9 +223,7 @@ int lws_header_table_detach(struct lws *wsi)
 	assert(pt->ah_count_in_use > 0);
 	/* and this specific one should have been in use */
 	assert(wsi->u.hdr.ah->in_use);
-	wsi->u.hdr.ah = NULL;
-	ah->wsi = NULL; /* no owner */
-
+	
 	/* oh there is nobody on the waiting list... leave it at that then */
 	if (!*pwsi) {
 		ah->in_use = 0;
@@ -233,6 +231,9 @@ int lws_header_table_detach(struct lws *wsi)
 
 		goto bail;
 	}
+
+	wsi->u.hdr.ah = NULL;
+	ah->wsi = NULL; /* no owner */
 
 	/* somebody else on same tsi is waiting, give it to oldest guy */
 

--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -225,7 +225,7 @@ int lws_header_table_detach(struct lws *wsi)
 	assert(wsi->u.hdr.ah->in_use);
 	wsi->u.hdr.ah = NULL;
 	ah->wsi = NULL; /* no owner */
-	
+
 	/* oh there is nobody on the waiting list... leave it at that then */
 	if (!*pwsi) {
 		ah->in_use = 0;

--- a/lib/parsers.c
+++ b/lib/parsers.c
@@ -223,6 +223,8 @@ int lws_header_table_detach(struct lws *wsi)
 	assert(pt->ah_count_in_use > 0);
 	/* and this specific one should have been in use */
 	assert(wsi->u.hdr.ah->in_use);
+	wsi->u.hdr.ah = NULL;
+	ah->wsi = NULL; /* no owner */
 	
 	/* oh there is nobody on the waiting list... leave it at that then */
 	if (!*pwsi) {
@@ -231,9 +233,6 @@ int lws_header_table_detach(struct lws *wsi)
 
 		goto bail;
 	}
-
-	wsi->u.hdr.ah = NULL;
-	ah->wsi = NULL; /* no owner */
 
 	/* somebody else on same tsi is waiting, give it to oldest guy */
 


### PR DESCRIPTION
Hello @lws-team, 

`lws_context_init_server_ssl` and `lws_context_init_server` allocates noticeable amount of memory and it can be skipped when the context is created as a client.

Regards,
Dulguun