### PR TITLE
Removing rudimental n1 variable

### DIFF
--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -39,9 +39,6 @@ lws_context_init_server(struct lws_context_creation_info *info,
 			struct lws_vhost *vhost)
 {
 	int n, opt = 1, limit = 1;
-#if defined(__linux__) && defined(SO_REUSEPORT)
-	int n1;
-#endif
 	lws_sockfd_type sockfd;
 	struct lws_vhost *vh;
 	struct lws *wsi;
@@ -197,13 +194,12 @@ done_list:
 #endif
 
 #if defined(__linux__) && defined(SO_REUSEPORT)
-		n1 = lws_check_opt(vhost->options,
-				  LWS_SERVER_OPTION_ALLOW_LISTEN_SHARE);
 		/* keep coverity happy */
 #if LWS_MAX_SMP > 1
 		n = 1;
 #else
-		n = n1;
+		n = lws_check_opt(vhost->options,
+				  LWS_SERVER_OPTION_ALLOW_LISTEN_SHARE);
 #endif
 		if (n && vhost->context->count_threads > 1)
 			if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT,


### PR DESCRIPTION
There is no real need in n1, since it used in only at one place once. 
Also it will prevent "variable ‘n1’ set but not used [-Werror=unused-but-set-variable]" error on build with -DLWS_MAX_SMP=N, where N > 1.