### PR TITLE
Mismatched lws_zalloc, free => lws_zalloc, lws_free.

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -535,7 +535,7 @@ lws_create_vhost(struct lws_context *context,
 		vh->protocols = lwsp;
 	else {
 		vh->protocols = info->protocols;
-		free(lwsp);
+		lws_free(lwsp);
 	}
 
 	vh->same_vh_protocol_list = (struct lws **)


### PR DESCRIPTION
This causes problems if lws_set_allocator is used.  lwsp is allocated on line 488.