### PR TITLE
Get thread service index wsi belong to

### DIFF
--- a/include/libwebsockets/lws-misc.h
+++ b/include/libwebsockets/lws-misc.h
@@ -580,6 +580,15 @@ lws_dir(const char *dirpath, void *user, lws_dir_callback_function cb);
 size_t lws_get_allocated_heap(void);
 
 /**
+ * lws_get_tsi() - Get thread service index wsi belong to
+ * \param wsi:  websocket connection to check
+ *
+ * Returns more than zero (or zero if only one service thread as is the default).
+ */
+LWS_VISIBLE LWS_EXTERN int
+lws_get_tsi(struct lws *wsi);
+
+/**
  * lws_is_ssl() - Find out if connection is using SSL
  * \param wsi:	websocket connection to check
  *

--- a/lib/core-net/wsi.c
+++ b/lib/core-net/wsi.c
@@ -400,7 +400,11 @@ lws_adjust_protocol_psds(struct lws *wsi, size_t new_size)
 	return wsi->user_space;
 }
 
-
+LWS_VISIBLE int
+lws_get_tsi(struct lws *wsi)
+{
+        return (int)wsi->tsi;
+}
 
 LWS_VISIBLE int
 lws_is_ssl(struct lws *wsi)


### PR DESCRIPTION
Its needed when using external 'epoll' event loop (SMP) with separated epoll file descriptors for each service thread.