### PR TITLE
sul_compare integer overflow bug

### DIFF
--- a/lib/core-net/sorted-usec-list.c
+++ b/lib/core-net/sorted-usec-list.c
@@ -27,8 +27,18 @@
 static int
 sul_compare(const lws_dll2_t *d, const lws_dll2_t *i)
 {
-	return ((lws_sorted_usec_list_t *)d)->us -
-			((lws_sorted_usec_list_t *)i)->us;
+    lws_usec_t a = ((lws_sorted_usec_list_t *)d)->us;
+    lws_usec_t b = ((lws_sorted_usec_list_t *)i)->us;
+
+    /* returning (a - b) may lead to an integer overlow bug */
+
+    if (a > b) {
+        return 1;
+    } else if (a < b) {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 int

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -217,7 +217,7 @@ lws_client_socket_service(struct lws *wsi, struct lws_pollfd *pollfd,
 			lwsl_client("SOCKS password OK, sending connect\n");
 			if (socks_generate_msg(wsi, SOCKS_MSG_CONNECT, &len)) {
 socks_send_msg_fail:
-				*cce = "socks gen msg fail";
+				cce = "socks gen msg fail";
 				goto bail3;
 			}
 			conn_mode = LRS_WAITING_SOCKS_CONNECT_REPLY;


### PR DESCRIPTION
If the value of `a` is much bigger than `b` it may lead to an integer overflow bug.
I found this issue when our client app hanged in `poll` function call for 23 hours waiting for SSL certificate check to trigger.