### PR TITLE
Fix QTA erase after factory partition update

### DIFF
--- a/include/libwebsockets/lws-esp32.h
+++ b/include/libwebsockets/lws-esp32.h
@@ -109,7 +109,7 @@ static LWS_INLINE void uv_close(uv_handle_t *h, void *v)
 #define LWS_MAGIC_REBOOT_TYPE_REQ_FACTORY 0xb00bcafe
 #define LWS_MAGIC_REBOOT_TYPE_FORCED_FACTORY 0xfaceb00b
 #define LWS_MAGIC_REBOOT_TYPE_FORCED_FACTORY_BUTTON 0xf0cedfac
-
+#define LWS_MAGIC_REBOOT_TYPE_REQ_FACTORY_ERASE_OTA 0xfac0eeee
 
 /* user code provides these */
 

--- a/lib/plat/esp32/esp32-helpers.c
+++ b/lib/plat/esp32/esp32-helpers.c
@@ -1032,14 +1032,12 @@ lws_esp_ota_get_boot_partition(void)
 	                	}
 			}
 
-			/* destroy our OTA image header */
-			spi_flash_erase_range(ota->address, 4096);
-
 			/*
-			 * with no viable OTA image, we will come back up in
+			 * We send a message to the bootloader to erase the OTA header, we will come back up in
 			 * factory where the user can reload the OTA image
 			 */
 			lwsl_notice("  FACTORY copy successful, rebooting\n");
+			lws_esp32_restart_guided(LWS_MAGIC_REBOOT_TYPE_REQ_FACTORY_ERASE_OTA);
 retry:
 			esp_restart();
 		}


### PR DESCRIPTION
This PR together with a PR in lws-esp32-factory fix the problem that the OTA header cannot be erased after doing a factory partition update. 

Solves [https://github.com/warmcat/lws-esp32-factory/issues/35](https://github.com/warmcat/lws-esp32-factory/issues/35)