### PR TITLE
Fixes #2019: lwsws will not iterate all plugin directories

### DIFF
--- a/lib/event-libs/libuv/libuv.c
+++ b/lib/event-libs/libuv/libuv.c
@@ -345,8 +345,8 @@ lws_uv_plugins_init(struct lws_context *context, const char * const *d)
 		lwsl_notice("  Scanning %s\n", *d);
 		m =uv_fs_scandir(&context->uv.loop, &req, *d, 0, NULL);
 		if (m < 1) {
-			lwsl_err("Scandir on %s failed\n", *d);
-			return 1;
+			lwsl_err("Scandir on %s failed\n", *d++);
+			continue;
 		}
 
 		while (uv_fs_scandir_next(&req, &dent) != UV_EOF) {


### PR DESCRIPTION
The result after this fix, would be :

lwsws libwebsockets web server - license CC0 + MIT
(C) Copyright 2010-2020 Andy Green <andy@warmcat.com>
Using config dir: "/etc/lwsws"
  Plugins:
  **Scanning /usr/share/libwebsockets-test-server/plugins/
Scandir on /usr/share/libwebsockets-test-server/plugins/ failed
  Scanning /usr/lib64/lwsws/plugins**
   protocol_test.so
 Using foreign event loop...

