### PR TITLE
Fix iface is not preserved on redirect

### DIFF
--- a/lib/client/client-handshake.c
+++ b/lib/client/client-handshake.c
@@ -475,7 +475,7 @@ lws_client_reset(struct lws **pwsi, int ssl, const char *address, int port,
 
 	p = lws_hdr_simple_ptr(wsi, _WSI_TOKEN_CLIENT_IFACE);
 	if (p)
-		strncpy(method, p, sizeof(iface) - 1);
+		strncpy(iface, p, sizeof(iface) - 1);
 
 	lwsl_info("redirect ads='%s', port=%d, path='%s', ssl = %d\n",
 		   address, port, path, ssl);


### PR DESCRIPTION
No idea if v2.4-stable is still maintained but if it is, we encountered this issue where interface binding would not work anymore when upgrading from 1.7.9 to 2.4.0.

This is probably due to an unfortunate copy paste of the strncpy line for method.

Note that this has been fixed in v3 by aa816e98a9081bde460c0dea36ba3ecd792bcc06.