### PR TITLE
contrib, cross-atmel: build-out FILE_OPS

### DIFF
--- a/contrib/cross-atmel.cmake
+++ b/contrib/cross-atmel.cmake
@@ -4,7 +4,7 @@
 # To build without tls
 #
 #  cd build/
-#  cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/opt/linkit/cross-root \
+#  cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/opt/atmel/cross-root \
 #           -DCMAKE_TOOLCHAIN_FILE=../contrib/cross-atmel.cmake \
 #           -DLWS_PLAT_FREERTOS=1 \
 #           -DLWS_WITH_ZLIB=0 \
@@ -12,7 +12,8 @@
 #           -DLWS_WITH_ZIP_FOPS=0 \
 #           -DLWS_WITH_HTTP_STREAM_COMPRESSION=0 \
 #           -DLWS_WITH_MBEDTLS=0 \
-#           -DLWS_WITH_SSL=0
+#           -DLWS_WITH_SSL=0 \
+#           -DLWS_WITH_FILE_OPS=0
 #
 
 # I had to edit /opt/xdk-asf-3.48.0/thirdparty/lwip/lwip-port-1.4.1-dev/sam/include/arch/cc.h


### PR DESCRIPTION
Fix build failure against Atmel ASF3 SDK that does not provide a file
API conforming to POSIX.

libwebsockets/lib/core/libwebsockets.c: In function 'lws_open':
libwebsockets/lib/core/libwebsockets.c:187:18: error: 'O_CREAT' undeclared (first use in this function)
  if (((__oflag & O_CREAT) == O_CREAT)
                  ^~~~~~~