### PR TITLE
fixed dead poll

### DIFF
--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -818,12 +818,6 @@ lws_server_socket_service_ssl(struct lws *wsi, lws_sockfd_type accept_fd)
 					wsi->redirect_to_https = 1;
 				goto accepted;
 			}
-			if (!n) /*
-				 * connection is gone, or nothing to read
-				 * if it's gone, we will timeout on
-				 * PENDING_TIMEOUT_SSL_ACCEPT
-				 */
-				break;
 			if (n < 0 && (LWS_ERRNO == LWS_EAGAIN ||
 				      LWS_ERRNO == LWS_EWOULDBLOCK)) {
 				/*


### PR DESCRIPTION
Removed unnecessary and dangerous test for zero read bytes.
I guess, there is no reason for `poll` to trigger a file descriptor in this case except `EOF`. Anyway, the server is hanging up for `timeout_secs` in the `poll` loop on instant client disconnect:
`nc --send-only localhost 8888 < /dev/null`

Tested with:
`ctx.options = LWS_SERVER_OPTION_VALIDATE_UTF8 | LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT | LWS_SERVER_OPTION_ALLOW_NON_SSL_ON_SSL_PORT`