### PR TITLE
Windows fixes

### DIFF
--- a/lib/plat/windows/windows-sockets.c
+++ b/lib/plat/windows/windows-sockets.c
@@ -120,10 +120,10 @@ lws_plat_set_socket_options(struct lws_vhost *vhost, lws_sockfd_type fd,
 	tcp_proto = getprotobyname("TCP");
 	if (!tcp_proto) {
 		int error = LWS_ERRNO;
-		lwsl_err("getprotobyname() failed with error %d\n", error);
-		return 1;
-	}
-	protonbr = tcp_proto->p_proto;
+		lwsl_warn("getprotobyname(\"TCP\") failed with error, falling back to 6 %d\n", error);
+		protonbr = 6;  /* IPPROTO_TCP */
+	} else
+		protonbr = tcp_proto->p_proto;
 #else
 	protonbr = 6;
 #endif

--- a/lib/roles/h2/http2.c
+++ b/lib/roles/h2/http2.c
@@ -2378,7 +2378,7 @@ lws_h2_ws_handshake(struct lws *wsi)
 			if (lws_add_http_header_by_token(wsi, WSI_TOKEN_PROTOCOL,
 				(uint8_t *)lws_hdr_simple_ptr(wsi,
 							   WSI_TOKEN_PROTOCOL),
-				strlen(lws_hdr_simple_ptr(wsi,
+				(int)strlen(lws_hdr_simple_ptr(wsi,
 							   WSI_TOKEN_PROTOCOL)),
 						 &p, end))
 			return -1;

--- a/lib/tls/openssl/openssl-x509.c
+++ b/lib/tls/openssl/openssl-x509.c
@@ -242,7 +242,7 @@ lws_x509_parse_from_pem(struct lws_x509_cert *x509, const void *pem, size_t len)
 {
 	BIO* bio = BIO_new(BIO_s_mem());
 
-	BIO_write(bio, pem, len);
+	BIO_write(bio, pem, (int)len);
 	x509->cert = PEM_read_bio_X509(bio, NULL, NULL, NULL);
 	BIO_free(bio);
 	if (!x509->cert) {
@@ -496,7 +496,7 @@ lws_x509_jwk_privkey_pem(struct lws_jwk *jwk, void *pem, size_t len,
 	const BIGNUM *cmpi;
 	int n, m, ret = -1;
 
-	BIO_write(bio, pem, len);
+	BIO_write(bio, pem, (int)len);
 	PEM_read_bio_PrivateKey(bio, &pkey, lws_x509_jwk_privkey_pem_pp_cb,
 				(void *)passphrase);
 	BIO_free(bio);


### PR DESCRIPTION
This pull requests combines three things:
1) explicit conversion from size_t to int to remove warnings on win64 platforms
2) Added error logging for some windows socket APIS
3) fallback if getprotobyname("TCP") fails, as has been observed in the wild.  The value 6 is universal, but I assume that there is a good reason for using this api never the less.

There remains one case of implicit size coercion not addressed,
```
  D:\git\libwebsockets\lib\roles\http\server\server.c(701): warning C4244: '=': conversion from '__int64' to 'char', possible loss of data
```
I leavi ti to the discression of the maintainer to find an adequate fix / check for that.