### PR TITLE
add version resource for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 message(STATUS "CMAKE_TOOLCHAIN_FILE='${CMAKE_TOOLCHAIN_FILE}'")
 
+if(WIN32)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/win32port/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/win32port/version.rc @ONLY)
+	set(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/win32port/version.rc)
+endif()
+
 # Try to find the current Git hash.
 find_package(Git)
 if(GIT_EXECUTABLE)
@@ -964,6 +969,7 @@ endif()
 source_group("Headers Private"  FILES ${HDR_PRIVATE})
 source_group("Headers Public"   FILES ${HDR_PUBLIC})
 source_group("Sources"          FILES ${SOURCES})
+source_group("Resources"        FILES ${RESOURCES})
 
 #
 # Create the lib.
@@ -1004,7 +1010,8 @@ if (LWS_WITH_SHARED)
 	add_library(websockets_shared SHARED
 				${HDR_PRIVATE}
 				${HDR_PUBLIC}
-				${SOURCES})
+				${SOURCES}
+				${RESOURCES})
 	list(APPEND LWS_LIBRARIES websockets_shared)
 
 	# We want the shared lib to be named "libwebsockets"

--- a/win32port/version.rc.in
+++ b/win32port/version.rc.in
@@ -1,0 +1,34 @@
+#include <winver.h>
+
+#define LWS_VERSION 	@LWS_LIBRARY_VERSION_MAJOR@,@LWS_LIBRARY_VERSION_MINOR@,@LWS_LIBRARY_VERSION_PATCH@,0
+#define LWS_VERSION_STR "@LWS_LIBRARY_VERSION_MAJOR@.@LWS_LIBRARY_VERSION_MINOR@.@LWS_LIBRARY_VERSION_PATCH@\0"
+#define LWS_PACKAGE_NAME "@PACKAGE@\0"
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    LWS_VERSION
+  PRODUCTVERSION LWS_VERSION
+  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+  FILEFLAGS      0
+  FILEOS         VOS__WINDOWS32
+  FILETYPE       VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "ProductName", LWS_PACKAGE_NAME
+            VALUE "ProductVersion", LWS_VERSION_STR
+            VALUE "FileVersion", LWS_VERSION_STR
+            VALUE "FileDescription", "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.\0"
+			VALUE "InternalName", "websockets.dll\0"
+            VALUE "OriginalFilename", "websockets.dll\0"
+            VALUE "CompanyName", "Open Source Software community LGPL\0"
+            VALUE "LegalCopyright", "Copyright (C) Project contributors\0"
+            VALUE "Comments", "https://libwebsockets.org\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
The Windows build is missing version information.
![image](https://user-images.githubusercontent.com/36075579/35810008-95cdc094-0a8a-11e8-8437-401258def455.png)

For Windows builds a resource file is added that uses the LWS_LIBRARY_VERSION_... variables from the CMakeLists.txt file.
![image](https://user-images.githubusercontent.com/36075579/35810080-d233d636-0a8a-11e8-8163-3e13f8f5d232.png)
