### PR TITLE
Added LWS_CALLBACK_OPENSSL_SERVER_NAME callback 

### DIFF
--- a/include/libwebsockets/lws-callbacks.h
+++ b/include/libwebsockets/lws-callbacks.h
@@ -153,6 +153,13 @@ enum lws_callback_reasons {
 	 * by the OS, for example if it is stored on a smartcard.
 	 * user is the server's OpenSSL SSL_CTX* */
 
+    LWS_CALLBACK_OPENSSL_SERVER_NAME = 102,
+    /**< this callback is called after a vhost accepted the connection and read
+     * the server name from the SSL SNI header. This callback can be used to
+     * update the vhost SSL context just before the SSL handshake, which can
+     * for example be used for building SSL mitm (man-in-the-middle) proxies.
+     * user is the server's OpenSSL SSL_CTX, an in is the LNI server name */
+
 	LWS_CALLBACK_SSL_INFO					= 67,
 	/**< SSL connections only.  An event you registered an
 	 * interest in at the vhost has occurred on a connection

--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -96,6 +96,7 @@ lws_ssl_server_name_cb(SSL *ssl, int *ad, void *arg)
 	struct lws_context *context = (struct lws_context *)arg;
 	struct lws_vhost *vhost, *vh;
 	const char *servername;
+	struct lws *wsi;
 
 	if (!ssl)
 		return SSL_TLSEXT_ERR_NOACK;
@@ -134,6 +135,11 @@ lws_ssl_server_name_cb(SSL *ssl, int *ad, void *arg)
 	}
 
 	lwsl_info("SNI: Found: %s:%d\n", servername, vh->listen_port);
+
+	wsi = SSL_get_ex_data(ssl, openssl_websocket_private_data_index);
+	if (vhost->protocols[0].callback(wsi,
+				LWS_CALLBACK_OPENSSL_SERVER_NAME,
+				vhost->tls.ssl_ctx, (char *)servername, 0))
 
 	/* select the ssl ctx from the selected vhost for this conn */
 	SSL_set_SSL_CTX(ssl, vhost->tls.ssl_ctx);


### PR DESCRIPTION
This allows for for updating SSL_CTX context after the SNI name is detected, but before
the SSL handshake is performed - handy for implementing MITM https
proxy, for example.