### PR TITLE
http server: Using default filename also for subdirectories.

### DIFF
--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -587,8 +587,8 @@ lws_http_serve(struct lws *wsi, char *uri, const char *origin,
 #endif
 		if ((S_IFMT & st.st_mode) == S_IFDIR) {
 			lwsl_debug("default filename append to dir\n");
-			lws_snprintf(path, sizeof(path) - 1, "%s/%s/index.html",
-				 origin, uri);
+			lws_snprintf(path, sizeof(path) - 1, "%s/%s/%s",
+				 origin, uri, m->def ? m->def : "index.html");
 		}
 
 	} while ((S_IFMT & st.st_mode) != S_IFREG && spin < 5);

--- a/lib/tls/lws-gencrypto-common.c
+++ b/lib/tls/lws-gencrypto-common.c
@@ -238,6 +238,8 @@ static const struct lws_jose_jwe_alg lws_gencrypto_jws_alg_map[] = {
 		"PS512", NULL, 2048, 4096, 0
 	},
 #endif
+	/* list terminator */
+	{ 0, 0, 0, 0, NULL, NULL, 0, 0, 0}
 };
 
 /*


### PR DESCRIPTION
If a user sets a default filename for a http mount (`.def` in `lws_http_mount`),
eg. `default.html`, then a GET request for `/` correctly forwards to

    /default.html

However, without this commit the default filename is not taken into account for subdirectories. Thus,

    GET subdir/

will forward to

    subdir/index.html

instead of the expected

    subdir/default.html

This commit changes the behavior such that the user-provided default filename is also used for subdirectories.