### PR TITLE
ssl: fix source and destination overlap in strcpy

### DIFF
--- a/lib/tls/openssl/ssl.c
+++ b/lib/tls/openssl/ssl.c
@@ -555,7 +555,7 @@ lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
 		X509_NAME_oneline(xn, buf->ns.name, (int)len - 1);
 		p = strstr(buf->ns.name, "/CN=");
 		if (p)
-			strcpy(buf->ns.name, p + 4);
+			memmove(buf->ns.name, p + 4, sizeof(buf->ns.name));
 		buf->ns.len = (int)strlen(buf->ns.name);
 		return 0;
 


### PR DESCRIPTION
Use memmove instead...

Signed-off-by: Petar Paradzik <petar.paradzik@sartura.hr>