### PR TITLE
contrib, cross-atmel: build-out FILE_OPS

### DIFF
--- a/.sai.json
+++ b/.sai.json
@@ -41,7 +41,7 @@
 			"default": false
 		},
 		"windows-10/x86_64-amd/msvc": {
-			"build": "mkdir build && cd build && set SAI_CPACK=\"-G ZIP\" && cmake .. -DLWS_OPENSSL_LIBRARIES=\"C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib\" -DLWS_OPENSSL_INCLUDE_DIRS=\"C:\\Program Files\\OpenSSL\\include\" -DLWS_EXT_PTHREAD_INCLUDE_DIR=\"C:\\Program Files (x86)\\pthreads\\include\" -DLWS_EXT_PTHREAD_LIBRARIES=\"C:\\Program Files (x86)\\pthreads\\lib\\x64\\libpthreadGC2.a\" ${cmake} && cmake --build . --config DEBUG && set CTEST_OUTPUT_ON_FAILURE=1 && ctest . -C DEBUG -j4 --output-on-failure",
+			"build": "mkdir build && cd build && set SAI_CPACK=\"-G ZIP\" && cmake .. -DLWS_OPENSSL_LIBRARIES=\"C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib\" -DLWS_OPENSSL_INCLUDE_DIRS=\"C:\\Program Files\\OpenSSL\\include\" -DLWS_EXT_PTHREAD_INCLUDE_DIR=\"C:\\Program Files (x86)\\pthreads\\include\" -DLWS_EXT_PTHREAD_LIBRARIES=\"C:\\Program Files (x86)\\pthreads\\lib\\x64\\libpthreadGC2.a\" ${cmake} && cmake --build . --config DEBUG && set CTEST_OUTPUT_ON_FAILURE=1 && ctest . -C DEBUG -j1 --output-on-failure",
 			"default": false
 		},
 		"windows-10/x86_64-amd/mingw32": {

--- a/.sai.json
+++ b/.sai.json
@@ -170,6 +170,10 @@
 			"cmake":	"-DLWS_IPV6=ON",
 			"platforms":	"windows-10/x86_64-amd/mingw64, windows-10/x86_64-amd/msvc"
 		},
+		"nonetlink":	{
+			"cmake":	"-DLWS_WITH_NETLINK=0",
+			"platforms":	"linux-ubuntu-2004/x86_64-amd/gcc"
+		},
 		"nossl": {
 			"cmake":	"-DLWS_WITH_SSL=OFF",
 			"platforms":	"netbsd-iOS/aarch64/llvm"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,13 @@ option(LWS_HTTP_HEADERS_ALL "Override header reduction optimization and include 
 option(LWS_WITH_SUL_DEBUGGING "Enable zombie lws_sul checking on object deletion" OFF)
 option(LWS_WITH_PLUGINS_API "Build generic lws_plugins apis (see LWS_WITH_PLUGINS to also build protocol plugins)" OFF)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	option(LWS_WITH_NETLINK "Monitor Netlink for Routing Table changes" ON)
+else()
+	set(LWS_WITH_NETLINK 0)
+endif()
+
+
 #
 # to use miniz, enable both LWS_WITH_ZLIB and LWS_WITH_MINIZ
 #

--- a/READMEs/README.routing.md
+++ b/READMEs/README.routing.md
@@ -1,0 +1,51 @@
+# Lws routing
+
+lws is mainly built around POSIX sockets and operates from the
+information available from those.  But in some cases, it needs to go
+a step further and monitor and understand the device routing table.
+
+## Recognizing loss of routability
+
+On mobile devices, switching between interfaces and losing / regaining
+connections quickly is a given.  But POSIX sockets do not act like
+that, the socket remains connected until something times it out if it
+no longer has a route to its peer, and the tcp timeouts can be in the
+order of minutes.
+
+In order to do better, lws must monitor and understand how the routing
+table relates to existing connections, dynamically.
+
+## Linux: netlink
+
+For linux-based devices you can build in netlink-based route monitoring
+with `-DLWS_WITH_NETLINK=1`, lws aquires a copy of the routing table
+when the context / pt starts up and modifies it according to netlink
+messages from then on.
+
+On Linux routing table events do not take much care about backing out
+changes made on interface up by, eg, NetworkManager.  So lws also
+monitors for link / interface down to remove the related routes.
+
+## Actions in lws based on routing table
+
+Both server and client connections now store their peer sockaddr in the
+wsi, and when the routing table changes, all active wsi on a pt are
+checked against the routing table to confirm the peer is still
+routable.
+
+For example if there is no net route matching the peer and no gateway,
+the connection is invalidated and closed.  Similarly, if we are
+removing the highest priority gateway route, all connections to a peer
+without a net route match are invalidated.  However connections with
+an unaffected  matching net route like 127.0.0.0/8 are left alone.
+
+## Intergration to other subsystems
+
+If SMD is built in, on any route change a NETWORK message
+`{"rt":"add|del"}` is issued.
+
+If SMD is built in, on any route change involving a gateway, a NETWORK
+message `{"trigger":"cpdcheck", "src":"gw-change"}` is issued.  If
+Captive Portal Detection is built in, this will cause a new captive
+portal detection sequence.
+

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -154,6 +154,7 @@
 #cmakedefine LWS_LOGS_TIMESTAMP
 #cmakedefine LWS_WITH_MBEDTLS
 #cmakedefine LWS_WITH_MINIZ
+#cmakedefine LWS_WITH_NETLINK
 #cmakedefine LWS_WITH_NETWORK
 #cmakedefine LWS_WITH_NO_LOGS
 #cmakedefine LWS_WITH_CLIENT

--- a/contrib/cross-atmel.cmake
+++ b/contrib/cross-atmel.cmake
@@ -4,7 +4,7 @@
 # To build without tls
 #
 #  cd build/
-#  cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/opt/linkit/cross-root \
+#  cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/opt/atmel/cross-root \
 #           -DCMAKE_TOOLCHAIN_FILE=../contrib/cross-atmel.cmake \
 #           -DLWS_PLAT_FREERTOS=1 \
 #           -DLWS_WITH_ZLIB=0 \
@@ -12,7 +12,8 @@
 #           -DLWS_WITH_ZIP_FOPS=0 \
 #           -DLWS_WITH_HTTP_STREAM_COMPRESSION=0 \
 #           -DLWS_WITH_MBEDTLS=0 \
-#           -DLWS_WITH_SSL=0
+#           -DLWS_WITH_SSL=0 \
+#           -DLWS_WITH_FILE_OPS=0
 #
 
 # I had to edit /opt/xdk-asf-3.48.0/thirdparty/lwip/lwip-port-1.4.1-dev/sam/include/arch/cc.h

--- a/include/libwebsockets/lws-network-helper.h
+++ b/include/libwebsockets/lws-network-helper.h
@@ -124,10 +124,27 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
  * \param sa46a: first
  * \param sa46b: second
  *
- * Returns 0 if the address family and address are the same, otherwise nonzero.
+ * Returns 0 if the address family is INET or INET6 and the address is the same,
+ * or if the AF is the same but not INET or INET6, otherwise nonzero.
  */
 LWS_VISIBLE LWS_EXTERN int
 lws_sa46_compare_ads(const lws_sockaddr46 *sa46a, const lws_sockaddr46 *sa46b);
+
+/**
+ * lws_sa46_on_net() - checks if an sa46 is on the subnet represented by another
+ *
+ * \param sa46a: first
+ * \param sa46_net: network
+ * \param net_len: length of network non-mask
+ *
+ * Returns 0 if sa46a belongs on network sa46_net/net_len
+ *
+ * If there is an ipv4 / v6 mismatch between the ip and the net, the ipv4
+ * address is promoted to ::ffff:x.x.x.x before the comparison.
+ */
+LWS_VISIBLE LWS_EXTERN int
+lws_sa46_on_net(const lws_sockaddr46 *sa46a, const lws_sockaddr46 *sa46_net,
+			int net_len);
 
 /*
  * lws_parse_numeric_address() - converts numeric ipv4 or ipv6 to byte address

--- a/include/libwebsockets/lws-network-helper.h
+++ b/include/libwebsockets/lws-network-helper.h
@@ -40,6 +40,23 @@ typedef union {
 	struct sockaddr_in sa4;
 } lws_sockaddr46;
 
+/*
+ * This represents an entry in the system routing table
+ */
+
+typedef struct lws_route {
+	lws_dll2_t		list;
+
+	lws_sockaddr46		dest;
+	lws_sockaddr46		gateway;
+
+	int			if_idx;
+	int			priority;
+
+	uint8_t			proto;
+	uint8_t			dest_len;
+} lws_route_t;
+
 /**
  * lws_canonical_hostname() - returns this host's hostname
  *

--- a/include/libwebsockets/lws-secure-streams-policy.h
+++ b/include/libwebsockets/lws-secure-streams-policy.h
@@ -165,9 +165,9 @@ typedef struct lws_ss_metadata {
 	void			*value;
 	size_t			length;
 
-	uint8_t			value_on_lws_heap; /* proxy + rx metadata does this */
-	uint8_t			value_is_http_token; /* valid if set by policy */
 	uint8_t			value_length; /* only valid if set by policy */
+	uint8_t			value_on_lws_heap:1; /* proxy + rx metadata does this */
+	uint8_t			value_is_http_token:1; /* valid if set by policy */
 #if defined(LWS_WITH_SECURE_STREAMS_PROXY_API)
 	uint8_t			pending_onward:1;
 #endif

--- a/lib/core-net/CMakeLists.txt
+++ b/lib/core-net/CMakeLists.txt
@@ -45,6 +45,12 @@ if (LWS_WITH_SYS_STATE)
 	)
 endif()
 
+if (LWS_WITH_NETLINK)
+	list(APPEND SOURCES
+		core-net/route.c
+	)
+endif()
+
 if (LWS_WITH_DETAILED_LATENCY)
 	list(APPEND SOURCES
 		core-net/detailed-latency.c)

--- a/lib/core-net/adopt.c
+++ b/lib/core-net/adopt.c
@@ -466,13 +466,8 @@ lws_adopt_descriptor_vhost(struct lws_vhost *vh, lws_adoption_type type,
 struct lws *
 lws_adopt_descriptor_vhost_via_info(const lws_adopt_desc_t *info)
 {
-	socklen_t slen = sizeof(sa46);
+	socklen_t slen = sizeof(lws_sockaddr46);
 	struct lws *new_wsi;
-
-	if (info->type & LWS_ADOPT_SOCKET &&
-	    getpeername(info->fd.sockfd, (struct sockaddr *)&wsi->sa46_peer,
-								    &slen) < 0)
-		lwsl_info("%s: getpeername failed\n", __func__);
 
 #if defined(LWS_WITH_PEER_LIMITS)
 	struct lws_peer *peer = NULL;
@@ -506,6 +501,11 @@ lws_adopt_descriptor_vhost_via_info(const lws_adopt_desc_t *info)
 			compatible_close(info->fd.sockfd);
 		return NULL;
 	}
+
+	if (info->type & LWS_ADOPT_SOCKET &&
+	    getpeername(info->fd.sockfd, (struct sockaddr *)&new_wsi->sa46_peer,
+								    &slen) < 0)
+		lwsl_info("%s: getpeername failed\n", __func__);
 
 #if defined(LWS_WITH_PEER_LIMITS)
 	if (peer)

--- a/lib/core-net/client/connect3.c
+++ b/lib/core-net/client/connect3.c
@@ -402,6 +402,10 @@ ads_known:
 #if defined(LWS_ESP_PLATFORM)
 	errno = 0;
 #endif
+
+	/* grab a copy for peer tracking */
+	wsi->sa46_peer = *psa;
+
 	m = connect(wsi->desc.sockfd, (const struct sockaddr *)psa, n);
 	if (m == -1) {
 		int errno_copy = LWS_ERRNO;

--- a/lib/core-net/client/connect3.c
+++ b/lib/core-net/client/connect3.c
@@ -404,7 +404,10 @@ ads_known:
 #endif
 
 	/* grab a copy for peer tracking */
-	wsi->sa46_peer = *psa;
+#if defined(LWS_WITH_UNIX_SOCK)
+	if (!wsi->unix_skt)
+#endif
+		memcpy(&wsi->sa46_peer, psa, n);
 
 	m = connect(wsi->desc.sockfd, (const struct sockaddr *)psa, n);
 	if (m == -1) {

--- a/lib/core-net/pollfd.c
+++ b/lib/core-net/pollfd.c
@@ -293,7 +293,12 @@ __insert_wsi_socket_into_fds(struct lws_context *context, struct lws *wsi)
 #endif
 
 	assert(wsi);
+
+#if defined(LWS_WITH_NETLINK)
+	assert(wsi->event_pipe || wsi->a.vhost || wsi == pt->netlink);
+#else
 	assert(wsi->event_pipe || wsi->a.vhost);
+#endif
 	assert(lws_socket_is_valid(wsi->desc.sockfd));
 
 #if defined(LWS_WITH_EXTERNAL_POLL)

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -731,9 +731,8 @@ struct lws {
 	struct lws_dll2_owner		dll2_cli_txn_queue_owner;
 #endif
 
-#if defined(LWS_WITH_ACCESS_LOG)
-	char simple_ip[(8 * 5)];
-#endif
+	lws_sockaddr46			sa46_peer;
+
 	/* pointers */
 
 	struct lws			*parent; /* points to parent, if any */

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -1133,6 +1133,9 @@ lws_parse(struct lws *wsi, unsigned char *buf, int *len);
 int LWS_WARN_UNUSED_RESULT
 lws_parse_urldecode(struct lws *wsi, uint8_t *_c);
 
+void
+lws_sa46_copy_address(lws_sockaddr46 *sa46a, const void *in, int af);
+
 int LWS_WARN_UNUSED_RESULT
 lws_http_action(struct lws *wsi);
 

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -415,6 +415,11 @@ struct lws_context_per_thread {
 	lws_sockfd_type dummy_pipe_fds[2];
 	struct lws *pipe_wsi;
 
+#if defined(LWS_WITH_NETLINK)
+	lws_dll2_owner_t			routing_table;
+	struct lws				*netlink;
+#endif
+
 	/* --- role based members --- */
 
 #if defined(LWS_ROLE_WS) && !defined(LWS_WITHOUT_EXTENSIONS)
@@ -1244,6 +1249,16 @@ struct lws *
 lws_http_client_connect_via_info2(struct lws *wsi);
 
 
+struct lws *
+lws_wsi_create_with_role(struct lws_context *context, int tsi,
+			 const struct lws_role_ops *ops);
+int
+lws_wsi_inject_to_loop(struct lws_context_per_thread *pt, struct lws *wsi);
+
+int
+lws_wsi_extract_from_loop(struct lws *wsi);
+
+
 #if defined(LWS_WITH_CLIENT)
 int
 lws_http_client_socket_service(struct lws *wsi, struct lws_pollfd *pollfd);
@@ -1359,6 +1374,28 @@ lws_same_vh_protocol_insert(struct lws *wsi, int n);
 
 void
 lws_seq_destroy_all_on_pt(struct lws_context_per_thread *pt);
+
+int
+lws_route_pt_close_unroutable(struct lws_context_per_thread *pt,
+			int priority_deleted_route);
+
+void
+lws_routing_entry_dump(lws_route_t *rou);
+
+void
+lws_routing_table_dump(struct lws_context_per_thread *pt);
+
+int
+lws_route_remove(struct lws_context_per_thread *pt, lws_route_t *robj);
+
+void
+lws_route_table_empty(struct lws_context_per_thread *pt);
+
+void
+lws_route_table_ifdown(struct lws_context_per_thread *pt, int idx);
+
+void
+lws_addrinfo_clean(struct lws *wsi);
 
 int
 lws_broadcast(struct lws_context_per_thread *pt, int reason, void *in, size_t len);

--- a/lib/core-net/route.c
+++ b/lib/core-net/route.c
@@ -1,0 +1,186 @@
+/*
+ * libwebsockets - small server side websockets and web server implementation
+ *
+ * Copyright (C) 2010 - 2020 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * We mainly focus on the routing table / gateways because those are the
+ * elements that decide if we can get on to the internet or not.
+ *
+ * However also we maintain a getifaddrs cache, so we have to invalidate +
+ * update that when any addresses are added and removed.
+ */
+
+#include <private-lib-core.h>
+
+#if defined(_DEBUG)
+void
+lws_routing_entry_dump(lws_route_t *rou)
+{
+	char da[48], gw[48];
+
+	lws_sa46_write_numeric_address(&rou->dest, da, sizeof(da));
+	lws_sa46_write_numeric_address(&rou->gateway, gw, sizeof(gw));
+
+	lwsl_info("  %s/%d, gw: %s, ifidx: %d, pri: %d, proto: %d\n",
+		    da, rou->dest_len, gw, rou->if_idx, rou->priority,
+		    rou->proto);
+}
+
+void
+lws_routing_table_dump(struct lws_context_per_thread *pt)
+{
+	lws_start_foreach_dll(struct lws_dll2 *, d,
+			      lws_dll2_get_head(&pt->routing_table)) {
+		lws_route_t *rou = lws_container_of(d, lws_route_t, list);
+
+		lws_routing_entry_dump(rou);
+	} lws_end_foreach_dll(d);
+}
+#endif
+
+int
+lws_route_remove(struct lws_context_per_thread *pt, lws_route_t *robj)
+{
+	lws_start_foreach_dll(struct lws_dll2 *, d,
+			lws_dll2_get_head(&pt->routing_table)) {
+		lws_route_t *rou = lws_container_of(d, lws_route_t, list);
+
+		if (!lws_sa46_compare_ads(&robj->dest, &rou->dest) &&
+		    !lws_sa46_compare_ads(&robj->gateway, &rou->gateway) &&
+		    robj->dest_len == rou->dest_len &&
+		    robj->if_idx == rou->if_idx &&
+		    robj->priority == rou->priority) {
+			// lwsl_debug("%s: deleting route\n", __func__);
+			lws_dll2_remove(&rou->list);
+			lws_free(rou);
+			return 0;
+		}
+
+	} lws_end_foreach_dll(d);
+
+	return 1;
+}
+
+void
+lws_route_table_empty(struct lws_context_per_thread *pt)
+{
+	lws_start_foreach_dll_safe(struct lws_dll2 *, d, d1,
+				   lws_dll2_get_head(&pt->routing_table)) {
+		lws_route_t *rou = lws_container_of(d, lws_route_t, list);
+		lws_dll2_remove(&rou->list);
+		lws_free(rou);
+
+	} lws_end_foreach_dll_safe(d, d1);
+}
+
+void
+lws_route_table_ifdown(struct lws_context_per_thread *pt, int idx)
+{
+	lws_start_foreach_dll_safe(struct lws_dll2 *, d, d1,
+				   lws_dll2_get_head(&pt->routing_table)) {
+		lws_route_t *rou = lws_container_of(d, lws_route_t, list);
+
+		if (rou->if_idx == idx) {
+			lws_dll2_remove(&rou->list);
+			lws_free(rou);
+		}
+
+	} lws_end_foreach_dll_safe(d, d1);
+}
+
+int
+lws_route_check_wsi(struct lws *wsi, int priority_deleted_route)
+{
+	struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
+	int best_gw_priority = INT_MAX;
+	char no_gw = 1;
+
+	if (!wsi->sa46_peer.sa4.sin_family ||
+	    wsi->desc.sockfd == LWS_SOCK_INVALID)
+		/* not a socket or not connected, leave it alone */
+		return 0;
+
+	/*
+	 * Given its peer address and the current routing table, assess if this
+	 * connection is viable
+	 */
+
+	lws_start_foreach_dll(struct lws_dll2 *, d,
+			      lws_dll2_get_head(&pt->routing_table)) {
+		lws_route_t *rou = lws_container_of(d, lws_route_t, list);
+		lws_sockaddr46 *sa46 = &rou->dest;
+
+		if (!sa46->sa4.sin_family)
+			sa46 = &rou->gateway;
+
+		if (!lws_sa46_on_net(&wsi->sa46_peer, sa46, rou->dest_len))
+			/* yes, he has a network route */
+			return 0;
+
+		if (wsi->sa46_peer.sa4.sin_family == rou->dest.sa4.sin_family &&
+		    rou->gateway.sa4.sin_family) {
+			/* this guy isn't our net, but he has a gateway */
+			no_gw = 0;
+			if (rou->priority < best_gw_priority)
+				best_gw_priority = rou->priority;
+		}
+
+	} lws_end_foreach_dll(d);
+
+	/*
+	 * No net matched... if also no gateway, he's had it.
+	 *
+	 * If we're scanning because we just deleted the best gateway route
+	 * that, since no net route matched, he would have been using (eg,
+	 * switch from wifi to lte) implying external IP change, he's had it.
+	 *
+	 * Otherwise with no net matched but an unchanged "best" gateway, leave
+	 * him be.
+	 */
+
+	return no_gw || (priority_deleted_route != -1 &&
+			 priority_deleted_route < best_gw_priority);
+}
+
+/*
+ * priority_deleted_route should be -1 if no deleted route
+ */
+
+int
+lws_route_pt_close_unroutable(struct lws_context_per_thread *pt,
+			      int priority_deleted_route)
+{
+	struct lws *wsi;
+	unsigned int n;
+
+	for (n = 0; n < pt->fds_count; n++) {
+		wsi = wsi_from_fd(pt->context, pt->fds[n].fd);
+		if (!wsi)
+			continue;
+
+		if (lws_route_check_wsi(wsi, priority_deleted_route)) {
+			lwsl_info("%s: culling wsi %p\n", __func__, wsi);
+			lws_wsi_close(wsi, LWS_TO_KILL_ASYNC);
+		}
+	}
+
+	return 0;
+}

--- a/lib/core-net/vhost.c
+++ b/lib/core-net/vhost.c
@@ -43,6 +43,9 @@ const struct lws_role_ops *available_roles[] = {
 #if defined(LWS_ROLE_MQTT) && defined(LWS_WITH_CLIENT)
 	&role_ops_mqtt,
 #endif
+#if defined(LWS_WITH_NETLINK)
+	&role_ops_netlink,
+#endif
 	NULL
 };
 
@@ -909,7 +912,6 @@ int
 lws_create_event_pipes(struct lws_context *context)
 {
 	struct lws_context_per_thread *pt;
-	size_t s = sizeof(struct lws);
 	struct lws *wsi;
 	int n;
 
@@ -929,29 +931,9 @@ lws_create_event_pipes(struct lws_context *context)
 		if (pt->pipe_wsi)
 			return 0;
 
-#if defined(LWS_WITH_EVENT_LIBS)
-		s += context->event_loop_ops->evlib_size_wsi;
-#endif
-
-		wsi = lws_zalloc(s, "event pipe wsi");
-		if (!wsi) {
-			lwsl_err("%s: Out of mem\n", __func__);
+		wsi = lws_wsi_create_with_role(context, n, &role_ops_pipe);
+		if (!wsi)
 			return 1;
-		}
-#if defined(LWS_WITH_EVENT_LIBS)
-		wsi->evlib_wsi = (uint8_t *)wsi + sizeof(*wsi);
-#endif
-		wsi->a.context = context;
-		lws_role_transition(wsi, 0, LRS_UNCONNECTED, &role_ops_pipe);
-		wsi->a.protocol = NULL;
-		wsi->tsi = n;
-		wsi->a.vhost = NULL;
-		wsi->event_pipe = 1;
-		wsi->desc.sockfd = LWS_SOCK_INVALID;
-		context->pt[n].pipe_wsi = wsi;
-		context->count_wsi_allocated++;
-
-		lws_pt_lock(pt, __func__); /* -------------- pt { */
 
 		if (!lws_plat_pipe_create(wsi)) {
 			/*
@@ -963,24 +945,20 @@ lws_create_event_pipes(struct lws_context *context)
 			 * etc.
 			 */
 
+			wsi->event_pipe = 1;
+			pt->pipe_wsi = wsi;
+
 			wsi->desc.sockfd = context->pt[n].dummy_pipe_fds[0];
 			lwsl_debug("event pipe fd %d\n", wsi->desc.sockfd);
 
-			if (context->event_loop_ops->sock_accept)
-				if (context->event_loop_ops->sock_accept(wsi))
+			if (lws_wsi_inject_to_loop(pt, wsi))
 					goto bail;
-
-			if (__insert_wsi_socket_into_fds(context, wsi))
-				goto bail;
 		}
-
-		lws_pt_unlock(pt);
 	}
 
 	return 0;
 
 bail:
-	lws_pt_unlock(pt);
 
 	return 1;
 }
@@ -988,23 +966,14 @@ bail:
 void
 lws_destroy_event_pipe(struct lws *wsi)
 {
+	int n;
+
 	lwsl_info("%s\n", __func__);
 
-	if (lws_socket_is_valid(wsi->desc.sockfd))
-		__remove_wsi_socket_from_fds(wsi);
-
-	if (!wsi->a.context->event_loop_ops->destroy_wsi &&
-	    wsi->a.context->event_loop_ops->wsi_logical_close) {
-		wsi->a.context->event_loop_ops->wsi_logical_close(wsi);
-		lws_plat_pipe_close(wsi);
-		return;
-	}
-
-	if (wsi->a.context->event_loop_ops->destroy_wsi)
-		wsi->a.context->event_loop_ops->destroy_wsi(wsi);
+	n = lws_wsi_extract_from_loop(wsi);
 	lws_plat_pipe_close(wsi);
-	wsi->a.context->count_wsi_allocated--;
-	lws_free(wsi);
+	if (!n)
+		lws_free(wsi);
 }
 
 

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -872,12 +872,6 @@ lws_create_context(const struct lws_context_creation_info *info)
 		lws_seq_pt_init(&context->pt[n]);
 #endif
 
-		LWS_FOR_EVERY_AVAILABLE_ROLE_START(ar) {
-			if (ar->pt_init_destroy)
-				ar->pt_init_destroy(context, info,
-						    &context->pt[n], 0);
-		} LWS_FOR_EVERY_AVAILABLE_ROLE_END;
-
 #if defined(LWS_WITH_CGI)
 		role_ops_cgi.pt_init_destroy(context, info, &context->pt[n], 0);
 #endif
@@ -970,6 +964,14 @@ lws_create_context(const struct lws_context_creation_info *info)
 
 	if (lws_create_event_pipes(context))
 		goto bail;
+
+	for (n = 0; n < context->count_threads; n++) {
+		LWS_FOR_EVERY_AVAILABLE_ROLE_START(ar) {
+			if (ar->pt_init_destroy)
+				ar->pt_init_destroy(context, info,
+						    &context->pt[n], 0);
+		} LWS_FOR_EVERY_AVAILABLE_ROLE_END;
+	}
 #endif
 
 	lws_context_init_ssl_library(info);

--- a/lib/plat/unix/unix-pipe.c
+++ b/lib/plat/unix/unix-pipe.c
@@ -75,4 +75,3 @@ lws_plat_pipe_close(struct lws *wsi)
 
 	pt->dummy_pipe_fds[0] = pt->dummy_pipe_fds[1] = -1;
 }
-

--- a/lib/roles/CMakeLists.txt
+++ b/lib/roles/CMakeLists.txt
@@ -80,6 +80,10 @@ if (LWS_WITH_CLIENT AND (LWS_ROLE_H1 OR LWS_ROLE_H2))
 		roles/http/client/client-http.c)
 endif()
 
+if (LWS_WITH_NETLINK)
+	list(APPEND SOURCES roles/netlink/ops-netlink.c)
+endif()
+
 #
 # Keep explicit parent scope exports at end
 #

--- a/lib/roles/http/header.c
+++ b/lib/roles/http/header.c
@@ -48,7 +48,7 @@ lws_http_string_to_known_header(const char *s, size_t slen)
 		if (!strncmp(set[n], s, slen))
 			return n;
 
-	return -1;
+	return LWS_HTTP_NO_KNOWN_HEADER;
 }
 
 int

--- a/lib/roles/http/private-lib-roles-http.h
+++ b/lib/roles/http/private-lib-roles-http.h
@@ -94,6 +94,8 @@ void
 lws_ranges_reset(struct lws_range_parsing *rp);
 #endif
 
+#define LWS_HTTP_NO_KNOWN_HEADER 0xff
+
 /*
  * these are assigned from a pool held in the context.
  * Both client and server mode uses them for http header analysis

--- a/lib/roles/http/server/access-log.c
+++ b/lib/roles/http/server/access-log.c
@@ -43,7 +43,7 @@ static const char * const hver[] = {
 void
 lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int uri_len, int meth)
 {
-	char da[64], uri[256];
+	char da[64], uri[256], ta[64];
 	time_t t = time(NULL);
 	struct lws *nwsi;
 	const char *me;
@@ -89,10 +89,14 @@ lws_prepare_access_log_info(struct lws *wsi, char *uri_ptr, int uri_len, int met
 
 	nwsi = lws_get_network_wsi(wsi);
 
+	if (wsi->sa46_peer.sa4.sin_family)
+		lws_sa46_write_numeric_address(&nwsi->sa46_peer, ta, sizeof(ta));
+	else
+		strncpy(ta, "unknown", sizeof(ta));
+
 	lws_snprintf(wsi->http.access_log.header_log, l,
 		     "%s - - [%s] \"%s %s %s\"",
-		     nwsi->simple_ip[0] ? nwsi->simple_ip : "unknown", da, me, uri,
-			hver[wsi->http.request_version]);
+		     ta, da, me, uri, hver[wsi->http.request_version]);
 
 	//lwsl_notice("%s\n", wsi->http.access_log.header_log);
 

--- a/lib/roles/netlink/ops-netlink.c
+++ b/lib/roles/netlink/ops-netlink.c
@@ -1,0 +1,367 @@
+/*
+ * libwebsockets - small server side websockets and web server implementation
+ *
+ * Copyright (C) 2010 - 2020 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * We mainly focus on the routing table / gateways because those are the
+ * elements that decide if we can get on to the internet or not.
+ */
+
+#include <private-lib-core.h>
+
+#include <asm/types.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+static int
+rops_handle_POLLIN_netlink(struct lws_context_per_thread *pt, struct lws *wsi,
+			   struct lws_pollfd *pollfd)
+{
+	uint8_t s[512]
+#if defined(_DEBUG)
+	        , route_change = 0
+#endif
+#if defined(LWS_WITH_SYS_SMD)
+		, gateway_change = 0
+#endif
+			;
+	struct sockaddr_nl nladdr;
+	lws_route_t robj, *rou;
+	struct nlmsghdr *h;
+	struct msghdr msg;
+	struct iovec iov;
+	int n;
+
+	if (!(pollfd->revents & LWS_POLLIN))
+		return LWS_HPI_RET_HANDLED;
+
+	memset(&msg, 0, sizeof(msg));
+
+	iov.iov_base		= (void *)s;
+	iov.iov_len		= sizeof(s);
+	msg.msg_name		= (void *)&(nladdr);
+	msg.msg_namelen		= sizeof(nladdr);
+
+	msg.msg_iov		= &iov;
+	msg.msg_iovlen		= 1;
+
+	n = recvmsg(wsi->desc.sockfd, &msg, 0);
+	if (n < 0)
+		return LWS_HPI_RET_PLEASE_CLOSE_ME;
+
+	h = (struct nlmsghdr *)s;
+
+/*
+ * On some platforms nlh->nlmsg_len is a uint32_t but len is expected to be
+ * an int.  This causes the last comparison to blow with
+ *
+ * comparison of integers of different signs: '__u32' (aka 'unsigned int') and
+ * 'int' [-Werror,-Wsign-compare]
+ *
+ * rtnetlink messages cannot be huge, solve it by casting nmmsg_len to int
+ */
+
+#define LWS_NLMSG_OK(nlh, len) ((len) >= (int) sizeof(struct nlmsghdr) && \
+			       (nlh)->nlmsg_len >= sizeof(struct nlmsghdr) && \
+			       (int)(nlh)->nlmsg_len <= (len))
+
+	for ( ; LWS_NLMSG_OK(h, n); h = NLMSG_NEXT(h, n)) {
+		struct rtattr *ra;
+		struct rtmsg *rm;
+		int ra_len;
+		uint8_t *p;
+
+		if (h->nlmsg_type == RTM_NEWLINK) {
+			struct ifinfomsg *ifi = NLMSG_DATA(h);
+
+			/*
+			 * Despite "New"link this is actually telling us there
+			 * is some change on the network interface IFF_ state
+			 */
+
+			if (!(ifi->ifi_flags & IFF_UP))
+				/*
+				 * Interface is down, so scrub all routes that
+				 * apply to it
+				 */
+				lws_route_table_ifdown(pt, ifi->ifi_index);
+			continue;
+		}
+
+		rm = (struct rtmsg *)NLMSG_DATA(h);
+		ra = (struct rtattr *)RTM_RTA(rm);
+		ra_len = RTM_PAYLOAD(h);
+
+		memset(&robj, 0, sizeof(robj));
+		robj.if_idx = -1;
+		robj.priority = -1;
+		robj.proto = rm->rtm_protocol;
+
+		for ( ; RTA_OK(ra, ra_len); ra = RTA_NEXT(ra, ra_len)) {
+			switch (ra->rta_type) {
+			case RTA_DST:
+				lws_sa46_copy_address(&robj.dest, RTA_DATA(ra),
+							rm->rtm_family);
+				robj.dest_len = rm->rtm_dst_len;
+				break;
+			case RTA_GATEWAY:
+				lws_sa46_copy_address(&robj.gateway,
+						      RTA_DATA(ra),
+						      rm->rtm_family);
+#if defined(LWS_WITH_SYS_SMD)
+				gateway_change = 1;
+#endif
+				break;
+			case RTA_OIF: /* int: output interface index */
+				robj.if_idx = *(char*)RTA_DATA(ra);
+				break;
+			case RTA_PRIORITY: /* int: priority of route */
+				p = RTA_DATA(ra);
+				robj.priority = p[3] << 24 | p[2] << 16 |
+						 p[1] << 8  | p[0];
+				break;
+			case RTA_PREFSRC: /* protocol ads: preferred src ads */
+				break;
+			case RTA_CACHEINFO: /* struct rta_cacheinfo */
+				break;
+			case RTA_PREF: /* char: RFC4191 v6 router preference */
+				break;
+			case RTA_TABLE: /* int */
+				break;
+
+			default:
+				lwsl_info("%s: unknown attr type %d\n",
+						__func__, ra->rta_type);
+				break;
+			}
+		}
+
+		if (rm->rtm_type != RTN_UNICAST &&
+		    rm->rtm_type != RTN_LOCAL)
+			break;
+
+		if (rm->rtm_flags & RTM_F_CLONED)
+			break;
+
+		switch (h->nlmsg_type) {
+
+		case RTM_DELROUTE:
+			lws_route_remove(pt, &robj);
+			lws_route_pt_close_unroutable(pt, robj.priority);
+			goto inform;
+
+		case RTM_NEWROUTE:
+			rou = lws_malloc(sizeof(*rou), __func__);
+			if (!rou) {
+				lwsl_err("%s: oom\n", __func__);
+				return LWS_HPI_RET_HANDLED;
+			}
+
+			*rou = robj;
+			lws_dll2_add_tail(&rou->list, &pt->routing_table);
+			lws_route_pt_close_unroutable(pt, -1);
+
+inform:
+#if defined(_DEBUG)
+			route_change = 1;
+#endif
+#if defined(LWS_WITH_SYS_SMD)
+			/*
+			 * Reflect the route add / del event using SMD.
+			 * Participants interested can refer to the pt
+			 * routing table
+			 */
+			(void)lws_smd_msg_printf(pt->context, LWSSMDCL_NETWORK,
+				   "{\"rt\":\"%s\"}\n",
+				   (h->nlmsg_type == RTM_DELROUTE) ?
+						"del" : "add");
+#endif
+
+			break;
+
+		default:
+			// lwsl_info("%s: unknown msg type %d\n", __func__,
+			//		h->nlmsg_type);
+			break;
+		}
+	}
+
+#if defined(LWS_WITH_SYS_SMD)
+	if (gateway_change)
+		/*
+		 * If a route with a gw was added or deleted, retrigger captive
+		 * portal detection if we have that
+		 */
+		(void)lws_smd_msg_printf(pt->context, LWSSMDCL_NETWORK,
+				   "{\"trigger\": \"cpdcheck\", "
+				   "\"src\":\"gw-change\"}");
+#endif
+
+#if defined(_DEBUG)
+	if (route_change)
+		lws_routing_table_dump(pt);
+#endif
+
+	return LWS_HPI_RET_HANDLED;
+}
+
+struct nl_req_s {
+	struct nlmsghdr hdr;
+	struct rtmsg gen;
+};
+
+int
+rops_pt_init_destroy_netlink(struct lws_context *context,
+			     const struct lws_context_creation_info *info,
+			     struct lws_context_per_thread *pt, int destroy)
+{
+	struct sockaddr_nl sanl;
+	struct nl_req_s req;
+	struct msghdr msg;
+	struct iovec iov;
+	struct lws *wsi;
+	int n;
+
+	if (destroy) {
+		/*
+		 * pt netlink wsi closed + freed as part of pt's destroy
+		 * wsi mass close, just need to take down the routing table
+		 */
+		lws_route_table_empty(pt);
+
+		return 0;
+	}
+
+	lwsl_info("%s: creating netlink skt\n", __func__);
+
+	/*
+	 * We want a netlink socket per pt as well
+	 */
+	wsi = lws_wsi_create_with_role(context, (int)(pt - &context->pt[0]),
+				       &role_ops_netlink);
+	if (!wsi)
+		goto bail;
+
+	wsi->desc.sockfd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	if (wsi->desc.sockfd == LWS_SOCK_INVALID) {
+		lwsl_err("%s: unable to open netlink\n", __func__);
+		goto bail1;
+	}
+
+	memset(&sanl, 0, sizeof(sanl));
+	sanl.nl_family		= AF_NETLINK;
+	sanl.nl_pid		= getpid();
+	sanl.nl_groups		= RTMGRP_LINK | RTMGRP_IPV4_ROUTE
+#if defined(LWS_WITH_IPV6)
+				  | RTMGRP_IPV6_ROUTE
+#endif
+				  ;
+
+	if (bind(wsi->desc.sockfd, (struct sockaddr*)&sanl, sizeof(sanl)) < 0) {
+		lwsl_err("%s: netlink bind failed\n", __func__);
+		goto bail2;
+	}
+
+	pt->netlink = wsi;
+	if (lws_wsi_inject_to_loop(pt, wsi))
+		goto bail2;
+
+	if (lws_change_pollfd(wsi, 0, LWS_POLLIN)) {
+		lwsl_err("%s: pollfd in fail\n", __func__);
+		goto bail2;
+	}
+
+	/*
+	 * Since we're starting the PT, ask to be sent all the existing routes.
+	 *
+	 * This requires CAP_ADMIN, or root... we do this early before dropping
+	 * privs
+	 */
+
+	memset(&sanl, 0, sizeof(sanl));
+	memset(&msg, 0, sizeof(msg));
+	memset(&req, 0, sizeof(req));
+
+	sanl.nl_family		= AF_NETLINK;
+
+	req.hdr.nlmsg_len	= NLMSG_LENGTH(sizeof(req.gen));
+	req.hdr.nlmsg_type	= RTM_GETROUTE;
+	req.hdr.nlmsg_flags	= NLM_F_REQUEST | NLM_F_DUMP;
+	req.hdr.nlmsg_seq	= 1;
+	req.hdr.nlmsg_pid	= getpid();
+	req.gen.rtm_family	= AF_PACKET;
+	req.gen.rtm_table	= RT_TABLE_DEFAULT;
+
+	iov.iov_base		= &req;
+	iov.iov_len		= req.hdr.nlmsg_len;
+	msg.msg_iov		= &iov;
+	msg.msg_iovlen		= 1;
+	msg.msg_name		= &sanl;
+	msg.msg_namelen		= sizeof(sanl);
+
+	n = sendmsg(wsi->desc.sockfd, (struct msghdr *)&msg, 0);
+	if (n < 0) {
+		lwsl_notice("%s: rt dump req failed... permissions? errno %d\n",
+				__func__, LWS_ERRNO);
+	}
+
+	return 0;
+
+bail2:
+	compatible_close(wsi->desc.sockfd);
+bail1:
+	lws_free(wsi);
+bail:
+	return 1;
+}
+
+const struct lws_role_ops role_ops_netlink = {
+	/* role name */			"netlink",
+	/* alpn id */			NULL,
+	/* check_upgrades */		NULL,
+	/* pt_init_destroy */		rops_pt_init_destroy_netlink,
+	/* init_vhost */		NULL,
+	/* destroy_vhost */		NULL,
+	/* service_flag_pending */	NULL,
+	/* handle_POLLIN */		rops_handle_POLLIN_netlink,
+	/* handle_POLLOUT */		NULL,
+	/* perform_user_POLLOUT */	NULL,
+	/* callback_on_writable */	NULL,
+	/* tx_credit */			NULL,
+	/* write_role_protocol */	NULL,
+	/* encapsulation_parent */	NULL,
+	/* alpn_negotiated */		NULL,
+	/* close_via_role_protocol */	NULL,
+	/* close_role */		NULL,
+	/* close_kill_connection */	NULL,
+	/* destroy_role */		NULL,
+	/* adoption_bind */		NULL,
+	/* client_bind */		NULL,
+	/* issue_keepalive */		NULL,
+	/* adoption_cb clnt, srv */	{ 0, 0 },
+	/* rx_cb clnt, srv */		{ 0, 0 },
+	/* writeable cb clnt, srv */	{ 0, 0 },
+	/* close cb clnt, srv */	{ 0, 0 },
+	/* protocol_bind_cb c,s */	{ 0, 0 },
+	/* protocol_unbind_cb c,s */	{ 0, 0 },
+	/* file_handle */		0,
+};

--- a/lib/roles/private-lib-roles.h
+++ b/lib/roles/private-lib-roles.h
@@ -274,7 +274,8 @@ struct lws_role_ops {
 
 /* core roles */
 extern const struct lws_role_ops role_ops_raw_skt, role_ops_raw_file,
-				 role_ops_listen, role_ops_pipe;
+				 role_ops_listen, role_ops_pipe,
+				 role_ops_netlink;
 
 /* bring in role private declarations */
 

--- a/lib/secure-streams/policy-common.c
+++ b/lib/secure-streams/policy-common.c
@@ -95,7 +95,7 @@ lws_ss_get_metadata(struct lws_ss_handle *h, const char *name,
 lws_ss_metadata_t *
 lws_ss_get_handle_metadata(struct lws_ss_handle *h, const char *name)
 {
-	int n = 0;
+	int n;
 
 	for (n = 0; n < h->policy->metadata_count; n++)
 		if (!strcmp(name, h->metadata[n].name))

--- a/lib/secure-streams/policy-json.c
+++ b/lib/secure-streams/policy-json.c
@@ -670,8 +670,8 @@ lws_ss_policy_parser_cb(struct lejp_ctx *ctx, char reason)
 #if defined(LWS_ROLE_H1) || defined(LWS_ROLE_H2)
 		/*
 		 * Check the metadata value part to see if it's a well-known
-		 * http header... if so, 0xff means no header string match else
-		 * it's the well-known header index
+		 * http header... if so, LWS_HTTP_NO_KNOWN_HEADER (0xff) means
+		 * no header string match else it's the well-known header index
 		 */
 		a->curr[LTY_POLICY].p->metadata->value_is_http_token = (uint8_t)
 			lws_http_string_to_known_header(ctx->buf, ctx->npos);

--- a/lib/secure-streams/protocols/ss-h1.c
+++ b/lib/secure-streams/protocols/ss-h1.c
@@ -235,7 +235,7 @@ lws_extract_metadata(lws_ss_handle_t *h, struct lws *wsi)
 
 	while (polmd) {
 
-		if (polmd->value_is_http_token != 0xff) {
+		if (polmd->value_is_http_token != LWS_HTTP_NO_KNOWN_HEADER) {
 
 			/* it's a well-known header token */
 
@@ -294,8 +294,8 @@ lws_extract_metadata(lws_ss_handle_t *h, struct lws *wsi)
 					}
 
 					/*
-					 * copy the named custom header value into the
-					 * malloc'd buffer
+					 * copy the named custom header value
+					 * into the malloc'd buffer
 					 */
 
 					if (lws_hdr_custom_copy(wsi, p, n + 1,

--- a/lib/system/smd/README.md
+++ b/lib/system/smd/README.md
@@ -151,6 +151,36 @@ click|The button activity resulted in a classification as a single-click
 longclick|The button activity resulted in a classification as a long-click
 doubleclick|The button activity resulted in a classification as a double-click
 
+### Routing Table Change
+
+Class: `LWSSMDCL_NETWORK`
+
+If able to subscribe to OS routing table changes (eg, by rtnetlink on Linux
+which is supported), lws announces there have been changes using SMD.
+
+If Captive Portal Detect is enabled, and routing tables changes can be seen,
+then a new CPD is requested automatically and the results will be seen over SMD
+when that completes.
+
+Schema:
+
+```
+	{
+	  "rt":      "add|del",   "add" if being added
+	}
+```
+
+When the context / pts are created, if linux then lws attempts to get the
+routing table sent, which requires root.  This is done before the permissions
+are dropped after protocols init.
+
+Lws maintains a cache of the routing table in each pt.  Upon changes, existing
+connections are reassessed to see if their peer can still be routed to, if not
+the connection is closed.
+
+If a gateway route changes, `{"trigger":"cpdcheck","src":"gw-change"}` is
+issued on SMD as well.
+
 ### Captive Portal Detection
 
 Class: `LWSSMDCL_NETWORK`


### PR DESCRIPTION
Fix build failure against Atmel ASF3 SDK that does not provide a file
API conforming to POSIX.

libwebsockets/lib/core/libwebsockets.c: In function 'lws_open':
libwebsockets/lib/core/libwebsockets.c:187:18: error: 'O_CREAT' undeclared (first use in this function)
  if (((__oflag & O_CREAT) == O_CREAT)
                  ^~~~~~~