### PR TITLE
Build system check for cap library and uses it without linking to it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -799,6 +799,11 @@ if (LWS_WITH_HUBBUB)
 	list(APPEND LIB_LIST ${LIBHUBBUB_LIBRARIES} )
 endif()
 
+if (LWS_HAVE_LIBCAP)
+	find_library(LIBCAP_LIBRARIES NAMES cap)
+	list(APPEND LIB_LIST ${LIBCAP_LIBRARIES} )
+endif()
+
 
 #
 # Append the "at end" pieces to the lib list


### PR DESCRIPTION
While packaging libwebsockets 4.1.0 RC1 for Debian, I found that cmake check for cap_set_flag() and uses it if available - but doesn't link to the library. This pull request corrects linking.