### PR TITLE
Creation of secure server context without certificate

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -1299,7 +1299,14 @@ enum lws_callback_reasons {
 	/**< Sent to parent to notify them a child is closing / being
 	 * destroyed.  @in is the child wsi.
 	 */
-
+	LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT	= 70,
+	/**< if configured for including OpenSSL support but no server cert
+	 * file has been specified (ssl_cert_filepath is NULL), this is
+	 * called to allow the user to set the server cert directly via
+	 * libopenssl and perform further operations if required; this might be
+	 * useful in situations where the server cert is not directly accessible
+	 * by the OS, for example if it is stored on a smartcard.
+	 * user is the server's OpenSSL SSL_CTX* */
 	/****** add new things just above ---^ ******/
 
 	LWS_CALLBACK_USER = 1000,
@@ -1865,7 +1872,10 @@ enum lws_context_options {
 	 * listen socket at a time.  This is automatically selected if you
 	 * have multiple service threads.
 	 */
-
+	LWS_SERVER_OPTION_NO_CERT				= (1 << 24),
+	/**< (CTX) creating server context without any certificate and
+	 * private key.
+	 */
 	/****** add new things just above ---^ ******/
 };
 

--- a/test-server/test-server-http.c
+++ b/test-server/test-server-http.c
@@ -38,6 +38,8 @@
 /* location of the certificate revocation list */
 extern char crl_path[1024];
 #endif
+extern char cert_path[1024];
+extern char key_path[1024];
 
 extern int debug_level;
 
@@ -789,6 +791,31 @@ bail:
 		}
 		break;
 #endif
+	case LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT:
+		if (cert_path[0]) {
+			lwsl_notice("Loading server cert %s", cert_path);
+			n = SSL_CTX_use_certificate_chain_file((SSL_CTX*)user, cert_path);
+			if (n != 1) {
+				char errbuf[256];
+				n = ERR_get_error();
+				lwsl_err("LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_CERT: SSL error: %s (%d)\n", ERR_error_string(n, errbuf), n);
+				return 1;
+			}
+		}
+		break;
+
+        case LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY:
+		if (key_path[0]) {
+			lwsl_notice("Loading server private key %s", key_path);
+			n = SSL_CTX_use_PrivateKey_file((SSL_CTX*)user, key_path, SSL_FILETYPE_PEM);
+			if (n != 1) {
+				char errbuf[256];
+				n = ERR_get_error();
+				lwsl_err("LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY: SSL error: %s (%d)\n", ERR_error_string(n, errbuf), n);
+				return 1;
+			}
+		}
+		break;
 #endif
 
 	default:

--- a/test-server/test-server-libev.c
+++ b/test-server/test-server-libev.c
@@ -34,6 +34,9 @@ char *resource_path = LOCAL_RESOURCE_PATH;
 char crl_path[1024] = "";
 #endif
 
+char cert_path[1024] = "";
+char key_path[1024] = "";
+
 #define LWS_PLUGIN_STATIC
 #include "../plugins/protocol_lws_mirror.c"
 #include "../plugins/protocol_lws_status.c"
@@ -180,8 +183,6 @@ int main(int argc, char **argv)
 	char interface_name[128] = "";
 	const char *iface = NULL;
 	ev_timer timeout_watcher;
-	char cert_path[1024];
-	char key_path[1024];
 	int use_ssl = 0;
 	int opts = 0;
 	int n = 0;

--- a/test-server/test-server-libevent.c
+++ b/test-server/test-server-libevent.c
@@ -34,6 +34,9 @@ char *resource_path = LOCAL_RESOURCE_PATH;
 char crl_path[1024] = "";
 #endif
 
+char cert_path[1024] = "";
+char key_path[1024] = "";
+
 #define LWS_PLUGIN_STATIC
 #include "../plugins/protocol_lws_mirror.c"
 #include "../plugins/protocol_lws_status.c"
@@ -174,8 +177,6 @@ int main(int argc, char **argv)
 	char interface_name[128] = "";
 	const char *iface = NULL;
 	struct event *timeout_watcher;
-	char cert_path[1024];
-	char key_path[1024];
 	int use_ssl = 0;
 	int opts = 0;
 	int n = 0;

--- a/test-server/test-server-libuv.c
+++ b/test-server/test-server-libuv.c
@@ -37,6 +37,9 @@ char *resource_path = LOCAL_RESOURCE_PATH;
 char crl_path[1024] = "";
 #endif
 
+char cert_path[1024] = "";
+char key_path[1024] = "";
+
 /* singlethreaded version --> no locks */
 
 void test_server_lock(int care)
@@ -208,8 +211,6 @@ int main(int argc, char **argv)
 /* <--- only needed for foreign loop test --- */
 #endif
 	const char *iface = NULL;
-	char cert_path[1024];
-	char key_path[1024];
 	int use_ssl = 0;
 	int opts = 0;
 	int n = 0;

--- a/test-server/test-server-pthreads.c
+++ b/test-server/test-server-pthreads.c
@@ -37,6 +37,9 @@ struct lws_context *context;
 char crl_path[1024] = "";
 #endif
 
+char cert_path[1024] = "";
+char key_path[1024] = "";
+
 #define LWS_PLUGIN_STATIC
 #include "../plugins/protocol_lws_mirror.c"
 #include "../plugins/protocol_lws_status.c"
@@ -191,8 +194,6 @@ int main(int argc, char **argv)
 	char interface_name[128] = "";
 	const char *iface = NULL;
 	pthread_t pthread_dumb, pthread_service[32];
-	char cert_path[1024];
-	char key_path[1024];
 	int threads = 1;
 	int use_ssl = 0;
 	void *retval;

--- a/test-server/test-server-v2.0.c
+++ b/test-server/test-server-v2.0.c
@@ -48,6 +48,9 @@ char *resource_path = LOCAL_RESOURCE_PATH;
 char crl_path[1024] = "";
 #endif
 
+char cert_path[1024] = "";
+char key_path[1024] = "";
+
 /*
  * This test server is ONLY this .c file, it's radically simpler than the
  * pre-v2.0 test servers.  For example it has no user callback content or
@@ -317,8 +320,6 @@ int main(int argc, char **argv)
 	struct lws_vhost *vhost;
 	char interface_name[128] = "";
 	const char *iface = NULL;
-	char cert_path[1024] = "";
-	char key_path[1024] = "";
 	char ca_path[1024] = "";
 	int uid = -1, gid = -1;
 	int use_ssl = 0;


### PR DESCRIPTION
This patch enables user of libwebsockets library to create server's secure context without providing cert file path. This change is required for systems like where user of libwebsockets library does not have access to file system where certificate is stored or does not provided certificate path for some security reasons and it can get certificate content in binary format from some other module in same system.