### PR TITLE
Fix warnings/errors for WIN64

### DIFF
--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -100,8 +100,6 @@ typedef unsigned long long lws_intptr_t;
 #else
 #define LWS_EXTERN extern __declspec(dllimport)
 #endif
-#else
-#define LWS_EXTERN
 #endif
 #endif
 

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -885,7 +885,7 @@ user_callback_handle_rxflow(lws_callback_function, struct lws *wsi,
 			    void *in, size_t len);
 
 LWS_EXTERN int
-lws_plat_set_nonblocking(int fd);
+lws_plat_set_nonblocking(lws_sockfd_type fd);
 
 LWS_EXTERN int
 lws_plat_set_socket_options(struct lws_vhost *vhost, lws_sockfd_type fd,

--- a/lib/core/libwebsockets.c
+++ b/lib/core/libwebsockets.c
@@ -149,7 +149,7 @@ lws_hex_to_byte_array(const char *h, uint8_t *dest, int max)
 	if (max < 0)
 		return -1;
 
-	return dest - odest;
+	return (int)(dest - odest);
 }
 
 

--- a/lib/misc/lejp.c
+++ b/lib/misc/lejp.c
@@ -146,7 +146,8 @@ void
 lejp_check_path_match(struct lejp_ctx *ctx)
 {
 	const char *p, *q;
-	int n, s = sizeof(char *);
+	int n;
+	size_t s = sizeof(char *);
 
 	if (ctx->path_stride)
 		s = ctx->path_stride;

--- a/lib/misc/lws-struct-lejp.c
+++ b/lib/misc/lws-struct-lejp.c
@@ -32,7 +32,7 @@ lws_struct_schema_only_lejp_cb(struct lejp_ctx *ctx, char reason)
 {
 	lws_struct_args_t *a = (lws_struct_args_t *)ctx->user;
 	const lws_struct_map_t *map = a->map_st[ctx->pst_sp];
-	int n = a->map_entries_st[ctx->pst_sp];
+	size_t n = a->map_entries_st[ctx->pst_sp];
 	lejp_callback cb = map->lejp_cb;
 
 	if (reason != LEJPCB_VAL_STR_END || ctx->path_match != 1)
@@ -93,7 +93,7 @@ lws_struct_default_lejp_cb(struct lejp_ctx *ctx, char reason)
 	const lws_struct_map_t *map, *pmap = NULL;
 	uint8_t *ch;
 	char *u;
-	int n;
+	size_t n;
 
 	if (reason == LEJPCB_ARRAY_END) {
 		lejp_parser_pop(ctx);

--- a/lib/plat/windows/private-lib-plat-windows.h
+++ b/lib/plat/windows/private-lib-plat-windows.h
@@ -133,7 +133,7 @@ struct lws_fd_hashtable {
 #define LWS_EXTERN extern __declspec(dllimport)
 #endif
 #else
-#define LWS_EXTERN
+#define LWS_EXTERN extern
 #endif
 
 typedef SOCKET lws_sockfd_type;

--- a/lib/plat/windows/windows-sockets.c
+++ b/lib/plat/windows/windows-sockets.c
@@ -67,7 +67,7 @@ lws_poll_listen_fd(struct lws_pollfd *fd)
 }
 
 int
-lws_plat_set_nonblocking(int fd)
+lws_plat_set_nonblocking(lws_sockfd_type fd)
 {
 	u_long optl = 1;
 


### PR DESCRIPTION
Various issues on windows 64 bit builds.  Socket types cannot be ints, size_t isn't int, and externs must be extern when declaring arrays, as in `extern int my_array[];`.  Newly introduced extern arrays caused errors when being compiled into non-dlls on windows.
Problems were discovered in 3.2 stable, and if accepted, possibly should be back-ported.