### PR TITLE
#1279 changed the hexdump is only logged in debug mode instead of rel…

### DIFF
--- a/lib/handshake.c
+++ b/lib/handshake.c
@@ -120,7 +120,9 @@ lws_read(struct lws *wsi, unsigned char *buf, lws_filepos_t len)
 		}
 		lwsl_parser("issuing %d bytes to parser\n", (int)len);
 
+#ifdef _DEBUG
 		lwsl_hexdump(buf, (size_t)len);
+#endif // _DEBUG
 
 		if (lws_handshake_client(wsi, &buf, (size_t)len))
 			goto bail;

--- a/lib/server/server.c
+++ b/lib/server/server.c
@@ -1351,7 +1351,9 @@ lws_handshake_server(struct lws *wsi, unsigned char **buf, size_t len)
 		assert(0);
 	}
 
+#ifdef _DEBUG
 	lwsl_hexdump(*buf, len);
+#endif // _DEBUG
 
 	while (len--) {
 		wsi->more_rx_waiting = !!len;


### PR DESCRIPTION
#1279 changed the "lwsl_hexdump()s" are only logged in debug mode instead of release and debug mode. As your suggestion, here is the patch. 