### PR TITLE
Silence CMP0048 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
+if(POLICY CMP0048)
+	cmake_policy(SET CMP0048 NEW)
+endif()
+
 # General Advice
 #
 # For selecting between DEBUG / RELEASE, use -DCMAKE_BUILD_TYPE=DEBUG or =RELEASE


### PR DESCRIPTION
When libwebsockets is included as a subdirectory in other projects that rely on a minimum CMake version of 3.x, a CMP0048 policy warning will be raised due to the project not specifying a version in the `project` call:

```
CMake Warning (dev) at externals/libwebsockets/CMakeLists.txt:17 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
```

This patch silences the warning by explicitly setting the policy within libwebsockets to `NEW` if it has already been forwarded as such, without any further impact on the behavior of CMake. Since the `OLD` behavior of this policy is [officially declared as deprecated](https://cmake.org/cmake/help/v3.3/policy/CMP0048.html), I think this is the way to go.