### PR TITLE
mbedtls_wrapper: fix using uninitialized variable

### DIFF
--- a/lib/mbedtls_wrapper/platform/ssl_pm.c
+++ b/lib/mbedtls_wrapper/platform/ssl_pm.c
@@ -669,7 +669,7 @@ int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
 {
 	SSL *ssl = (SSL *)((char *)param - offsetof(SSL, param));
 	struct ssl_pm *ssl_pm = (struct ssl_pm *)ssl->ssl_pm;
-	char *name_cstr;
+	char *name_cstr = NULL;
 
 	if (namelen) {
 		name_cstr = malloc(namelen + 1);


### PR DESCRIPTION
Fixes issues when compiling with "-Werror=maybe-uninitialized".

Signed-off-by: Petar Paradzik <petar.paradzik@sartura.hr>