### PR TITLE
Fix lws_hdr_total_length match the lws_hdr_copy

### DIFF
--- a/lib/roles/http/server/parsers.c
+++ b/lib/roles/http/server/parsers.c
@@ -459,6 +459,10 @@ LWS_VISIBLE int lws_hdr_total_length(struct lws *wsi, enum lws_token_indexes h)
 	do {
 		len += wsi->http.ah->frags[n].len;
 		n = wsi->http.ah->frags[n].nfrag;
+
+		if (n && h != WSI_TOKEN_HTTP_COOKIE)
+			++len;
+
 	} while (n);
 
 	return len;
@@ -500,6 +504,7 @@ LWS_VISIBLE int lws_hdr_copy(struct lws *wsi, char *dst, int len,
 {
 	int toklen = lws_hdr_total_length(wsi, h);
 	int n;
+	int comma;
 
 	*dst = '\0';
 	if (!toklen)
@@ -516,7 +521,9 @@ LWS_VISIBLE int lws_hdr_copy(struct lws *wsi, char *dst, int len,
 		return 0;
 
 	do {
-		if (wsi->http.ah->frags[n].len + 1 >= len)
+		comma = (wsi->http.ah->frags[n].nfrag && h != WSI_TOKEN_HTTP_COOKIE) ? 1 : 0;
+
+		if (wsi->http.ah->frags[n].len + comma >= len)
 			return -1;
 		strncpy(dst, &wsi->http.ah->data[wsi->http.ah->frags[n].offset],
 		        wsi->http.ah->frags[n].len);
@@ -524,9 +531,9 @@ LWS_VISIBLE int lws_hdr_copy(struct lws *wsi, char *dst, int len,
 		len -= wsi->http.ah->frags[n].len;
 		n = wsi->http.ah->frags[n].nfrag;
 
-		if (n)
-			if (h != WSI_TOKEN_HTTP_COOKIE)
-				*dst++ = ',';
+		if (comma)
+			*dst++ = ',';
+				
 	} while (n);
 	*dst = '\0';
 


### PR DESCRIPTION
I upgrade my code to the matser, but I found a difference from v3.0-stable branch. 
```

@@ -512,13 +516,17 @@ LWS_VISIBLE int lws_hdr_copy(struct lws *wsi, char *dst, int len,
                return 0;

        do {
-               if (wsi->http.ah->frags[n].len >= len)
+               if (wsi->http.ah->frags[n].len + 1 >= len)
                        return -1;
                strncpy(dst, &wsi->http.ah->data[wsi->http.ah->frags[n].offset],
                        wsi->http.ah->frags[n].len);
                dst += wsi->http.ah->frags[n].len;
                len -= wsi->http.ah->frags[n].len;
                n = wsi->http.ah->frags[n].nfrag;
+
+               if (n)
+                       if (h != WSI_TOKEN_HTTP_COOKIE)
+                               *dst++ = ',';
        } while (n);
        *dst = '\0';

```
The lws_hdr_copy function may takes more bytes, but the lws_hdr_total_length  function same as before.
So, if I malloc the bytes base on lws_hdr_total_length, and then use lws_hdr_copy to get the header, it will failed.
And the comma is not add every frag.