### PR TITLE
libuv: fix casting from pointer to integer of different size

### DIFF
--- a/lib/libuv.c
+++ b/lib/libuv.c
@@ -529,7 +529,7 @@ lws_libuv_closehandle(struct lws *wsi)
 static void
 lws_libuv_closewsi_m(uv_handle_t* handle)
 {
-	lws_sockfd_type sockfd = (lws_sockfd_type)(long long)handle->data;
+	lws_sockfd_type sockfd = (lws_sockfd_type)(intptr_t)handle->data;
 
 	compatible_close(sockfd);
 }
@@ -539,7 +539,7 @@ lws_libuv_closehandle_manually(struct lws *wsi)
 {
 	uv_handle_t *h = (void *)&wsi->w_read.uv_watcher;
 
-	h->data = (void *)(long long)wsi->desc.sockfd;
+	h->data = (void *)(intptr_t)wsi->desc.sockfd;
 	/* required to defer actual deletion until libuv has processed it */
 	uv_close((uv_handle_t*)&wsi->w_read.uv_watcher, lws_libuv_closewsi_m);
 }


### PR DESCRIPTION
When building for platforms where sizeof 'long long' is 8, but sizeof
pointer is 4 bytes, we get 'cast to pointer from integer of different size
[-Werror=int-to-pointer-cast]' and vice versa. Instead of 'long long'
type, 'intptr_t' is used while casting.

Signed-off-by: Petar Paradzik <petar.paradzik@sartura.hr>