### PR TITLE
Eliminated 'unused variable' compiler warning generated with -DLWS_WI…

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -384,10 +384,9 @@ lws_callback_http_dummy(struct lws *wsi, enum lws_callback_reasons reason,
 
 	case LWS_CALLBACK_SSL_INFO:
 		{
-			struct lws_ssl_info *si = in;
-
 			lwsl_notice("LWS_CALLBACK_SSL_INFO: where: 0x%x, ret: 0x%x\n",
-					si->where, si->ret);
+					((struct lws_ssl_info *) in)->where,
+					((struct lws_ssl_info *) in)->ret);
 		}
 		break;
 


### PR DESCRIPTION
…TH_NO_LOGS=ON.

The unused variable was only declared for use in a log macro that's
compiled out with the above compiler switch. I removed the declaration
and casted the variable at each use in the block.