### PR TITLE
Fix reads getting stuck when the socket has disconnected

### DIFF
--- a/lib/tls/mbedtls/ssl.c
+++ b/lib/tls/mbedtls/ssl.c
@@ -83,6 +83,11 @@ lws_ssl_capable_read(struct lws *wsi, unsigned char *buf, int len)
 	if (n < 0) {
 		m = SSL_get_error(wsi->tls.ssl, n);
 		lwsl_debug("%p: ssl err %d errno %d\n", wsi, m, errno);
+		if (errno == LWS_ENOTCONN) {
+			/* If the socket isn't connected anymore, bail out. */
+			wsi->socket_is_permanently_unusable = 1;
+			return LWS_SSL_CAPABLE_ERROR;
+		}
 		if (m == SSL_ERROR_ZERO_RETURN ||
 		    m == SSL_ERROR_SYSCALL)
 			return LWS_SSL_CAPABLE_ERROR;


### PR DESCRIPTION
We've seen this behaviour when iOS resumes from sleep:

dbg> 0x11cd03750: ssl err dbg> lws_ssl_capable_read: WANT_READ
dbg> 0x11cd03750: LWS_SSL_CAPABLE_MORE_SERVICE
dbg> SSL Capable more service
dbg> 0x11cd03750: SSL_read says -1
dbg> 0x11cd03750: ssl err 2 errno 57
dbg> lws_ssl_capable_read: WANT_READ
dbg> 0x11cd0375dbg> SSL Capable more service
dbg> 0x11cd03750: SSL_read says -1
dbg> 0x11cd03750: ssl err 2 errno 57
dbg> lws_ssl_capable_read: WANT_READ