### PR TITLE
lws_create_vhost compile failure with +SOCKS5 -client.

### DIFF
--- a/lib/core-net/vhost.c
+++ b/lib/core-net/vhost.c
@@ -437,7 +437,7 @@ lws_create_vhost(struct lws_context *context,
 	struct lws_protocols *lwsp;
 	int m, f = !info->pvo, fx = 0, abs_pcol_count = 0;
 	char buf[96];
-#if !defined(LWS_WITHOUT_CLIENT) && defined(LWS_HAVE_GETENV)
+#if (!defined(LWS_WITHOUT_CLIENT) || defined(LWS_WITH_SOCKS5)) && defined(LWS_HAVE_GETENV)
 	char *p;
 #endif
 	int n;


### PR DESCRIPTION
If LWS is build with SOCKS5 support, but WITHOUT_CLIENT then a compile
failure occurs which this fixes.

Signed-off-by: Jaco Kroon <jaco@iewc.co.za>