### PR TITLE
cgi: fix uint64_t formating

### DIFF
--- a/lib/context.c
+++ b/lib/context.c
@@ -392,7 +392,7 @@ lws_callback_http_dummy(struct lws *wsi, enum lws_callback_reasons reason,
 		break;
 
 	case LWS_CALLBACK_CGI_TERMINATED:
-		lwsl_debug("LWS_CALLBACK_CGI_TERMINATED: %d %lu\n", wsi->cgi->explicitly_chunked, (uint64_t)wsi->cgi->content_length);
+		lwsl_debug("LWS_CALLBACK_CGI_TERMINATED: %d %" PRIu64 "\n", wsi->cgi->explicitly_chunked, (uint64_t)wsi->cgi->content_length);
 		if (!wsi->cgi->explicitly_chunked && !wsi->cgi->content_length) {
 			/* send terminating chunk */
 			lwsl_debug("LWS_CALLBACK_CGI_TERMINATED: looking to send terminating chunk\n");

--- a/lib/private-libwebsockets.h
+++ b/lib/private-libwebsockets.h
@@ -38,6 +38,7 @@
 #include <ctype.h>
 #include <limits.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #if defined(LWS_WITH_ESP32)
 #define MSG_NOSIGNAL 0


### PR DESCRIPTION
On some platforms 'llu' format is needed for uint64_t instead of 'lu'.
PRIu64 format specifier fixes these platform specific issues.

Signed-off-by: Petar Paradzik <petar.paradzik@sartura.hr>