### PR TITLE
Report unauthorized error when 401 is received, instead of "HS: ACCEPT missing"

### DIFF
--- a/lib/client/client.c
+++ b/lib/client/client.c
@@ -757,6 +757,13 @@ lws_client_interpret_server_handshake(struct lws *wsi)
 		return 0;
 	}
 
+	if (p && strncmp(p, "401", 3)) {
+		lwsl_warn(
+		       "lws_client_handshake: got bad HTTP response '%s'\n", p);
+		cce = "HS: ws upgrade unauthorized";
+		goto bail3;
+	}
+
 	if (p && strncmp(p, "101", 3)) {
 		lwsl_warn(
 		       "lws_client_handshake: got bad HTTP response '%s'\n", p);

--- a/lib/client/client.c
+++ b/lib/client/client.c
@@ -757,16 +757,16 @@ lws_client_interpret_server_handshake(struct lws *wsi)
 		return 0;
 	}
 
-	if (lws_hdr_total_length(wsi, WSI_TOKEN_ACCEPT) == 0) {
-		lwsl_info("no ACCEPT\n");
-		cce = "HS: ACCEPT missing";
-		goto bail3;
-	}
-
 	if (p && strncmp(p, "101", 3)) {
 		lwsl_warn(
 		       "lws_client_handshake: got bad HTTP response '%s'\n", p);
 		cce = "HS: ws upgrade response not 101";
+		goto bail3;
+	}
+
+	if (lws_hdr_total_length(wsi, WSI_TOKEN_ACCEPT) == 0) {
+		lwsl_info("no ACCEPT\n");
+		cce = "HS: ACCEPT missing";
 		goto bail3;
 	}
 

--- a/minimal-examples/minimal-http-client/CMakeLists.txt
+++ b/minimal-examples/minimal-http-client/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(lws-minimal-http-client C)
-
 set(SAMP lws-minimal-http-client)
 set(SRCS minimal-http-client.c)
+
+if (UNIX)
+      set(CMAKE_C_FLAGS "-Wall -Wsign-compare -Wignored-qualifiers -Wtype-limits -Wuninitialized -Werror -Wundef ${CMAKE_C_FLAGS}" )
+endif()
 
 add_executable(${SAMP} ${SRCS})
 target_link_libraries(${SAMP} -lwebsockets)

--- a/minimal-examples/minimal-http-client/minimal-http-client.c
+++ b/minimal-examples/minimal-http-client/minimal-http-client.c
@@ -21,8 +21,6 @@ static int
 callback_http(struct lws *wsi, enum lws_callback_reasons reason,
 	      void *user, void *in, size_t len)
 {
-	const char *p = in;
-
 	switch (reason) {
 
 	/* because we are protocols[0] ... */
@@ -36,11 +34,15 @@ callback_http(struct lws *wsi, enum lws_callback_reasons reason,
 	case LWS_CALLBACK_RECEIVE_CLIENT_HTTP_READ:
 		lwsl_user("RECEIVE_CLIENT_HTTP_READ: read %d\n", (int)len);
 #if 0  /* enable to dump the html */
-		while (len--)
-			if (*p < 0x7f)
-				putchar(*p++);
-			else
-				putchar('.');
+		{
+			const char *p = in;
+
+			while (len--)
+				if (*p < 0x7f)
+					putchar(*p++);
+				else
+					putchar('.');
+		}
 #endif
 		return 0; /* don't passthru */
 

--- a/minimal-examples/minimal-http-server/CMakeLists.txt
+++ b/minimal-examples/minimal-http-server/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(lws-minimal-http-server C)
-
 set(SAMP lws-minimal-http-server)
 set(SRCS minimal-http-server.c)
+
+if (UNIX)
+      set(CMAKE_C_FLAGS "-Wall -Wsign-compare -Wignored-qualifiers -Wtype-limits -Wuninitialized -Werror -Wundef ${CMAKE_C_FLAGS}" )
+endif()
 
 add_executable(${SAMP} ${SRCS})
 target_link_libraries(${SAMP} -lwebsockets)

--- a/minimal-examples/minimal-ws-server-pmd-bulk/CMakeLists.txt
+++ b/minimal-examples/minimal-ws-server-pmd-bulk/CMakeLists.txt
@@ -12,5 +12,9 @@ else()
 	message(FATAL_ERROR "LWS need to have been built for extensions")
 endif()
 
+if (UNIX)
+      set(CMAKE_C_FLAGS "-Wall -Wsign-compare -Wignored-qualifiers -Wtype-limits -Wuninitialized -Werror -Wundef ${CMAKE_C_FLAGS}" )
+endif()
+
 add_executable(${SAMP} ${SRCS})
 target_link_libraries(${SAMP} -lwebsockets)

--- a/minimal-examples/minimal-ws-server-pmd/CMakeLists.txt
+++ b/minimal-examples/minimal-ws-server-pmd/CMakeLists.txt
@@ -9,7 +9,11 @@ set(CMAKE_REQUIRED_LIBRARIES websockets)
 CHECK_FUNCTION_EXISTS(lws_extension_callback_pm_deflate HAVE_PMD)
 if (HAVE_PMD)
 else()
-	message(FATAL_ERROR "LWS need to have been built for extensions")
+	message(FATAL_ERROR "LWS needs to have been built for extensions")
+endif()
+
+if (UNIX)
+      set(CMAKE_C_FLAGS "-Wall -Wsign-compare -Wignored-qualifiers -Wtype-limits -Wuninitialized -Werror -Wundef ${CMAKE_C_FLAGS}" )
 endif()
 
 add_executable(${SAMP} ${SRCS})

--- a/minimal-examples/minimal-ws-server-pmd/protocol_lws_minimal.c
+++ b/minimal-examples/minimal-ws-server-pmd/protocol_lws_minimal.c
@@ -63,13 +63,12 @@ static int
 callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 			void *user, void *in, size_t len)
 {
-	struct per_session_data__minimal **ppss, *pss =
+	struct per_session_data__minimal *pss =
 			(struct per_session_data__minimal *)user;
 	struct per_vhost_data__minimal *vhd =
 			(struct per_vhost_data__minimal *)
 			lws_protocol_vh_priv_get(lws_get_vhost(wsi),
 					lws_get_protocol(wsi));
-	uint32_t oldest;
 	int n, m;
 
 	switch (reason) {
@@ -111,7 +110,7 @@ callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 		/* notice we allowed for LWS_PRE in the payload already */
 		m = lws_write(wsi, vhd->amsg.payload + LWS_PRE, vhd->amsg.len,
 			      LWS_WRITE_TEXT);
-		if (m < vhd->amsg.len) {
+		if (m < (int)vhd->amsg.len) {
 			lwsl_err("ERROR %d writing to di socket\n", n);
 			return -1;
 		}

--- a/minimal-examples/minimal-ws-server-ring/CMakeLists.txt
+++ b/minimal-examples/minimal-ws-server-ring/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(lws-minimal-ws-server C)
-
 set(SAMP lws-minimal-ws-server)
 set(SRCS minimal-ws-server.c)
+
+if (UNIX)
+      set(CMAKE_C_FLAGS "-Wall -Wsign-compare -Wignored-qualifiers -Wtype-limits -Wuninitialized -Werror -Wundef ${CMAKE_C_FLAGS}" )
+endif()
 
 add_executable(${SAMP} ${SRCS})
 target_link_libraries(${SAMP} -lwebsockets)

--- a/minimal-examples/minimal-ws-server-ring/protocol_lws_minimal.c
+++ b/minimal-examples/minimal-ws-server-ring/protocol_lws_minimal.c
@@ -61,7 +61,7 @@ static int
 callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 			void *user, void *in, size_t len)
 {
-	struct per_session_data__minimal **ppss, *pss =
+	struct per_session_data__minimal *pss =
 			(struct per_session_data__minimal *)user;
 	struct per_vhost_data__minimal *vhd =
 			(struct per_vhost_data__minimal *)
@@ -116,7 +116,7 @@ callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 		/* notice we allowed for LWS_PRE in the payload already */
 		m = lws_write(wsi, pmsg->payload + LWS_PRE, pmsg->len,
 			      LWS_WRITE_TEXT);
-		if (m < pmsg->len) {
+		if (m < (int)pmsg->len) {
 			lwsl_err("ERROR %d writing to di socket\n", n);
 			return -1;
 		}
@@ -145,7 +145,7 @@ callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 		/* more to do? */
 		if (lws_ring_get_element(vhd->ring, &pss->tail))
 			/* come back as soon as we can write more */
-			lws_callback_on_writable((*ppss)->wsi);
+			lws_callback_on_writable(pss->wsi);
 		break;
 
 	case LWS_CALLBACK_RECEIVE:

--- a/minimal-examples/minimal-ws-server/CMakeLists.txt
+++ b/minimal-examples/minimal-ws-server/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(lws-minimal-ws-server C)
-
 set(SAMP lws-minimal-ws-server)
 set(SRCS minimal-ws-server.c)
+
+if (UNIX)
+      set(CMAKE_C_FLAGS "-Wall -Wsign-compare -Wignored-qualifiers -Wtype-limits -Wuninitialized -Werror -Wundef ${CMAKE_C_FLAGS}" )
+endif()
 
 add_executable(${SAMP} ${SRCS})
 target_link_libraries(${SAMP} -lwebsockets)

--- a/minimal-examples/minimal-ws-server/protocol_lws_minimal.c
+++ b/minimal-examples/minimal-ws-server/protocol_lws_minimal.c
@@ -63,13 +63,12 @@ static int
 callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 			void *user, void *in, size_t len)
 {
-	struct per_session_data__minimal **ppss, *pss =
+	struct per_session_data__minimal *pss =
 			(struct per_session_data__minimal *)user;
 	struct per_vhost_data__minimal *vhd =
 			(struct per_vhost_data__minimal *)
 			lws_protocol_vh_priv_get(lws_get_vhost(wsi),
 					lws_get_protocol(wsi));
-	uint32_t oldest;
 	int n, m;
 
 	switch (reason) {
@@ -111,8 +110,8 @@ callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
 		/* notice we allowed for LWS_PRE in the payload already */
 		m = lws_write(wsi, vhd->amsg.payload + LWS_PRE, vhd->amsg.len,
 			      LWS_WRITE_TEXT);
-		if (m < vhd->amsg.len) {
-			lwsl_err("ERROR %d writing to di socket\n", n);
+		if (m < (int)vhd->amsg.len) {
+			lwsl_err("ERROR %d writing to ws\n", n);
 			return -1;
 		}
 


### PR DESCRIPTION
See #1200 

The two changes included here are as discussed:

1. Check the response status before checking for the Sec-WebSocket-Accept header 

2. Return `HS: ws upgrade unauthorized` as the failure message when 401 is received.

@lws-team I opted to add a specific message here to avoid issues with having to format a new string to contain the response status, or finding an appropriate place to put it that would be freed (I couldn't find one). I considered creating a new fixed length char array to hold cce writing a formatting string to it (e.g. snprintf), but in the end just opted to keep this simple. Let me know your thoughts and I can revisit if necessary.