### PR TITLE
ws: fix coredump of lws_create_context

### DIFF
--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -363,7 +363,7 @@ lwsl_info("context created\n");
 
 #if LWS_MAX_SMP > 1
 	/* each thread serves his own chunk of fds */
-	for (n = 1; n < (int)info->count_threads; n++)
+	for (n = 1; n < (int)context->count_threads; n++)
 		context->pt[n].fds = context->pt[n - 1].fds +
 				     context->fd_limit_per_thread;
 #endif


### PR DESCRIPTION
if we defined `LWS_MAX_SMP`, `context->pt` has max size of `LWS_MAX_SMP`, `info->context` may large than it, which caused coredump.

Signed-off-by: t00416110 <tanyifeng1@huawei.com>