### PR TITLE
unix plat: Do not break strict aliasing rules

### DIFF
--- a/lib/plat/unix/unix-sockets.c
+++ b/lib/plat/unix/unix-sockets.c
@@ -399,7 +399,6 @@ lws_plat_ifconfig_ip(const char *ifname, int fd, uint8_t *ip, uint8_t *mask_ip,
 			uint8_t *gateway_ip)
 {
 #if defined(__linux__)
-	struct sockaddr_in *addr;
 	struct sockaddr_in sin;
 	struct rtentry route;
 	struct ifreq ifr;
@@ -430,17 +429,12 @@ lws_plat_ifconfig_ip(const char *ifname, int fd, uint8_t *ip, uint8_t *mask_ip,
 
 	lws_plat_if_up(ifname, fd, 1);
 
-	addr = (struct sockaddr_in *)&route.rt_gateway;
-	addr->sin_family = AF_INET;
-	addr->sin_addr.s_addr = htonl(*(uint32_t *)gateway_ip);
+	sin.sin_addr.s_addr = htonl(*(uint32_t *)gateway_ip);
+	memcpy(&route.rt_gateway, &sin, sizeof(struct sockaddr));
 
-	addr = (struct sockaddr_in *)&route.rt_dst;
-	addr->sin_family = AF_INET;
-	addr->sin_addr.s_addr = 0;
-
-	addr = (struct sockaddr_in *)&route.rt_genmask;
-	addr->sin_family = AF_INET;
-	addr->sin_addr.s_addr = 0;
+	sin.sin_addr.s_addr = 0;
+	memcpy(&route.rt_dst, &sin, sizeof(struct sockaddr));
+	memcpy(&route.rt_genmask, &sin, sizeof(struct sockaddr));
 
 	route.rt_flags = RTF_UP | RTF_GATEWAY;
 	route.rt_metric = 100;


### PR DESCRIPTION
The type of the fields in rtentry is sockaddr, and it is
casted to sockaddr_in. Size-wise it is ok, they should both
be the same size. But casting a pointer breaks build with
optimizations with the following error:

unix-sockets.c:434: error: dereferencing pointer 'addr' does break strict-aliasing rules

Amends commit 3c95483518e8e1e203f9f75e25bd65b298445cfa.