### PR TITLE
Ensure that timeout events are serviced even when polling on windows.

### DIFF
--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -130,7 +130,10 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 	if (!lws_service_adjust_timeout(context, 1, tsi))
 		_lws_plat_service_forced_tsi(context, tsi);
 
-	if (timeout_us) {
+	/*
+	 * service pending callbakcs and get maximum wait time
+	 */
+	{
 		lws_usec_t us;
 
 		lws_pt_lock(pt, __func__);


### PR DESCRIPTION
Previously the timeout queue would only be polled if the supplied timeout was non-zero.  This caused functionality such as ping/pong and other timeout dependent things to stop working in polling mode.
This patch makes the behaviour similar to the platform esp32_service.c