### PR TITLE
change logic to store next iter prior to logic because logic can inva…

### DIFF
--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -1851,7 +1851,7 @@ lws_check_deferred_free(struct lws_context *context, int tsi, int force)
 
 	lws_context_lock(context, "check deferred free"); /* ------ context { */
 
-	lws_start_foreach_ll(struct lws_vhost *, v, context->vhost_list) {
+	lws_start_foreach_pre_ll(struct lws_vhost *, v, context->vhost_list, vhost_next) {
 		if (v->being_destroyed
 #if LWS_MAX_SMP > 1
 			&& !v->close_flow_vs_tsi[tsi]
@@ -1882,7 +1882,7 @@ lws_check_deferred_free(struct lws_context *context, int tsi, int force)
 
 			lws_pt_unlock(pt); /* } pt -------------- */
 		}
-	} lws_end_foreach_ll(v, vhost_next);
+	} lws_end_foreach_pre_ll(v);
 
 
 	lws_context_unlock(context); /* } context ------------------- */

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -1851,7 +1851,7 @@ lws_check_deferred_free(struct lws_context *context, int tsi, int force)
 
 	lws_context_lock(context, "check deferred free"); /* ------ context { */
 
-	lws_start_foreach_pre_ll(struct lws_vhost *, v, context->vhost_list, vhost_next) {
+	lws_start_foreach_ll2(struct lws_vhost *, v, context->vhost_list, vhost_next) {
 		if (v->being_destroyed
 #if LWS_MAX_SMP > 1
 			&& !v->close_flow_vs_tsi[tsi]
@@ -1882,7 +1882,7 @@ lws_check_deferred_free(struct lws_context *context, int tsi, int force)
 
 			lws_pt_unlock(pt); /* } pt -------------- */
 		}
-	} lws_end_foreach_pre_ll(v);
+	} lws_end_foreach_ll2(v);
 
 
 	lws_context_unlock(context); /* } context ------------------- */

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -5486,6 +5486,42 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 }
 
 /**
+ * lws_start_foreach_pre_ll(): linkedlist iterator helper start (pre increment)
+ *
+ * \param type: type of iteration, eg, struct xyz *
+ * \param it: iterator var name to create
+ * \param start: start of list
+ * \param nxt: member name in the iterator pointing to next list element
+ *
+ * This helper creates an iterator and starts a while (it) {
+ * loop.  The iterator runs through the linked list starting at start and
+ * ends when it gets a NULL.
+ * The while loop should be terminated using lws_start_foreach_pre_ll().
+ * Performs preincrement for situations where iterator can become invalidated
+ * during iteration.
+ */
+#define lws_start_foreach_pre_ll(type, it, start, nxt)\
+{ \
+	type it = start; \
+	while (it) { \
+		type next_##it = it->nxt;
+
+/**
+ * lws_end_foreach_pre_ll(): linkedlist iterator helper end (pre increment)
+ *
+ * \param it: same iterator var name given when starting
+ *
+ * This helper is the partner for lws_start_foreach_pre_ll() that ends the
+ * while loop. It uses the precreated next_ variable already stored during
+ * start.
+ */
+
+#define lws_end_foreach_pre_ll(it) \
+		it = next_##it; \
+	} \
+}
+
+/**
  * lws_start_foreach_llp(): linkedlist pointer iterator helper start
  *
  * \param type: type of iteration, eg, struct xyz **

--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -5486,7 +5486,7 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 }
 
 /**
- * lws_start_foreach_pre_ll(): linkedlist iterator helper start (pre increment)
+ * lws_start_foreach_ll2(): linkedlist iterator helper start (pre increment storage)
  *
  * \param type: type of iteration, eg, struct xyz *
  * \param it: iterator var name to create
@@ -5496,27 +5496,27 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
  * This helper creates an iterator and starts a while (it) {
  * loop.  The iterator runs through the linked list starting at start and
  * ends when it gets a NULL.
- * The while loop should be terminated using lws_start_foreach_pre_ll().
- * Performs preincrement for situations where iterator can become invalidated
+ * The while loop should be terminated using lws_start_foreach_ll2().
+ * Performs storage of next increment for situations where iterator can become invalidated
  * during iteration.
  */
-#define lws_start_foreach_pre_ll(type, it, start, nxt)\
+#define lws_start_foreach_ll2(type, it, start, nxt)\
 { \
 	type it = start; \
 	while (it) { \
 		type next_##it = it->nxt;
 
 /**
- * lws_end_foreach_pre_ll(): linkedlist iterator helper end (pre increment)
+ * lws_end_foreach_ll2(): linkedlist iterator helper end (pre increment storage)
  *
  * \param it: same iterator var name given when starting
  *
- * This helper is the partner for lws_start_foreach_pre_ll() that ends the
+ * This helper is the partner for lws_start_foreach_ll2() that ends the
  * while loop. It uses the precreated next_ variable already stored during
  * start.
  */
 
-#define lws_end_foreach_pre_ll(it) \
+#define lws_end_foreach_ll2(it) \
 		it = next_##it; \
 	} \
 }


### PR DESCRIPTION
@lws-team Here are the changes to allow pre storage of next iter. I can also just change `lws_start_foreach_ll` itself if preferred and update all references. I would just need to move "nxt" from end into the start macro. I am not sure which paths could result in the teardown so I just updated the one I encountered. Let me know your thoughts.