### PR TITLE
Server secure context creation without cert

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1299,7 +1299,14 @@ enum lws_callback_reasons {
 	/**< Sent to parent to notify them a child is closing / being
 	 * destroyed.  @in is the child wsi.
 	 */
-
+	LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT	= 70,
+	/**< if configured for including OpenSSL support but no server cert
+	 * file has been specified (ssl_cert_filepath is NULL), this is
+	 * called to allow the user to set the server cert directly via
+	 * libopenssl and perform further operations if required; this might be
+	 * useful in situations where the server cert is not directly accessible
+	 * by the OS, for example if it is stored on a smartcard.
+	 * user is the server's OpenSSL SSL_CTX* */
 	/****** add new things just above ---^ ******/
 
 	LWS_CALLBACK_USER = 1000,
@@ -1865,7 +1872,10 @@ enum lws_context_options {
 	 * listen socket at a time.  This is automatically selected if you
 	 * have multiple service threads.
 	 */
-
+	LWS_SERVER_OPTION_NO_CERT				= (1 << 24),
+	/**< (CTX) creating server context without any certificate and
+	 * private key.
+	 */
 	/****** add new things just above ---^ ******/
 };
 

--- a/lib/ssl-server.c
+++ b/lib/ssl-server.c
@@ -401,14 +401,15 @@ lws_context_init_server_ssl(struct lws_context_creation_info *info,
 				free(p);
 				p = NULL;
 #endif
-			} else
-			        if (vhost->protocols[0].callback(&wsi,
-			                LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT,
-			                vhost->ssl_ctx, NULL, 0)) {
-			                lwsl_err("ssl certificate not set\n");
-			                return 1;
-			        }
 #endif
+			} else
+				if (vhost->protocols[0].callback(&wsi,
+					LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT,
+					vhost->ssl_ctx, NULL, 0)) {
+					lwsl_err("ssl certificate not set\n");
+					return 1;
+				}
+
 			if (info->ssl_private_key_filepath != NULL) {
 #if !defined(LWS_USE_MBEDTLS)
 				/* set the private key from KeyFile */

--- a/lib/ssl-server.c
+++ b/lib/ssl-server.c
@@ -199,8 +199,7 @@ lws_context_init_server_ssl(struct lws_context_creation_info *info,
 		return 0;
 	}
 	if (info->port != CONTEXT_PORT_NO_LISTEN) {
-
-		vhost->use_ssl = info->ssl_cert_filepath != NULL;
+		vhost->use_ssl = 1;
 
 		if (vhost->use_ssl && info->ssl_cipher_list)
 			lwsl_notice(" SSL ciphers: '%s'\n", info->ssl_cipher_list);
@@ -346,90 +345,100 @@ lws_context_init_server_ssl(struct lws_context_creation_info *info,
 
 	if (vhost->use_ssl) {
 		/* openssl init for server sockets */
+		if (!lws_check_opt(info->options, LWS_SERVER_OPTION_NO_CERT)) {
+			if (info->ssl_cert_filepath != NULL) {
 #if !defined(LWS_USE_MBEDTLS)
-		/* set the local certificate from CertFile */
-		n = SSL_CTX_use_certificate_chain_file(vhost->ssl_ctx,
-					info->ssl_cert_filepath);
-		if (n != 1) {
-			error = ERR_get_error();
-			lwsl_err("problem getting cert '%s' %lu: %s\n",
-				info->ssl_cert_filepath,
-				error,
-				ERR_error_string(error,
-					      (char *)context->pt[0].serv_buf));
-			return 1;
-		}
-		lws_ssl_bind_passphrase(vhost->ssl_ctx, info);
+				/* set the local certificate from CertFile */
+				n = SSL_CTX_use_certificate_chain_file(vhost->ssl_ctx,
+							info->ssl_cert_filepath);
+				if (n != 1) {
+					error = ERR_get_error();
+					lwsl_err("problem getting cert '%s' %lu: %s\n",
+						info->ssl_cert_filepath,
+						error,
+						ERR_error_string(error,
+							      (char *)context->pt[0].serv_buf));
+					return 1;
+				}
+				lws_ssl_bind_passphrase(vhost->ssl_ctx, info);
 #else
-		uint8_t *p;
-		lws_filepos_t flen;
-		int err;
+				uint8_t *p;
+				lws_filepos_t flen;
+				int err;
 
-		if (alloc_pem_to_der_file(vhost->context, info->ssl_cert_filepath, &p,
-				                &flen)) {
-			lwsl_err("couldn't find cert file %s\n",
-				 info->ssl_cert_filepath);
+				if (alloc_pem_to_der_file(vhost->context, info->ssl_cert_filepath, &p,
+						                &flen)) {
+					lwsl_err("couldn't find cert file %s\n",
+						 info->ssl_cert_filepath);
 
-			return 1;
-		}
-		err = SSL_CTX_use_certificate_ASN1(vhost->ssl_ctx, flen, p);
-		if (!err) {
-			lwsl_err("Problem loading cert\n");
-			return 1;
-		}
+					return 1;
+				}
+				err = SSL_CTX_use_certificate_ASN1(vhost->ssl_ctx, flen, p);
+				if (!err) {
+					lwsl_err("Problem loading cert\n");
+					return 1;
+				}
 #if !defined(LWS_WITH_ESP32)
-		free(p);
-		p = NULL;
+				free(p);
+				p = NULL;
 #endif
 
-		if (alloc_pem_to_der_file(vhost->context,
-			       info->ssl_private_key_filepath, &p, &flen)) {
-			lwsl_err("couldn't find cert file %s\n",
-				 info->ssl_cert_filepath);
+				if (alloc_pem_to_der_file(vhost->context,
+					       info->ssl_private_key_filepath, &p, &flen)) {
+					lwsl_err("couldn't find cert file %s\n",
+						 info->ssl_cert_filepath);
 
-			return 1;
-		}
-		err = SSL_CTX_use_PrivateKey_ASN1(0, vhost->ssl_ctx, p, flen);
-		if (!err) {
-			lwsl_err("Problem loading key\n");
+					return 1;
+				}
+				err = SSL_CTX_use_PrivateKey_ASN1(0, vhost->ssl_ctx, p, flen);
+				if (!err) {
+					lwsl_err("Problem loading key\n");
 
-			return 1;
-		}
+					return 1;
+				}
 
 #if !defined(LWS_WITH_ESP32)
-		free(p);
-		p = NULL;
+				free(p);
+				p = NULL;
 #endif
+			} else
+			        if (vhost->protocols[0].callback(&wsi,
+			                LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT,
+			                vhost->ssl_ctx, NULL, 0)) {
+			                lwsl_err("ssl certificate not set\n");
+			                return 1;
+			        }
 #endif
-		if (info->ssl_private_key_filepath != NULL) {
+			if (info->ssl_private_key_filepath != NULL) {
 #if !defined(LWS_USE_MBEDTLS)
-			/* set the private key from KeyFile */
-			if (SSL_CTX_use_PrivateKey_file(vhost->ssl_ctx,
-				     info->ssl_private_key_filepath,
-						       SSL_FILETYPE_PEM) != 1) {
-				error = ERR_get_error();
-				lwsl_err("ssl problem getting key '%s' %lu: %s\n",
-					 info->ssl_private_key_filepath, error,
-					 ERR_error_string(error,
-					      (char *)context->pt[0].serv_buf));
+				/* set the private key from KeyFile */
+				if (SSL_CTX_use_PrivateKey_file(vhost->ssl_ctx,
+					     info->ssl_private_key_filepath,
+							       SSL_FILETYPE_PEM) != 1) {
+					error = ERR_get_error();
+					lwsl_err("ssl problem getting key '%s' %lu: %s\n",
+						 info->ssl_private_key_filepath, error,
+						 ERR_error_string(error,
+						      (char *)context->pt[0].serv_buf));
+					return 1;
+				}
+#endif
+			} else
+				if (vhost->protocols[0].callback(&wsi,
+					LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
+					vhost->ssl_ctx, NULL, 0)) {
+					lwsl_err("ssl private key not set\n");
+
+					return 1;
+				}
+#if !defined(LWS_USE_MBEDTLS)
+			/* verify private key */
+			if (!SSL_CTX_check_private_key(vhost->ssl_ctx)) {
+				lwsl_err("Private SSL key doesn't match cert\n");
 				return 1;
 			}
 #endif
-		} else
-			if (vhost->protocols[0].callback(&wsi,
-				LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-				vhost->ssl_ctx, NULL, 0)) {
-				lwsl_err("ssl private key not set\n");
-
-				return 1;
-			}
-#if !defined(LWS_USE_MBEDTLS)
-		/* verify private key */
-		if (!SSL_CTX_check_private_key(vhost->ssl_ctx)) {
-			lwsl_err("Private SSL key doesn't match cert\n");
-			return 1;
 		}
-#endif
 		if (lws_context_ssl_init_ecdh(vhost))
 			return 1;
 

--- a/test-server/test-server-http.c
+++ b/test-server/test-server-http.c
@@ -38,6 +38,8 @@
 /* location of the certificate revocation list */
 extern char crl_path[1024];
 #endif
+extern char cert_path[1024];
+extern char key_path[1024];
 
 extern int debug_level;
 
@@ -789,6 +791,31 @@ bail:
 		}
 		break;
 #endif
+	case LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT:
+		if (cert_path[0]) {
+			lwsl_notice("Loading server cert %s", cert_path);
+			n = SSL_CTX_use_certificate_chain_file((SSL_CTX*)user, cert_path);
+			if (n != 1) {
+				char errbuf[256];
+				n = ERR_get_error();
+				lwsl_err("LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT: SSL error: %s (%d)\n", ERR_error_string(n, errbuf), n);
+				return 1;
+			}
+		}
+		break;
+
+        case LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY:
+		if (key_path[0]) {
+			lwsl_notice("Loading server private key %s", key_path);
+			n = SSL_CTX_use_PrivateKey_file((SSL_CTX*)user, key_path, SSL_FILETYPE_PEM);
+			if (n != 1) {
+				char errbuf[256];
+				n = ERR_get_error();
+				lwsl_err("LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY: SSL error: %s (%d)\n", ERR_error_string(n, errbuf), n);
+				return 1;
+			}
+		}
+		break;
 #endif
 
 	default:


### PR DESCRIPTION
This patch enables user of libwebsockets library to create server's secure context without providing cert file path. This change is required for systems like where user of libwebsockets library does not have access to file system where certificate is stored or does not provided certificate path for some security reasons and it can get certificate content in binary format from some other module in same system.