### PR TITLE
Fix bzero misdetection also for GCC >=8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,9 @@ endif()
 
 CHECK_C_SOURCE_COMPILES(
 	"#include <strings.h>
+	#if __GNUC__
+	#pragma GCC diagnostic error \"-Wimplicit-function-declaration\"
+	#endif
 	int main(int argc, char **argv) { char buf[100]; bzero(buf, 100); return 0; }
 	" LWS_HAVE_BZERO)
 CHECK_C_SOURCE_COMPILES(


### PR DESCRIPTION
The fix in 1d6128d1fe76e6148cd9955db38be39481526f65 worked for
MinGW with GCC7, but GCC8 evidentially got smarter, and it
also substitutes bzero->memset for larger arrays.

Set the emitted warning as an error to avoid misdetection.