### PR TITLE
lib/core-net/close.c: Fix off-by-one error for lws_inform_client_conn…

### DIFF
--- a/lib/core-net/close.c
+++ b/lib/core-net/close.c
@@ -452,10 +452,10 @@ just_kill_connection:
 	     lwsi_state(wsi) == LRS_WAITING_DNS ||
 	     lwsi_state(wsi) == LRS_WAITING_CONNECT) &&
 	     !wsi->already_did_cce && wsi->protocol) {
-		static const char reason[] = "closed before established";
+		static const char fail_reason[] = "closed before established";
 
 		lws_inform_client_conn_fail(wsi,
-			(void *)reason, sizeof(reason));
+			(void *)fail_reason, sizeof(fail_reason));
 	}
 #endif
 

--- a/lib/core-net/close.c
+++ b/lib/core-net/close.c
@@ -451,9 +451,12 @@ just_kill_connection:
 	if ((lwsi_state(wsi) == LRS_WAITING_SERVER_REPLY ||
 	     lwsi_state(wsi) == LRS_WAITING_DNS ||
 	     lwsi_state(wsi) == LRS_WAITING_CONNECT) &&
-	     !wsi->already_did_cce && wsi->protocol)
+	     !wsi->already_did_cce && wsi->protocol) {
+		static const char reason[] = "closed before established";
+
 		lws_inform_client_conn_fail(wsi,
-				(void *)"closed before established", 24);
+			(void *)reason, sizeof(reason));
+	}
 #endif
 
 	/*


### PR DESCRIPTION
This fixes an off-by-one error by letting the compiler help us by calculating the string size. We where missing the last character in our logline.