### PR TITLE
Cgi chunking and fixes

### DIFF
--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -2644,6 +2644,8 @@ lws_cgi(struct lws *wsi, const char * const *exec_array, int script_uri_path_len
 			p++;
 		}
 	}
+	env_array[n++] = "PATH=/bin:/usr/bin:/usr/local/bin:/var/www/cgi-bin";
+
 	env_array[n++] = p;
 	p += lws_snprintf(p, end - p, "SCRIPT_PATH=%s", exec_array[0]) + 1;
 
@@ -2658,7 +2660,6 @@ lws_cgi(struct lws *wsi, const char * const *exec_array, int script_uri_path_len
 	}
 
 	env_array[n++] = "SERVER_SOFTWARE=libwebsockets";
-	env_array[n++] = "PATH=/bin:/usr/bin:/usr/local/bin:/var/www/cgi-bin";
 	env_array[n] = NULL;
 
 #if 0

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -256,6 +256,7 @@ lws_bind_protocol(struct lws *wsi, const struct lws_protocols *p)
 	return 0;
 }
 
+#ifdef LWS_WITH_CGI
 static void
 lws_cgi_remove_and_kill(struct lws *wsi)
 {
@@ -280,6 +281,7 @@ lws_cgi_remove_and_kill(struct lws *wsi)
 	wsi->cgi->being_closed = 1;
 	lws_cgi_kill(wsi);
 }
+#endif
 
 void
 lws_close_free_wsi(struct lws *wsi, enum lws_close_status reason)

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -2791,6 +2791,11 @@ lws_cgi_write_split_stdout_headers(struct lws *wsi)
 					wsi->cgi->response_code);
 			if (lws_add_http_header_status(wsi, wsi->cgi->response_code, &p, end))
 				return 1;
+			if (!wsi->cgi->explicitly_chunked &&
+					!wsi->cgi->content_length &&
+					lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_TRANSFER_ENCODING,
+					(unsigned char *)"chunked", 7, &p, end))
+				return 1;
 			if (lws_add_http_header_by_token(wsi, WSI_TOKEN_CONNECTION,
 					(unsigned char *)"close", 5, &p, end))
 				return 1;
@@ -2988,14 +2993,24 @@ lws_cgi_write_split_stdout_headers(struct lws *wsi)
 
 	/* payload processing */
 
+	m = !wsi->cgi->explicitly_chunked && !wsi->cgi->content_length;
+
 	n = read(lws_get_socket_fd(wsi->cgi->stdwsi[LWS_STDOUT]),
-		 start, sizeof(buf) - LWS_PRE);
+		 start, sizeof(buf) - LWS_PRE - (m ? LWS_HTTP_CHUNK_HDR_SIZE : 0));
 
 	if (n < 0 && errno != EAGAIN) {
 		lwsl_debug("%s: stdout read says %d\n", __func__, n);
 		return -1;
 	}
 	if (n > 0) {
+		if (m) {
+			char chdr[LWS_HTTP_CHUNK_HDR_SIZE];
+			m = lws_snprintf(chdr, LWS_HTTP_CHUNK_HDR_SIZE - 3, "%X\x0d\x0a", n);
+			memmove(start + m, start, n);
+			memcpy(start, chdr, m);
+			memcpy(start + m + n, "\x0d\x0a", 2);
+			n += m + 2;
+		}
 		m = lws_write(wsi, (unsigned char *)start, n, LWS_WRITE_HTTP);
 		//lwsl_notice("write %d\n", m);
 		if (m < 0) {

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -3142,7 +3142,7 @@ lws_cgi_kill_terminated(struct lws_context_per_thread *pt)
 				lwsl_debug("%s: found PID %d on cgi list\n",
 					    __func__, n);
 
-				if (!cgi->content_length && cgi->explicitly_chunked) {
+				if (!cgi->content_length) {
 					/*
 					 * well, if he sends chunked... give him 5s after the
 					 * cgi terminated to send buffered

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -769,12 +769,13 @@ lws_close_free_wsi_final(struct lws *wsi)
 
 #ifdef LWS_WITH_CGI
 	if (wsi->cgi) {
-		for (n = 0; n < 6; n++) {
-			if (wsi->cgi->pipe_fds[n / 2][n & 1] == 0)
+
+		for (n = 0; n < 3; n++) {
+			if (wsi->cgi->pipe_fds[n][!!(n == 0)] == 0)
 				lwsl_err("ZERO FD IN CGI CLOSE");
 
-			if (wsi->cgi->pipe_fds[n / 2][n & 1] >= 0)
-				close(wsi->cgi->pipe_fds[n / 2][n & 1]);
+			if (wsi->cgi->pipe_fds[n][!!(n == 0)] >= 0)
+				close(wsi->cgi->pipe_fds[n][!!(n == 0)]);
 		}
 
 		lws_free(wsi->cgi);
@@ -2680,6 +2681,10 @@ lws_cgi(struct lws *wsi, const char * const *exec_array, int script_uri_path_len
 		/* we are the parent process */
 		wsi->context->count_cgi_spawned++;
 		lwsl_debug("%s: cgi %p spawned PID %d\n", __func__, cgi, cgi->pid);
+
+		for (n = 0; n < 3; n++)
+			close(cgi->pipe_fds[n][!(n == 0)]);
+
 		return 0;
 	}
 

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -1490,6 +1490,8 @@ struct _lws_websocket_related {
 
 #ifdef LWS_WITH_CGI
 
+#define LWS_HTTP_CHUNK_HDR_SIZE 16
+
 enum {
 	SIGNIFICANT_HDR_CONTENT_LENGTH,
 	SIGNIFICANT_HDR_LOCATION,

--- a/lib/service.c
+++ b/lib/service.c
@@ -1026,7 +1026,8 @@ lws_service_fd_tsi(struct lws_context *context, struct lws_pollfd *pollfd, int t
 #endif
 
 //       lwsl_debug("fd=%d, revents=%d, mode=%d, state=%d\n", pollfd->fd, pollfd->revents, (int)wsi->mode, (int)wsi->state);
-	if (pollfd->revents & LWS_POLLHUP) {
+	if ((!(pollfd->revents & pollfd->events & LWS_POLLIN)) &&
+			(pollfd->revents & LWS_POLLHUP)) {
 		lwsl_debug("pollhup\n");
 		wsi->socket_is_permanently_unusable = 1;
 		goto close_and_handled;


### PR DESCRIPTION
This set of patches fixes some of the issues in CGI handling and add support for manual chunking of CGI's which don't have content-length nor are explicitly chunked. It's done by making lws get POLLHUP event on CGI stdout (which it didn't before), and after that, sending terminating chunk to the client. POLLHUP enables lws to do reaping immediately after CGI finishes so there is no delay. This makes clients that are relying on this kind of CGI's more responsive.