### PR TITLE
Add getifaddrs/freeifaddrs include headers

### DIFF
--- a/lib/lws-plat-unix.c
+++ b/lib/lws-plat-unix.c
@@ -1,4 +1,5 @@
 #include "private-libwebsockets.h"
+#include "getifaddrs.h"
 
 #include <pwd.h>
 #include <grp.h>


### PR DESCRIPTION
If not, LLVM will generate "warning: implicit declaration of function 'getifaddrs' is invalid in C99" on Android with `LWS_HAVE_GETIFADDRS=1`