### PR TITLE
Add fix for incomplete type in BSD

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -106,7 +106,8 @@ typedef unsigned long long lws_intptr_t;
 #include <sys/capability.h>
 #endif
 
-#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__QNX__)
+#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__QNX__) || defined(__OpenBSD__)
+#include <sys/socket.h>
 #include <netinet/in.h>
 #endif
 


### PR DESCRIPTION
Build fails in OpenBSD and FreeBSD. Need to add `#include <sys/socket.h>` (and also `OpenBSD` detection).

This failure is in the `test-apps`, but the library itself cannot compile either.
```
In file included from /home/godot/libwebsockets/test-apps/test-server.c:21:
/home/godot/libwebsockets/lib/libwebsockets.h:5301:18: error: field has incomplete type 'struct sockaddr'
        struct sockaddr sa;
                        ^
/usr/include/netinet/in.h:582:8: note: forward declaration of 'struct sockaddr'
struct sockaddr;
       ^
In file included from /home/godot/libwebsockets/test-apps/test-server.c:21:
/home/godot/libwebsockets/lib/libwebsockets.h:5304:18: error: field has incomplete type 'struct sockaddr'
        struct sockaddr sa_pending;
                        ^
/usr/include/netinet/in.h:582:8: note: forward declaration of 'struct sockaddr'
struct sockaddr;
       ^
2 errors generated.
```