### PR TITLE
Do not pass AI_CANONNAME to getaddrinfo()

### DIFF
--- a/lib/client/client-handshake.c
+++ b/lib/client/client-handshake.c
@@ -20,7 +20,6 @@ lws_getaddrinfo46(struct lws *wsi, const char *ads, struct addrinfo **result)
 	{
 		hints.ai_family = PF_UNSPEC;
 		hints.ai_socktype = SOCK_STREAM;
-		hints.ai_flags = AI_CANONNAME;
 	}
 
 	return getaddrinfo(ads, NULL, &hints, result);

--- a/lib/libwebsockets.c
+++ b/lib/libwebsockets.c
@@ -970,7 +970,6 @@ lws_get_addresses(struct lws_vhost *vh, void *ads, char *name,
 		memset(&ai, 0, sizeof ai);
 		ai.ai_family = PF_UNSPEC;
 		ai.ai_socktype = SOCK_STREAM;
-		ai.ai_flags = AI_CANONNAME;
 #if !defined(LWS_WITH_ESP32)
 		if (getnameinfo((struct sockaddr *)ads,
 				sizeof(struct sockaddr_in),

--- a/test-apps/fuzxy.c
+++ b/test-apps/fuzxy.c
@@ -672,7 +672,6 @@ handle_accept(int n)
 			memset (&ai, 0, sizeof ai);
 			ai.ai_family = PF_UNSPEC;
 			ai.ai_socktype = SOCK_STREAM;
-			ai.ai_flags = AI_CANONNAME;
 
 			if (getaddrinfo(s->address, NULL, &ai, &result)) {
 				lwsl_notice("failed to lookup %s\n",


### PR DESCRIPTION
The reason for removing the flag is that, at with uclibc, it causes reverse DNS lookup even when numeric IP address is passed to `getaddrinfo()`. This causes unnecessary one minute delay when DNS server is configured but unreachable.

In theory this should not break anything since the `ai_canonname` member does not seem to be accessed anywhere in libwebsockets codebase. According `man getaddrinfo` that should be the only difference of using the flag:
> If the AI_CANONNAME bit is set, a successful call to getaddrinfo() will return a NUL-terminated string containing the canonical name of the specified host name in the ai_canonname element of the first addrinfo structure returned.

What do you think?