### PR TITLE
lws_gencrypto_jws_alg_to_definition:

### DIFF
--- a/lib/tls/lws-gencrypto-common.c
+++ b/lib/tls/lws-gencrypto-common.c
@@ -238,6 +238,8 @@ static const struct lws_jose_jwe_alg lws_gencrypto_jws_alg_map[] = {
 		"PS512", NULL, 2048, 4096, 0
 	},
 #endif
+	/* list terminator */
+	{ 0, 0, 0, 0, NULL, NULL, 0, 0, 0}
 };
 
 /*


### PR DESCRIPTION
Fix segfault when reached end of array.