### PR TITLE
Changed flash_ota and erase_ota to lws_flash_ota and lws_erase_ota

### DIFF
--- a/scripts/esp32.mk
+++ b/scripts/esp32.mk
@@ -93,14 +93,14 @@ all: $(LWS_BUILD_PATH)/pack.img
 
 flash: $(LWS_BUILD_PATH)/pack.img
 
-flash_ota: $(LWS_BUILD_PATH)/pack.img
+lws_flash_ota: $(LWS_BUILD_PATH)/pack.img
 	$(IDF_PATH)/components/esptool_py/esptool/esptool.py \
 		--chip esp32 \
 		--port $(ESPPORT) \
 		--baud $(CONFIG_ESPTOOLPY_BAUD) \
 		write_flash 0x110000 $(LWS_BUILD_PATH)/$(PROJECT_NAME).bin
 
-erase_ota:
+lws_erase_ota:
 	$(IDF_PATH)/components/esptool_py/esptool/esptool.py \
 	        --chip esp32 \
 	        --port $(ESPPORT) \


### PR DESCRIPTION
esp-idf has lately introduced their own version of erase_ota which to my understanding is not erasing the flash-area that matches the lws partition table. While it is possible to compile, warnings are given.

My suggestion is therefore to change the name and also do it for flash_ota for consistency. With this patch the commands to erase (or flash) the ota partition will now be:

make lws_erase_ota
make lws_flash_ota