### PR TITLE
Fix control messages are inflated

### DIFF
--- a/lib/roles/ws/ext/extension-permessage-deflate.c
+++ b/lib/roles/ws/ext/extension-permessage-deflate.c
@@ -179,7 +179,7 @@ lws_extension_callback_pm_deflate(struct lws_context *context,
 	case LWS_EXT_CB_PAYLOAD_RX:
 		lwsl_ext(" %s: LWS_EXT_CB_PAYLOAD_RX: in %d, existing in %d\n",
 			 __func__, ebuf->len, priv->rx.avail_in);
-		if (!(wsi->ws->rsv_first_msg & 0x40))
+		if (!(wsi->ws->rsv_first_msg & 0x40) || (wsi->ws->opcode & 8))
 			return 0;
 
 		// lwsl_hexdump_debug(ebuf->token, ebuf->len);


### PR DESCRIPTION
RFC7692 states that control messages should not be compressed so there is no
need to inflate these messages.

There can be a bug if a control message is received while processing a
compressed message since lws relies on the RSV bit of the first message to
inflate the rx buffer or not.
Here we also check the opcode to only inflate a message if it is a data message.

Fixes: #1470