### PR TITLE
Prevent ifaddrs redefinitions on new Android NDKs

### DIFF
--- a/lib/getifaddrs.h
+++ b/lib/getifaddrs.h
@@ -54,7 +54,12 @@ extern "C" {
 
 #undef ifa_dstaddr
 
+#if defined(ANDROID)
+#define ifaddrs __lws_ifaddrs
+struct __lws_ifaddrs {
+#else
 struct ifaddrs {
+#endif
 	struct ifaddrs *ifa_next;
 	char *ifa_name;
 	unsigned int ifa_flags;


### PR DESCRIPTION
Before this PR this errors may be thrown by the Android NDK :

`getifaddrs.h:58:8: error: redefinition of 'ifaddrs'`
`getifaddrs.c:163:11: error: no member named 'ifa_dstaddr' in 'struct ifaddrs'; did you mean 'ifa_addr'`

While the struct is already defined, Android seems to not fully support all functionalities needed by LWS.

This workaround will redefine the struct as a macro and should only affect Android builds.