### PR TITLE
core-net/vhost Compile errors with SOCKS5 but WITHOUT_CLIENT.

### DIFF
--- a/lib/core-net/vhost.c
+++ b/lib/core-net/vhost.c
@@ -450,8 +450,8 @@ lws_create_vhost(struct lws_context *context,
 	struct lws_protocols *lwsp;
 	int m, f = !info->pvo, fx = 0, abs_pcol_count = 0;
 	char buf[96];
-#if defined(LWS_CLIENT_HTTP_PROXYING) && \
-    defined(LWS_WITH_CLIENT) && defined(LWS_HAVE_GETENV)
+#if ((defined(LWS_CLIENT_HTTP_PROXYING) && defined(LWS_WITH_CLIENT)) \
+		|| defined(LWS_WITH_SOCKS5)) && defined(LWS_HAVE_GETENV)
 	char *p;
 #endif
 #if defined(LWS_WITH_SYS_ASYNC_DNS)


### PR DESCRIPTION
Signed-off-by: Jaco Kroon <jaco@iewc.co.za>