### PR TITLE
fix wrong return code in server.c

### DIFF
--- a/lib/libwebsockets.h
+++ b/lib/libwebsockets.h
@@ -2653,6 +2653,10 @@ enum lws_context_options {
 	 * example the ACME plugin was configured to fetch a cert, this lets
 	 * you bootstrap your vhost from having no cert to start with.
 	 */
+	LWS_SERVER_OPTION_FAIL_UPON_UNABLE_TO_BIND      = (1 << 27),
+	/**< (VH) When instantiating a new vhost and the specified port is
+	 * already in use, a null value shall be return to signal the error.
+	 */
 
 	/****** add new things just above ---^ ******/
 };

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -119,13 +119,15 @@ done_list:
 			if (info) /* first time */
 				lwsl_err("VH %s: iface %s port %d DOESN'T EXIST\n",
 				 vhost->name, vhost->iface, vhost->listen_port);
-			return 1;
+			return (info->options & LWS_SERVER_OPTION_FAIL_UPON_UNABLE_TO_BIND) == LWS_SERVER_OPTION_FAIL_UPON_UNABLE_TO_BIND?
+				-1 : 1;
 		case LWS_ITOSA_NOT_USABLE:
 			/* can't add it */
 			if (info) /* first time */
 				lwsl_err("VH %s: iface %s port %d NOT USABLE\n",
 				 vhost->name, vhost->iface, vhost->listen_port);
-			return 1;
+			return (info->options & LWS_SERVER_OPTION_FAIL_UPON_UNABLE_TO_BIND) == LWS_SERVER_OPTION_FAIL_UPON_UNABLE_TO_BIND?
+				-1 : 1;
 		}
 	}
 


### PR DESCRIPTION
I was trying to use `lws_vhost_create` and when the port is not available it did not return a null, did a little digging and found out that there're a couple of returns that return a positive number.