### PR TITLE
Clang compatibility and Windows pipe fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1350,7 +1350,11 @@ if (UNIX)
 	endif()
 endif()
 
-if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+if ((CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+	set(COMPILER_IS_CLANG ON)
+endif()
+
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG)
     include (CheckCCompilerFlag)
     CHECK_C_COMPILER_FLAG(-fvisibility=hidden LWS_HAVE_VISIBILITY)
     if (LWS_HAVE_VISIBILITY)
@@ -1361,7 +1365,10 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_C_COMPILER_ID 
     endif()
 
 	if (LWS_WITH_ASAN)
-		set (ASAN_FLAGS "-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined -fsanitize-address-use-after-scope -fsanitize-undefined-trap-on-error")
+		set (ASAN_FLAGS "-fsanitize=address -fsanitize=undefined -fsanitize-address-use-after-scope -fsanitize-undefined-trap-on-error")
+		if (NOT COMPILER_IS_CLANG)
+			set (ASAN_FLAGS "${ASAN_FLAGS} -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak")
+		endif()
 		message("Enabling ASAN")
 	endif()
 
@@ -1395,7 +1402,7 @@ if ((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND NOT LWS_WITHOUT_TE
     endif()
 endif()
 
-if ((CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+if (COMPILER_IS_CLANG)
 
 	# otherwise osx blows a bunch of openssl deprecated api errors
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations" )
@@ -1501,7 +1508,7 @@ endif()
 
 # Set the so version of the lib.
 # Equivalent to LDFLAGS=-version-info x:x:x
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG)
 	foreach(lib ${LWS_LIBRARIES})
 		set_target_properties(${lib}
 			PROPERTIES

--- a/lib/core-net/private.h
+++ b/lib/core-net/private.h
@@ -344,6 +344,9 @@ struct lws_context_per_thread {
 	unsigned char inside_service:1;
 	unsigned char event_loop_foreign:1;
 	unsigned char event_loop_destroy_processing_done:1;
+#ifdef _WIN32
+    unsigned char interrupt_requested:1;
+#endif
 };
 
 struct lws_conn_stats {

--- a/lib/core-net/private.h
+++ b/lib/core-net/private.h
@@ -289,6 +289,7 @@ struct lws_context_per_thread {
 	volatile struct lws_foreign_thread_pollfd * volatile foreign_pfd_list;
 #ifdef _WIN32
 	WSAEVENT events;
+	CRITICAL_SECTION interrupt_lock;
 #endif
 	lws_sockfd_type dummy_pipe_fds[2];
 	struct lws *pipe_wsi;
@@ -345,7 +346,7 @@ struct lws_context_per_thread {
 	unsigned char event_loop_foreign:1;
 	unsigned char event_loop_destroy_processing_done:1;
 #ifdef _WIN32
-    unsigned char interrupt_requested:1;
+	unsigned char interrupt_requested:1;
 #endif
 };
 

--- a/lib/plat/windows/windows-init.c
+++ b/lib/plat/windows/windows-init.c
@@ -71,6 +71,7 @@ lws_plat_init(struct lws_context *context,
 	while (n--) {
 		pt->fds_count = 0;
 		pt->events = WSACreateEvent(); /* the cancel event */
+		InitializeCriticalSection(&pt->interrupt_lock);
 
 		pt++;
 	}
@@ -93,6 +94,7 @@ lws_plat_context_early_destroy(struct lws_context *context)
 
 	while (n--) {
 		WSACloseEvent(pt->events);
+		DeleteCriticalSection(&pt->interrupt_lock);
 		pt++;
 	}
 }

--- a/lib/plat/windows/windows-pipe.c
+++ b/lib/plat/windows/windows-pipe.c
@@ -35,6 +35,7 @@ lws_plat_pipe_signal(struct lws *wsi)
 {
 	struct lws_context_per_thread *pt = &wsi->context->pt[(int)wsi->tsi];
 
+    pt->interrupt_requested = 1;
 	WSASetEvent(pt->events); /* trigger the cancel event */
 
 	return 0;

--- a/lib/plat/windows/windows-pipe.c
+++ b/lib/plat/windows/windows-pipe.c
@@ -35,7 +35,9 @@ lws_plat_pipe_signal(struct lws *wsi)
 {
 	struct lws_context_per_thread *pt = &wsi->context->pt[(int)wsi->tsi];
 
-    pt->interrupt_requested = 1;
+	EnterCriticalSection(&pt->interrupt_lock);
+	pt->interrupt_requested = 1;
+	LeaveCriticalSection(&pt->interrupt_lock);
 	WSASetEvent(pt->events); /* trigger the cancel event */
 
 	return 0;

--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -137,6 +137,12 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 
 	ev = WSAWaitForMultipleEvents(1, &pt->events, FALSE, timeout_ms, FALSE);
 	if (ev == WSA_WAIT_EVENT_0) {
+        if(pt->interrupt_requested) {
+            pt->interrupt_requested = 0;
+            lws_broadcast(context, LWS_CALLBACK_EVENT_WAIT_CANCELLED, NULL, 0);
+            return 0;
+        }
+
 		unsigned int eIdx;
 
 #if defined(LWS_WITH_TLS)

--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -137,11 +137,14 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 
 	ev = WSAWaitForMultipleEvents(1, &pt->events, FALSE, timeout_ms, FALSE);
 	if (ev == WSA_WAIT_EVENT_0) {
-        if(pt->interrupt_requested) {
-            pt->interrupt_requested = 0;
-            lws_broadcast(context, LWS_CALLBACK_EVENT_WAIT_CANCELLED, NULL, 0);
-            return 0;
-        }
+		EnterCriticalSection(&pt->interrupt_lock);
+		const int interrupt_requested = pt->interrupt_requested;
+		pt->interrupt_requested = 0;
+		LeaveCriticalSection(&pt->interrupt_lock);
+		if(interrupt_requested) {
+			lws_broadcast(context, LWS_CALLBACK_EVENT_WAIT_CANCELLED, NULL, 0);
+			return 0;
+		}
 
 		unsigned int eIdx;
 


### PR DESCRIPTION
See discussion at bottom of #1291 

The summary is that since Windows does not have a reliable POSIX pipe and polling mechanism that `lws_cancel_service` often fails to broadcast messages when it is called.  This adds some Windows specific logic to address that in a threadsafe way.

In addition, some fixes to the CMake project are there to make sure that the ASAN mode is compatible with the clang compiler flags.