### PR TITLE
Use mbedTLS OPTIONAL verification.

### DIFF
--- a/lib/tls/mbedtls/wrapper/library/ssl_lib.c
+++ b/lib/tls/mbedtls/wrapper/library/ssl_lib.c
@@ -1594,11 +1594,34 @@ void ERR_free_strings(void)
 
 char *ERR_error_string(unsigned long e, char *buf)
 {
-	if (buf) {
-		strcpy(buf, "unknown");
+	if (!buf)
+		return "unknown";
+
+	switch(e) {
+		case X509_V_ERR_INVALID_CA:
+			strcpy(buf, "CA is not trusted");
+			break;
+		case X509_V_ERR_HOSTNAME_MISMATCH:
+			strcpy(buf, "Hostname mismatch");
+			break;
+		case X509_V_ERR_CA_KEY_TOO_SMALL:
+			strcpy(buf, "CA key too small");
+			break;
+		case X509_V_ERR_CA_MD_TOO_WEAK:
+			strcpy(buf, "MD key too weak");
+			break;
+		case X509_V_ERR_CERT_NOT_YET_VALID:
+			strcpy(buf, "Cert from the future");
+			break;
+		case X509_V_ERR_CERT_HAS_EXPIRED:
+			strcpy(buf, "Cert expired");
+			break;
+		default:
+			strcpy(buf, "unknown");
+			break;
 	}
 
-	return "unknown";
+	return buf;
 }
 
 void *SSL_CTX_get_ex_data(const SSL_CTX *ctx, int idx)

--- a/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
+++ b/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
@@ -224,7 +224,7 @@ static int ssl_pm_reload_crt(SSL *ssl)
     struct x509_pm *crt_pm = (struct x509_pm *)ssl->cert->x509->x509_pm;
 
     if (ssl->verify_mode == SSL_VERIFY_PEER)
-        mode = MBEDTLS_SSL_VERIFY_REQUIRED;
+        mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
     else if (ssl->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
         mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
     else if (ssl->verify_mode == SSL_VERIFY_CLIENT_ONCE)
@@ -761,18 +761,47 @@ void ssl_pm_set_bufflen(SSL *ssl, int len)
 
 long ssl_pm_get_verify_result(const SSL *ssl)
 {
-    uint32_t ret;
-    long verify_result;
-    struct ssl_pm *ssl_pm = (struct ssl_pm *)ssl->ssl_pm;
+	uint32_t ret;
+	long verify_result;
+	struct ssl_pm *ssl_pm = (struct ssl_pm *)ssl->ssl_pm;
 
-    ret = mbedtls_ssl_get_verify_result(&ssl_pm->ssl);
-    if (ret) {
-        SSL_DEBUG(SSL_PLATFORM_ERROR_LEVEL, "mbedtls_ssl_get_verify_result() return 0x%x", ret);
-        verify_result = X509_V_ERR_UNSPECIFIED;
-    } else
-        verify_result = X509_V_OK;
+	ret = mbedtls_ssl_get_verify_result(&ssl_pm->ssl);
 
-    return verify_result;
+	if (ret) {
+		if (ret & MBEDTLS_X509_BADCERT_NOT_TRUSTED ||
+			(ret & MBEDTLS_X509_BADCRL_NOT_TRUSTED))
+			verify_result = X509_V_ERR_INVALID_CA;
+
+		else if (ret & MBEDTLS_X509_BADCERT_CN_MISMATCH)
+			verify_result = X509_V_ERR_HOSTNAME_MISMATCH;
+
+		else if ((ret & MBEDTLS_X509_BADCERT_BAD_KEY) ||
+			(ret & MBEDTLS_X509_BADCRL_BAD_KEY))
+			verify_result = X509_V_ERR_CA_KEY_TOO_SMALL;
+
+		else if ((ret & MBEDTLS_X509_BADCERT_BAD_MD) ||
+			(ret & MBEDTLS_X509_BADCRL_BAD_MD))
+			verify_result = X509_V_ERR_CA_MD_TOO_WEAK;
+
+		else if ((ret & MBEDTLS_X509_BADCERT_FUTURE) ||
+			(ret & MBEDTLS_X509_BADCRL_FUTURE))
+			verify_result = X509_V_ERR_CERT_NOT_YET_VALID;
+
+		else if ((ret & MBEDTLS_X509_BADCERT_EXPIRED) ||
+			(ret & MBEDTLS_X509_BADCRL_EXPIRED))
+			verify_result = X509_V_ERR_CERT_HAS_EXPIRED;
+
+		else
+			verify_result = X509_V_ERR_UNSPECIFIED;
+
+		SSL_DEBUG(SSL_PLATFORM_ERROR_LEVEL,
+				  "mbedtls_ssl_get_verify_result() return 0x%x", ret);
+
+	} else {
+		verify_result = X509_V_OK;
+	}
+
+	return verify_result;
 }
 
 /**
@@ -856,13 +885,13 @@ void SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
 	ssl->ctx = ctx;
 	ssl->cert = __ssl_cert_new(ctx->cert);
 
-	    if (ctx->verify_mode == SSL_VERIFY_PEER)
-	        mode = MBEDTLS_SSL_VERIFY_REQUIRED;
-	    else if (ctx->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
-	        mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
-	    else if (ctx->verify_mode == SSL_VERIFY_CLIENT_ONCE)
-	        mode = MBEDTLS_SSL_VERIFY_UNSET;
-	    else
+	if (ctx->verify_mode == SSL_VERIFY_PEER)
+		mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
+	else if (ctx->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+		mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
+	else if (ctx->verify_mode == SSL_VERIFY_CLIENT_ONCE)
+		mode = MBEDTLS_SSL_VERIFY_UNSET;
+	else
 	        mode = MBEDTLS_SSL_VERIFY_NONE;
 
 	    // printf("ssl: %p, client ca x509_crt %p, mbedtls mode %d\n", ssl, x509_pm_ca->x509_crt, mode);


### PR DESCRIPTION
This allows lws to distinguish between untrusted CAs, hostname
mismatches, expired certificates.

**NOTE:** LCCSCF_ALLOW_SELFSIGNED actually allows for untrusted CAs, and
will also skip hostname verification. This is somewhat a limitiation of
the current lws verification process, but I didn't want to change too much and risk breaking compatibility with other libraries. It think it's kind of pointless to do further checks if you accept self-signed, as anyone can self sign a certificate (note, a self-signed certificate added in the CA chain WILL be accepted even in strict mode)

Closes #1214 