### PR TITLE
Fix bzero mis-detection on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,7 +723,7 @@ endif()
 
 CHECK_C_SOURCE_COMPILES(
 	"#include <strings.h>
-	int main(int argc, char **argv) { char buf[1]; bzero(buf, 1); return 0; }
+	int main(int argc, char **argv) { char buf[100]; bzero(buf, 100); return 0; }
 	" LWS_HAVE_BZERO)
 CHECK_C_SOURCE_COMPILES(
 	"#include <malloc.h>


### PR DESCRIPTION
Using a C compiler ignores non-existent functions, and tries to link them anyway.

The compiler optimizes `bzero(buf, 1)` to `movb   $0x0,0xf(%esp)`, so bzero is
not called at all, and the linker succeeds.

Increase the buffer size to 100 to avoid this optimization.