### PR TITLE
Fix timeout between writes on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ doc
 /build2/
 /build3/
 /cov-int/
+/.vs/

--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -82,9 +82,9 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 			continue;
 
 		wsi = wsi_from_fd(context, pfd->fd);
-		if (wsi->listener)
+		if (!wsi || wsi->listener)
 			continue;
-		if (!wsi || wsi->sock_send_blocking)
+		if (wsi->sock_send_blocking)
 			continue;
 		pfd->revents = LWS_POLLOUT;
 		n = lws_service_fd(context, pfd);

--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -90,6 +90,10 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 		n = lws_service_fd(context, pfd);
 		if (n < 0)
 			return -1;
+
+		/* Force WSAWaitForMultipleEvents() to check events and then return immediately. */
+		timeout_ms = 0;
+
 		/* if something closed, retry this slot */
 		if (n)
 			i--;

--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -93,12 +93,6 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 		/* if something closed, retry this slot */
 		if (n)
 			i--;
-
-		/*
-		 * any wsi has truncated, force him signalled
-		 */
-		if (wsi->trunc_len)
-			WSASetEvent(pt->events);
 	}
 
 	/*


### PR DESCRIPTION
These patches fix #1371 and some minor things on the way.

Most important: after servicing a write request, set timeout to zero, so WSAWaitForMultipleEvents will return immediately and not wait for timeout.