### PR TITLE
openssl: Amend recent fix for old glibc compilation

### DIFF
--- a/include/libwebsockets/lws-esp32.h
+++ b/include/libwebsockets/lws-esp32.h
@@ -149,5 +149,3 @@ extern uint16_t lws_esp32_sine_interp(int n);
 
 /* required in external code by esp32 plat (may just return if no leds) */
 extern void lws_esp32_leds_timer_cb(TimerHandle_t th);
-
-#endif /* LWS_AMAZON_RTOS */

--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -21,12 +21,11 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#if defined LWS_HAVE_X509_VERIFY_PARAM_set1_host
-#include <features.h>
+
+#include "lws_config.h"
+#ifdef LWS_HAVE_X509_VERIFY_PARAM_set1_host
 /* Before glibc 2.10, strnlen required _GNU_SOURCE */
-#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
 #define _GNU_SOURCE
-#endif
 #endif
 #include <string.h>
 

--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -21,6 +21,13 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#if defined LWS_HAVE_X509_VERIFY_PARAM_set1_host
+#include <features.h>
+/* Before glibc 2.10, strnlen required _GNU_SOURCE */
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 10)
+#define _GNU_SOURCE
+#endif
+#endif
 #include <string.h>
 
 #include "private-lib-core.h"


### PR DESCRIPTION
Missed parentheses, and need to include `lws_config.h` before
testing the macro.

Also there's a chicken-and-egg situation here, because features.h is
required for testing glibc version, but including it indirectly includes
`string.h` before defining `_GNU_SOURCE`...

Fixed by defining `_GNU_SOURCE` if `strnlen` is used, regardless of glibc
version.