### PR TITLE
Ignore unknown headers in multipart file upload

### DIFF
--- a/lib/roles/http/server/lws-spa.c
+++ b/lib/roles/http/server/lws-spa.c
@@ -270,6 +270,7 @@ retry_as_first:
 				}
 			in++;
 			if (!m) {
+				s->state = MT_IGNORE1; // Unknown header - ignore it
 				s->mp = 0;
 				continue;
 			}


### PR DESCRIPTION
If multipart upload contains header `content-length`, the uploaded file is prepended with `/r/n`.
It seems that libwebsockets accepts only `content-disposition` and `content-type` headers, and any other header causes end in the header processing.
According to https://www.ietf.org/rfc/rfc1341.txt having other headers is valid, so we should ignore them:

> The  only header  fields  that have defined meaning for body parts are those the names of which begin with "Content-".   All  other header  fields  are  generally  to be ignored in body parts.

