### PR TITLE
Fix unused variable warning.

### DIFF
--- a/lib/core-net/vhost.c
+++ b/lib/core-net/vhost.c
@@ -477,8 +477,8 @@ lws_create_vhost(struct lws_context *context,
 	struct lws_protocols *lwsp;
 	int m, f = !info->pvo, fx = 0, abs_pcol_count = 0, sec_pcol_count = 0;
 	char buf[96];
-#if ((defined(LWS_CLIENT_HTTP_PROXYING) && defined(LWS_WITH_CLIENT)) \
-		|| defined(LWS_WITH_SOCKS5)) && defined(LWS_HAVE_GETENV)
+#if defined(LWS_CLIENT_HTTP_PROXYING) && defined(LWS_WITH_CLIENT) \
+	&& defined(LWS_HAVE_GETENV)
 	char *p;
 #endif
 #if defined(LWS_WITH_SYS_ASYNC_DNS)


### PR DESCRIPTION
after 6bb116b8d8d59139416ceb8cb3ca522b3fa9adb3 the variable p could be
declared without being used.

https://bugs.gentoo.org/716386 refers.

This just fixes that.