### PR TITLE
listen: Fix strict-aliasing warning on GCC 4.1

### DIFF
--- a/lib/roles/listen/ops-listen.c
+++ b/lib/roles/listen/ops-listen.c
@@ -106,9 +106,13 @@ rops_handle_POLLIN_listen(struct lws_context_per_thread *pt, struct lws *wsi,
 			ntohs(((struct sockaddr_in *) &cli_addr)->sin_port)),
 			accept_fd);
 #else
+		{
+		struct sockaddr_in sain;
+		memcpy(&sain, &cli_addr, sizeof(sain));
 		lwsl_debug("accepted new conn port %u on fd=%d\n",
-			   ntohs(((struct sockaddr_in *) &cli_addr)->sin_port),
+			   ntohs(sain.sin_port),
 			   accept_fd);
+		}
 #endif
 
 		/*


### PR DESCRIPTION
This fix is similar to 4afeefbb3cc8185a89626364b0babc5998ced581.