### PR TITLE
fix memleak when role h1 failed to upgrade to websocket

### DIFF
--- a/lib/roles/h1/ops-h1.c
+++ b/lib/roles/h1/ops-h1.c
@@ -660,6 +660,9 @@ rops_destroy_role_h1(struct lws *wsi)
 		ah = ah->next;
 	}
 
+#ifdef LWS_ROLE_WS
+	lws_free_set_NULL(wsi->ws);
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
if LWS_ROLE_WS is defined, a wsi->ws object is allocated in rops_client_bind_h1 but never destroyed in rops_destroy_role_h1.