### PR TITLE
Handle libuv >= 1.21.0 header change.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,6 +667,11 @@ CHECK_LIBRARY_EXISTS(cap cap_set_flag "" LWS_HAVE_LIBCAP)
 
 if (LWS_WITH_LIBUV)
 CHECK_INCLUDE_FILE(uv-version.h LWS_HAVE_UV_VERSION_H)
+  # libuv changed the location in 1.21.0. Retain both
+  # checks temporarily to ensure a smooth transition.
+  if(NOT LWS_HAVE_UV_VERSION_H)
+    CHECK_INCLUDE_FILE(uv/version.h LWS_HAVE_NEW_UV_VERSION_H)
+  endif()
 endif()
 
 

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -166,6 +166,9 @@ typedef unsigned long long lws_intptr_t;
 #ifdef LWS_HAVE_UV_VERSION_H
 #include <uv-version.h>
 #endif
+#ifdef LWS_HAVE_NEW_UV_VERSION_H
+#include <uv/version.h>
+#endif
 #endif /* LWS_WITH_LIBUV */
 #if defined(LWS_WITH_LIBEVENT)
 #include <event2/event.h>


### PR DESCRIPTION
In 1.21.0, the latest release, `libuv` moved from `uv-version.h` to `uv/version.h`. This PR handles that change whilst not immediately killing off the old header check for people & packagers who aren't running the very latest `libuv` release.

This change can be written a whole bunch of different ways so if you'd prefer to do it differently please feel free to do so & reject this.