### PR TITLE
socks5: fix remain dst buffer length when calls lws_strncpy

### DIFF
--- a/lib/roles/http/client/client-handshake.c
+++ b/lib/roles/http/client/client-handshake.c
@@ -1072,14 +1072,14 @@ void socks_generate_msg(struct lws *wsi, enum socks_msg_type type,
 		pt->serv_buf[len++] = n;
 		/* user name */
 		lws_strncpy((char *)&pt->serv_buf[len], wsi->vhost->socks_user,
-			context->pt_serv_buf_size - len + 1);
+			context->pt_serv_buf_size - len);
 		len += n;
 		/* length of the password */
 		pt->serv_buf[len++] = passwd_len;
 		/* password */
 		lws_strncpy((char *)&pt->serv_buf[len],
 			    wsi->vhost->socks_password,
-			    context->pt_serv_buf_size - len + 1);
+			    context->pt_serv_buf_size - len);
 		len += passwd_len;
 		break;
 
@@ -1099,7 +1099,7 @@ void socks_generate_msg(struct lws *wsi, enum socks_msg_type type,
 
 		/* the address we tell SOCKS proxy to connect to */
 		lws_strncpy((char *)&(pt->serv_buf[len]), wsi->stash->address,
-			context->pt_serv_buf_size - len + 1);
+			context->pt_serv_buf_size - len);
 		len += strlen(wsi->stash->address);
 		net_num = htons(wsi->c_port);
 


### PR DESCRIPTION
I've been using the libwebsockets 2.4 very well with the socks option so far.
but when I tried to apply libwebsockets master for my program, I've faced segmentation fault issue.

The different between 2.4.x and master was the length of the parameter in this PR.

According to the man page of strlcpy ...

> The stpncpy() and strncpy() functions copy at most len characters from src into dst.  If src is less than len  characters long, the remainder of dst is filled with `\0' characters.  Otherwise, dst is not terminated.

If you look at the current code in this PR, It tries to copy the string to the dst addr 'pt->server_buf+len' with 'sizeof(pt->serv_buf)-len+1' much length.  The given length means remain buffer length of the dst. But it's 1 byte over.
So, it seems current master code try to fill 1 more byte of '\0' over the actual buffer length. and it is the reason why I'm facing the crash on my testing platform Mac OS X.

After I applied this fix, it worked well same as libwebsockets 2.4.
FYI - I've tested on the Mac OS X Mojave, tested Socks5 server was 'ssh -D 1337'