### PR TITLE
if wsi->vhost == vhost then it is already bound to that vhost. doubli…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(LWS_WITH_ACCESS_LOG "Support generating Apache-compatible access logs" OF
 option(LWS_WITH_RANGES "Support http ranges (RFC7233)" OFF)
 option(LWS_WITH_SERVER_STATUS "Support json + jscript server monitoring" OFF)
 option(LWS_WITH_ACME "Enable support for ACME automatic cert acquisition + maintenance (letsencrypt etc)" OFF)
+option(LWS_WITH_GITWS "Enable support for gitws git websockets interface" OFF)
 #
 # TLS library options... all except mbedTLS are basically OpenSSL variants.
 #
@@ -1795,6 +1796,9 @@ if ((LWS_ROLE_H1 OR LWS_ROLE_H2) AND NOT LWS_WITHOUT_TESTAPPS)
 			     INSTALL_DATADIR="${CMAKE_INSTALL_PREFIX}/plugins"
 		)
 
+		SET_TARGET_PROPERTIES(${PLUGIN_NAME}
+                               PROPERTIES COMPILE_FLAGS ${CMAKE_C_FLAGS})
+
 #		set_target_properties(${PLUGIN_NAME}
 #			PROPERTIES
 #			OUTPUT_NAME ${PLUGIN_NAME})
@@ -1812,6 +1816,11 @@ if (LWS_ROLE_WS)
 			      "plugins/protocol_lws_status.c" "" "")
 		create_plugin(protocol_lws_table_dirlisting ""
 			      "plugins/generic-table/protocol_table_dirlisting.c" "" "")
+		if (LWS_WITH_GITWS)
+			create_plugin(protocol_gitws ""
+				      "plugins/gitws/protocol_gitws.c" "" "")
+			target_link_libraries(protocol_gitws jsongit2)
+		endif()
 		if (NOT WIN32)
 			create_plugin(protocol_lws_raw_test ""
 			      "plugins/protocol_lws_raw_test.c" "" "")

--- a/lib/core/libwebsockets.c
+++ b/lib/core/libwebsockets.c
@@ -2731,6 +2731,27 @@ lws_json_purify(char *escaped, const char *string, int len)
 	}
 
 	while (*p && len-- > 6) {
+		if (*p == '\t') {
+			p++;
+			*q++ = '\\';
+			*q++ = 't';
+			continue;
+		}
+
+		if (*p == '\n') {
+			p++;
+			*q++ = '\\';
+			*q++ = 'n';
+			continue;
+		}
+
+		if (*p == '\r') {
+			p++;
+			*q++ = '\\';
+			*q++ = 'r';
+			continue;
+		}
+
 		if (*p == '\"' || *p == '\\' || *p < 0x20) {
 			*q++ = '\\';
 			*q++ = 'u';

--- a/lib/core/private.h
+++ b/lib/core/private.h
@@ -1320,7 +1320,7 @@ lws_handshake_server(struct lws *wsi, unsigned char **buf, size_t len);
 LWS_EXTERN int
 lws_access_log(struct lws *wsi);
 LWS_EXTERN void
-lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int meth);
+lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int len, int meth);
 #else
 #define lws_access_log(_a)
 #endif

--- a/lib/event-libs/libuv/libuv.c
+++ b/lib/event-libs/libuv/libuv.c
@@ -442,6 +442,8 @@ lws_plat_plugins_destroy(struct lws_context *context)
 	void *v;
 	int m;
 
+//	return 0;
+
 #if  defined(__MINGW32__) || !defined(WIN32)
 	pofs = 3;
 #endif

--- a/lib/roles/http/server/access-log.c
+++ b/lib/roles/http/server/access-log.c
@@ -38,14 +38,14 @@ static const char * const hver[] = {
 };
 
 void
-lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int meth)
+lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int uri_len, int meth)
 {
 #ifdef LWS_WITH_IPV6
 	char ads[INET6_ADDRSTRLEN];
 #else
 	char ads[INET_ADDRSTRLEN];
 #endif
-	char da[64];
+	char da[64], uri[256];
 	const char *pa, *me;
 	struct tm *tmp;
 	time_t t = time(NULL);
@@ -81,10 +81,19 @@ lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int meth)
 		if (!me)
 			me = "(null)";
 
+		m = uri_len;
+		if (m > (int)sizeof(uri) - 1)
+			m = sizeof(uri) - 1;
+
+		strncpy(uri, uri_ptr, m);
+		uri[m] = '\0';
+
 		lws_snprintf(wsi->http.access_log.header_log, l,
 			 "%s - - [%s] \"%s %s %s\"",
-			 pa, da, me, uri_ptr,
+			 pa, da, me, uri,
 			 hver[wsi->http.request_version]);
+
+		lwsl_notice("%s\n", wsi->http.access_log.header_log);
 
 		l = lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_USER_AGENT);
 		if (l) {

--- a/lib/roles/http/server/parsers.c
+++ b/lib/roles/http/server/parsers.c
@@ -599,7 +599,8 @@ issue_char(struct lws *wsi, unsigned char c)
 	 * If we haven't hit the token limit, just copy the character into
 	 * the header
 	 */
-	if (frag_len < wsi->http.ah->current_token_limit) {
+	if (!wsi->http.ah->current_token_limit ||
+	    frag_len < wsi->http.ah->current_token_limit) {
 		wsi->http.ah->data[wsi->http.ah->pos++] = c;
 		if (c)
 			wsi->http.ah->frags[wsi->http.ah->nfrag].len++;

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -995,7 +995,7 @@ lws_http_action(struct lws *wsi)
 #endif
 
 #ifdef LWS_WITH_ACCESS_LOG
-	lws_prepare_access_log_info(wsi, uri_ptr, meth);
+	lws_prepare_access_log_info(wsi, uri_ptr, uri_len, meth);
 #endif
 
 	/* can we serve it from the mount list? */
@@ -1286,7 +1286,7 @@ lws_http_action(struct lws *wsi)
 	}
 #endif
 
-	n = (int)strlen(s);
+	n = uri_len - (s - uri_ptr); // (int)strlen(s);
 	if (s[0] == '\0' || (n == 1 && s[n - 1] == '/'))
 		s = (char *)hit->def;
 	if (!s)
@@ -1514,7 +1514,7 @@ raw_transition:
 							&uri_ptr, &uri_len);
 					if (meth >= 0)
 						lws_prepare_access_log_info(wsi,
-								uri_ptr, meth);
+							uri_ptr, uri_len, meth);
 
 					/* wsi close will do the log */
 #endif
@@ -1680,7 +1680,7 @@ lws_http_transaction_completed(struct lws *wsi)
 
 	/* if we can't go back to accept new headers, drop the connection */
 	if (wsi->http2_substream)
-		return 0;
+		return 1;
 
 	if (wsi->seen_zero_length_recv)
 		return 1;

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -1471,7 +1471,7 @@ raw_transition:
 				context, wsi->vhost->listen_port,
 				lws_hdr_simple_ptr(wsi, WSI_TOKEN_HOST));
 
-			if (vhost)
+			if (vhost && wsi->vhost != vhost)
 				lws_vhost_bind_wsi(vhost, wsi);
 		} else
 			lwsl_info("no host\n");

--- a/plugins/gitws/README.md
+++ b/plugins/gitws/README.md
@@ -1,0 +1,73 @@
+## gitws plugin
+
+This plugin allows you to use libjsongit2
+
+https://warmcat.com/git/libjsongit2
+
+to format and present a web view on bare git repos.
+
+## Integration with lwsws
+
+### Enabling the lws-gitws protocol
+
+The plugin is integrated using three per-vhost options in the vhost's ws-protocols section
+
+```
+"ws-protocols": [{
+...
+    "lws-gitws": {
+         "status": "ok",
+         "html-file": "/usr/local/share/libjsongit2/jg2.html",
+         "vpath": "/git",
+         "acl-user": "v-myvhost",
+         "repo-base-dir": "/srv/gitolite/repositories"
+       },
+...
+```
+
+pvo|Function
+---|---
+html-file|The template html file that will have JSON inserted into it
+repo-base-dir|Directory containing the bare repos to present
+vpath|Virtual "mountpoint" for the plugin in the URL space
+acl-user|Gitolite user that controls access to the repos that can be shown for this vhost
+
+libjsongit2 provides an example `jg2.html` template that can be
+modified to suit your vhost's style.
+
+### Adding the related mounts
+
+You also need to apply two mounts on the vhost
+
+```
+    {
+       "mountpoint": "/git",
+       "origin": "callback://lws-gitws"
+    }, {
+       "mountpoint": "/jg2",
+       "origin": "file:///usr/local/share/libjsongit2",
+       "cache-max-age": "60",
+       "cache-reuse": "1",
+       "cache-revalidate": "1",
+       "cache-intermediaries": "0",
+       "extra-mimetypes": {
+                ".zip": "application/zip",
+                ".map": "application/json"
+        }
+    }
+```
+
+The first `/git` mount creates the virtual URL space mapping for the
+plugin's HTML generation.
+
+The second, which can have any mountpoint so long as the html template
+references match it, is used to serve static files like the js and css from
+libjsongit2.
+
+### Adding access control to gitolite
+
+If you add a virtual user to your gitolite config that represents each
+vhost's ability to access repos, libjsongit2 will parse your gitolite config
+and restrict the shown repos accordingly.  Set the vhost's `acl-user` to
+reflect the vhost's "virtual user name" used in the gitolite config.
+

--- a/plugins/gitws/protocol_gitws.c
+++ b/plugins/gitws/protocol_gitws.c
@@ -1,0 +1,342 @@
+/*
+ * gitws - git to websockets bridge
+ *
+ * Copyright (C) 2018 Andy Green <andy@warmcat.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation:
+ *  version 2.1 of the License.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#define LWS_DLL
+#define LWS_INTERNAL
+#include "../lib/libwebsockets.h"
+#include <string.h>
+#include <stdlib.h>
+
+#include <libjsongit2.h>
+
+struct pss_gitws {
+	struct jg2_ctx *ctx;
+	struct lws *wsi;
+	int state;
+};
+
+struct vhd_gitws {
+	struct jg2_vhost *jg2_vhost;
+	const char *html, *vpath, *repo_base_dir, *acl_user;
+};
+
+void refchange(void * user)
+{
+	struct pss_gitws *pss = (struct pss_gitws *)user;
+
+	lwsl_notice("%s: %p\n", __func__, pss);
+
+	lws_callback_on_writable(pss->wsi);
+}
+
+static int
+callback_gitws(struct lws *wsi, enum lws_callback_reasons reason,
+	       void *user, void *in, size_t len)
+{
+	struct pss_gitws *pss = (struct pss_gitws *)user;
+	struct vhd_gitws *vhd = (struct vhd_gitws *)
+			      lws_protocol_vh_priv_get(lws_get_vhost(wsi),
+						       lws_get_protocol(wsi));
+	char buf[LWS_PRE + 4096];
+	unsigned char *p = (unsigned char *)&buf[LWS_PRE], *start = p,
+		      *end = (unsigned char *)buf + sizeof(buf);
+	const char *mimetype;
+	unsigned long length;
+	struct jg2_vhost_config config;
+	int n, m;
+
+	switch (reason) {
+
+	/* --------------- protocol --------------- */
+
+	case LWS_CALLBACK_PROTOCOL_INIT: /* per vhost */
+		lws_protocol_vh_priv_zalloc(lws_get_vhost(wsi),
+					    lws_get_protocol(wsi),
+					    sizeof(struct vhd_gitws));
+		vhd = (struct vhd_gitws *)
+			lws_protocol_vh_priv_get(lws_get_vhost(wsi),
+						 lws_get_protocol(wsi));
+
+		vhd->html = lws_pvo_search(
+				(const struct lws_protocol_vhost_options *)in,
+				"html-file")->value;
+		vhd->vpath = lws_pvo_search(
+				(const struct lws_protocol_vhost_options *)in,
+				"vpath")->value;
+		vhd->repo_base_dir = lws_pvo_search(
+				(const struct lws_protocol_vhost_options *)in,
+				"repo-base-dir")->value;
+		vhd->acl_user = lws_pvo_search(
+				(const struct lws_protocol_vhost_options *)in,
+				"acl-user")->value;
+
+		memset(&config, 0, sizeof(config));
+		config.virtual_base_urlpath = vhd->vpath;
+		config.refchange = refchange;
+		config.repo_base_dir = vhd->repo_base_dir;
+		config.vhost_html_filepath = vhd->html;
+		config.acl_user = vhd->acl_user;
+
+		vhd->jg2_vhost = jg2_vhost_create(&config);
+		if (!vhd->jg2_vhost)
+			return -1;
+
+		lws_timed_callback_vh_protocol(lws_get_vhost(wsi),
+					       lws_get_protocol(wsi),
+					       LWS_CALLBACK_USER, 3);
+		break;
+
+	case LWS_CALLBACK_PROTOCOL_DESTROY: /* per vhost */
+		jg2_vhost_destroy(vhd->jg2_vhost);
+		vhd->jg2_vhost = NULL;
+		break;
+
+	case LWS_CALLBACK_USER:
+
+		jg2_vhost_repo_reflist_update(vhd->jg2_vhost);
+
+		lws_timed_callback_vh_protocol(lws_get_vhost(wsi),
+						lws_get_protocol(wsi),
+						LWS_CALLBACK_USER, 3);
+		break;
+
+#if 0
+	/* --------------- ws --------------- */
+
+	case LWS_CALLBACK_ESTABLISHED:
+		lwsl_notice("%s: LWS_CALLBACK_ESTABLISHED\n", __func__);
+
+		p = start;
+		lws_hdr_copy(wsi, (char *)p, end - p, WSI_TOKEN_GET_URI);
+
+		if (!strncmp((char *)p, vhd->vpath, strlen(vhd->vpath))) {
+			p += strlen(vhd->vpath);
+			start += strlen(vhd->vpath);
+		}
+
+		p += strlen((char *)p);
+
+		n = 0;
+		while (lws_hdr_copy_fragment(wsi, (char *)p + 1, end - p - 2,
+					     WSI_TOKEN_HTTP_URI_ARGS, n) > 0) {
+			if (!n)
+				*p = '?';
+			else
+				*p = '&';
+
+			p += strlen((char *)p);
+			n++;
+		}
+
+		if (jg2_ctx_create(vhd->jg2_vhost, &pss->ctx,
+				   (const char *)start, 0,
+				   &mimetype, &length, NULL, pss)) {
+			lwsl_err("%s: jg2_ctx_create fail\n", __func__);
+			return -1;
+		}
+
+		pss->wsi = wsi;
+		break;
+
+	case LWS_CALLBACK_CLOSED:
+		lwsl_err("%s: LWS_CALLBACK_CLOSED\n", __func__);
+		jg2_ctx_destroy(pss->ctx);
+		break;
+
+	case LWS_CALLBACK_RECEIVE:
+		/*
+		 * 		pss->state = EMIT_STATE_SUMMARY;
+		jg2_ctx_set_job(pss->ctx, jg2_get_job(JG2_JOB_REFLIST),
+				     NULL, 0, 0);
+		lws_callback_on_writable(wsi);
+		 */
+		break;
+
+	case LWS_CALLBACK_SERVER_WRITEABLE:
+
+		if (!jg2_ctx_get_job(pss->ctx))
+			break;
+
+		partway = jg2_ctx_is_partway(pss->ctx);
+
+		m = jg2_ctx_get_job(pss->ctx)(pss->ctx, &buf[LWS_PRE],
+				     sizeof(buf) - LWS_PRE);
+		if (m < 0)
+			return -1;
+
+		if (lws_write(wsi, (unsigned char *)&buf[LWS_PRE],
+			      jg2_ctx_buf_used(pss->ctx),
+			      lws_write_ws_flags(LWS_WRITE_TEXT, !partway,
+					jg2_ctx_is_final(pss->ctx))) < 0) {
+			lwsl_err("write failed: %d %d\n",
+				 jg2_ctx_buf_used(pss->ctx),
+				 lws_write_ws_flags(LWS_WRITE_TEXT, !partway,
+					jg2_ctx_is_final(pss->ctx)));
+			return -1;
+		}
+
+		if (m)
+			lws_callback_on_writable(wsi);
+		else {
+			switch (pss->state) {
+			case EMIT_STATE_SUMMARY:
+				pss->state = EMIT_STATE_SUMMARY_LOG;
+				jg2_ctx_set_job(pss->ctx,
+						jg2_get_job(JG2_JOB_LOG),
+						     "refs/heads/master", 10, 1);
+				lws_callback_on_writable(wsi);
+				break;
+			default:
+				break;
+			}
+		}
+		break;
+#endif
+
+	/* --------------- http --------------- */
+
+	case LWS_CALLBACK_HTTP:
+		/*
+		 * "in" contains the url part after our mountpoint, if any.
+		 *
+		 * Our strategy is to record the URL for the duration of the
+		 * transaction and return the user's configured html template,
+		 * plus JSON prepared based on the URL.  That lets the page
+		 * display remotely in one roundtrip (+tls) without having to
+		 * wait for the ws link to come up.
+		 *
+		 * Serving anything other than the configured html template
+		 * will have to come from outside this mount URL path.
+		 */
+
+		{
+			p = start;
+			if ((int)len >= end - p)
+				len = end - p - 1;
+			memcpy(p, in, len);
+			p += len;
+
+			n = 0;
+			while (lws_hdr_copy_fragment(wsi, (char *)p + 1, end - p - 2,
+						     WSI_TOKEN_HTTP_URI_ARGS, n) > 0) {
+				if (!n)
+					*p = '?';
+				else
+					*p = '&';
+
+				p += strlen((char *)p);
+				n++;
+			}
+
+			*p++ = '\0';
+		}
+
+		if (jg2_ctx_create(vhd->jg2_vhost, &pss->ctx,
+				   (const char *)start, JG2_CTX_FLAG_HTML,
+				   &mimetype, &length, NULL, NULL)) {
+			lwsl_err("%s: jg2_ctx_create fail\n", __func__);
+			return -1;
+		}
+
+		p = start;
+
+		if (lws_add_http_common_headers(wsi, HTTP_STATUS_OK,
+				mimetype, length? length :
+				LWS_ILLEGAL_HTTP_CONTENT_LEN,
+				&p, end))
+			return 1;
+		if (lws_finalize_write_http_header(wsi, start, &p, end))
+			return 1;
+
+		lws_callback_on_writable(wsi);
+		return 0;
+
+	case LWS_CALLBACK_CLOSED_HTTP:
+		lwsl_err("%s: LWS_CALLBACK_CLOSED_HTTP\n", __func__);
+		jg2_ctx_destroy(pss->ctx);
+		return 0;
+
+	case LWS_CALLBACK_HTTP_WRITEABLE:
+
+		if (!pss)
+			break;
+
+		n = LWS_WRITE_HTTP;
+		if (jg2_ctx_fill(pss->ctx, buf + LWS_PRE, sizeof(buf) - LWS_PRE))
+			n = LWS_WRITE_HTTP_FINAL;
+
+		m = jg2_ctx_buf_used(pss->ctx);
+		if (!m)
+			break;
+
+		if (lws_write(wsi, (unsigned char *)buf + LWS_PRE, m, n) != m) {
+			lwsl_err("lws_write failed\n");
+
+			return 1;
+		}
+
+		if (n == LWS_WRITE_HTTP_FINAL) {
+		    if (lws_http_transaction_completed(wsi))
+			return -1;
+		} else
+			lws_callback_on_writable(wsi);
+
+		return 0;
+
+	default:
+		break;
+	}
+
+	return lws_callback_http_dummy(wsi, reason, user, in, len);
+}
+
+static const struct lws_protocols protocols[] = {
+	{
+		"lws-gitws",
+		callback_gitws,
+		sizeof(struct pss_gitws),
+		4096,
+	},
+};
+
+LWS_EXTERN LWS_VISIBLE int
+init_protocol_gitws(struct lws_context *context,
+				struct lws_plugin_capability *c)
+{
+	if (c->api_magic != LWS_PLUGIN_API_MAGIC) {
+		lwsl_err("Plugin API %d, library API %d",
+			 LWS_PLUGIN_API_MAGIC, c->api_magic);
+		return 1;
+	}
+
+	c->protocols = protocols;
+	c->count_protocols = ARRAY_SIZE(protocols);
+	c->extensions = NULL;
+	c->count_extensions = 0;
+
+	return 0;
+}
+
+LWS_EXTERN LWS_VISIBLE int
+destroy_protocol_gitws(struct lws_context *context)
+{
+	return 0;
+}

--- a/plugins/protocol_lws_sshd_demo.c
+++ b/plugins/protocol_lws_sshd_demo.c
@@ -415,6 +415,9 @@ callback_lws_sshd_demo(struct lws *wsi, enum lws_callback_reasons reason,
 	case LWS_CALLBACK_VHOST_CERT_AGING:
 		break;
 
+	case LWS_CALLBACK_EVENT_WAIT_CANCELLED:
+		break;
+
 	default:
 		if (!vhd->ssh_base_protocol) {
 			vhd->ssh_base_protocol = lws_vhost_name_to_protocol(

--- a/test-apps/.gitignore
+++ b/test-apps/.gitignore
@@ -1,9 +1,0 @@
-#Ignore build files
-libwebsockets-test-*
-Makefile
-*.o
-*.lo
-*.la
-.libs
-.deps
-


### PR DESCRIPTION
@lws-team 

I am running a test where the client and server is running on the same process and connecting to one another (in case that aspect is important). With this test, I believe I am seeing a double bind of wsi to a vhost which is stopping proper shutdown. Please note, logs provided are lws log lines from your source.

I modified the bind/unbind log lines to ensure we are comparing the same pointers. Here are my modified log lines for clarity.
https://github.com/warmcat/libwebsockets/blob/master/lib/core/libwebsockets.c#L118
**lws_vhost_bind_wsi:** ```lwsl_info("%s: wsi %p, vh %s(%p): count_bound_wsi %d\n", __func__, wsi, vh->name, vh, vh->count_bound_wsi);```
https://github.com/warmcat/libwebsockets/blob/master/lib/core/libwebsockets.c#L133
**lws_vhost_unbind_wsi:** ```lwsl_info("%s: wsi %p, vh %s(%p): count_bound_wsi %d\n", __func__, wsi, wsi->vhost->name, wsi->vhost, wsi->vhost->count_bound_wsi);```

When the wsi is first created for the vhost, it is bound.  https://github.com/warmcat/libwebsockets/blob/master/lib/core/adopt.c#L67
```Function where bind occurs lws_create_new_server_wsi
--Logs---
level=16 msg=new wsi 0x61400001fa40 joining vhost default, tsi 0
level=8 msg=lws_vhost_bind_wsi: wsi 0x61400001fa40, vh default(0x61700000fc80): count_bound_wsi 2
level=16 msg=lwsi_set_state(0x61400001fa40, 0x200)
```

Later when the handshake occurs, it binds again but to same vhost. https://github.com/warmcat/libwebsockets/blob/master/lib/roles/http/server/server.c#L1466
```
level=32 msg=v13 hdrs done
level=8 msg=lws_handshake_server: parsed count 228
level=32 msg=lws_handshake_server: lws_parse sees parsing complete
level=8 msg=lws_select_vhost: vhost match to default based on port 1234
level=8 msg=lws_vhost_bind_wsi: wsi 0x61400001fa40, vh default(0x61700000fc80): count_bound_wsi 3
```

Isnt wsi already bound to vhost by this point since wsi->vhost resolves? Is it attempting to update the vhost? 

When teardown occurs my shutdown is stalling out. Here is the destroy of the client wsi for the server (but technically this was added twice)
```
level=16 msg=__lws_close_free_wsi_final: wsi 0x61400001fa40: fd 9
LWS_CALLBACK_WSI_DESTROY received at my app layer
level=8 msg=lws_vhost_unbind_wsi: wsi 0x61400001fa40, vh default(0x61700000fc80): count_bound_wsi 2
level=16 msg=__lws_free_wsi: 0x61400001fa40, remaining wsi 2
level=8 msg=__lws_close_free_wsi: 0x61400000fc40: caller: vh destroy
```

Here is the teardown of the wsi for the vhost
```
LWS_CALLBACK_UNLOCK_POLL received at app layer
level=16 msg=lwsi_set_state(0x61400000fc40, 0x1e)
level=16 msg=__lws_close_free_wsi_final: wsi 0x61400000fc40: fd 7
LWS_CALLBACK_WSI_DESTROY received at app layer
level=8 msg=lws_vhost_unbind_wsi: wsi 0x61400000fc40, vh default(0x61700000fc80): count_bound_wsi 1
level=16 msg=__lws_free_wsi: 0x61400000fc40, remaining wsi 1
```

https://github.com/warmcat/libwebsockets/blob/master/lib/roles/http/server/server.c#L1466
Is this line really needed or should it guard against binding to a vhost if it matches the vhost that wsi is already bound to?

When I modify the check to `if (vhost && wsi->vhost != vhost)` it passes.