### PR TITLE
openssl-server: Fix null dereference

### DIFF
--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -121,7 +121,7 @@ lws_ssl_server_name_cb(SSL *ssl, int *ad, void *arg)
 	servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
 	if (!servername) {
 		/* the client doesn't know what hostname it wants */
-		lwsl_info("SNI: Unknown ServerName: %s\n", servername);
+		lwsl_info("SNI: Unknown ServerName\n");
 
 		return SSL_TLSEXT_ERR_OK;
 	}


### PR DESCRIPTION
Reported by GCC9.