### PR TITLE
add support for sd-event as event loop

### DIFF
--- a/CMakeLists-implied-options.txt
+++ b/CMakeLists-implied-options.txt
@@ -87,6 +87,7 @@ if(LWS_WITH_DISTRO_RECOMMENDED)
 	set(LWS_WITH_LIBUV 1)				# libuv
 	set(LWS_WITH_LIBEV 1)				# libev
 	set(LWS_WITH_LIBEVENT 1)			# libevent
+	set(LWS_WITH_SDEVENT 0)				# sd-event
 	set(LWS_WITH_EVLIB_PLUGINS 1)			# event libraries created as plugins / individual packages
 	set(LWS_WITHOUT_EXTENSIONS 0)			# libz
 	set(LWS_ROLE_DBUS 1)				# dbus-related libs
@@ -117,7 +118,8 @@ endif()
 if (LWS_WITH_LIBEV OR
     LWS_WITH_LIBUV OR
     LWS_WITH_LIBEVENT OR
-    LWS_WITH_GLIB)
+    LWS_WITH_GLIB OR
+    LWS_WITH_SDEVENT)
 	set(LWS_WITH_EVENT_LIBS 1)
 else()
 	unset(LWS_WITH_EVENT_LIBS)
@@ -343,6 +345,10 @@ endif()
 
 if (LWS_WITH_LIBEVENT)
 	set(LWS_WITH_LIBEVENT 1)
+endif()
+
+if (LWS_WITH_SDEVENT)
+	set(LWS_WITH_SDEVENT 1)
 endif()
 
 if (LWS_IPV6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ option(LWS_WITH_LIBEV "Compile with support for libev" OFF)
 option(LWS_WITH_LIBUV "Compile with support for libuv" OFF)
 option(LWS_WITH_LIBEVENT "Compile with support for libevent" OFF)
 option(LWS_WITH_GLIB "Compile with support for glib event loop" OFF)
+option(LWS_WITH_SDEVENT "Compile with support for systemd event loop" OFF)
 
 if (UNIX)
 # since v4.1, on unix platforms default is build any event libs as runtime plugins

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -150,6 +150,7 @@
 #cmakedefine LWS_WITH_LIBEV
 #cmakedefine LWS_WITH_LIBEVENT
 #cmakedefine LWS_WITH_LIBUV
+#cmakedefine LWS_WITH_SDEVENT
 #cmakedefine LWS_WITH_LWSAC
 #cmakedefine LWS_LOGS_TIMESTAMP
 #cmakedefine LWS_WITH_MBEDTLS

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -230,6 +230,9 @@
 	/**< (CTX) Disable lws_system state, eg, because we are a secure streams
 	 * proxy client that is not trying to track system state by itself. */
 
+#define LWS_SERVER_OPTION_SDEVENT			 (1ll << 36)
+    /**< (CTX) Use systemd event loop */
+
 	/****** add new things just above ---^ ******/
 
 

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -340,6 +340,7 @@ static const struct lws_evlib_map {
 	{ LWS_SERVER_OPTION_LIBEVENT, "evlib_event" },
 	{ LWS_SERVER_OPTION_GLIB,     "evlib_glib" },
 	{ LWS_SERVER_OPTION_LIBEV,    "evlib_ev" },
+	{ LWS_SERVER_OPTION_SDEVENT,  "evlib_sd" },
 };
 static const char * const dlist[] = {
 	LWS_INSTALL_LIBDIR,
@@ -509,6 +510,13 @@ lws_create_context(const struct lws_context_creation_info *info)
 		extern const lws_plugin_evlib_t evlib_ev;
 		plev = &evlib_ev;
 	}
+#endif
+
+#if defined(LWS_WITH_SDEVENT)
+    if (lws_check_opt(info->options, LWS_SERVER_OPTION_SDEVENT)) {
+        extern const lws_plugin_evlib_t evlib_sd;
+        plev = &evlib_sd;
+    }
 #endif
 
 #endif /* with event libs */

--- a/lib/event-libs/CMakeLists.txt
+++ b/lib/event-libs/CMakeLists.txt
@@ -91,6 +91,10 @@ if (LWS_WITH_LIBEV)
 	set(LWS_HAVE_EVBACKEND_IOURING ${LWS_HAVE_EVBACKEND_IOURING} PARENT_SCOPE)
 endif()
 
+if (LWS_WITH_SDEVENT)
+	add_subdir_include_directories(sdevent)
+endif()
+
 
 
 #

--- a/lib/event-libs/sdevent/CMakeLists.txt
+++ b/lib/event-libs/sdevent/CMakeLists.txt
@@ -1,0 +1,27 @@
+# The strategy is to only export to PARENT_SCOPE
+#
+#  - changes to LIB_LIST
+#  - includes via include_directories
+#
+# and keep everything else private
+
+include_directories(.)
+
+if (LWS_WITH_EVLIB_PLUGINS)
+
+    create_evlib_plugin(
+            evlib_sd
+            sdevent.c)
+
+else()
+
+    list(APPEND SOURCES
+            event-libs/sdevent/sdevent.c)
+
+endif()
+
+#
+# Keep explicit parent scope exports at end
+#
+
+exports_to_parent_scope()

--- a/lib/event-libs/sdevent/CMakeLists.txt
+++ b/lib/event-libs/sdevent/CMakeLists.txt
@@ -7,16 +7,26 @@
 
 include_directories(.)
 
+# configure or find systemd library
+set(LIB_SYSTEMD_LIBRARIES CACHE PATH "Path to the libsystemd library")
+if ("${LWS_SYSTEMD_LIBRARIES}" STREQUAL "")
+    if (NOT LIB_SYSTEMD_FOUND)
+        message("searching for systemd")
+        find_library(LIBSYSTEMD_LIBRARIES NAMES systemd)
+    endif()
+else()
+    set(LIBSYSTEMD_LIBRARIES ${LWS_SYSTEMD_LIBRARIES})
+endif()
+message("libsystemd libraries: ${LIBSYSTEMD_LIBRARIES}")
+
 if (LWS_WITH_EVLIB_PLUGINS)
 
-    create_evlib_plugin(
-            evlib_sd
-            sdevent.c)
+    create_evlib_plugin(evlib_sd sdevent.c ${LIBSYSTEMD_LIBRARIES})
 
 else()
 
-    list(APPEND SOURCES
-            event-libs/sdevent/sdevent.c)
+    list(APPEND LIB_LIST ${LIBSYSTEMD_LIBRARIES})
+    list(APPEND SOURCES event-libs/sdevent/sdevent.c)
 
 endif()
 

--- a/lib/event-libs/sdevent/private-lib-event-libs-sdevent.h
+++ b/lib/event-libs/sdevent/private-lib-event-libs-sdevent.h
@@ -1,0 +1,3 @@
+#include <private-lib-core.h>
+
+extern const struct lws_event_loop_ops event_loop_ops_sdevent;

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -1,4 +1,3 @@
-#include <pthread.h>
 #include <systemd/sd-event.h>
 
 #include <private-lib-core.h>
@@ -25,8 +24,7 @@ struct lws_wsi_watcher_sdevent {
 };
 
 static int init_context_sd(struct lws_context *context, const struct lws_context_creation_info *info) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
 
     // extra info, can be removed
     printf("%s(%d) %s info->signal_cb is %p\n", __FILE__, __LINE__, __func__, info->signal_cb);
@@ -36,32 +34,27 @@ static int init_context_sd(struct lws_context *context, const struct lws_context
 }
 
 static int destroy_context1_sd(struct lws_context *context) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
     return 0;
 }
 
 static int destroy_context2_sd(struct lws_context *context) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
     return 0;
 }
 
 static int init_vhost_listen_wsi_sd(struct lws *wsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
     return 0;
 }
 
 static int sultimer_handler(sd_event_source *s, uint64_t usec, void *userdata) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
     return 0;
 }
 
 static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s entered\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered %s\n", __FILE__, __LINE__, __func__);
 
     struct lws_context_per_thread *pt = &context->pt[tsi];
     struct lws_pt_eventlibs_sdevent *ptpriv = pt_to_priv_sd(pt);
@@ -101,7 +94,6 @@ static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
     }
 
     if (first) {
-        // TODO init sultimer
         if (0 > sd_event_add_time(
                 loop,
                 &ptpriv->sultimer,
@@ -119,25 +111,21 @@ static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
 }
 
 static int wsi_logical_close_sd(struct lws *wsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
     return 0;
 }
 
 static int check_client_connect_ok_sd(struct lws *wsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
     return 0;
 }
 
 static void close_handle_manually_sd(struct lws *wsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
 }
 
 static int sock_accept_handler(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s entered\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered %s\n", __FILE__, __LINE__, __func__);
 
     struct lws *wsi = (struct lws*) userdata;
     struct lws_context *context = wsi->a.context;
@@ -169,6 +157,7 @@ static int sock_accept_handler(sd_event_source *s, int fd, uint32_t revents, voi
     lws_pt_unlock(pt);
     lws_context_unlock(pt->context);
 
+    printf("%s(%d) called lws_service_fd_tsi\n", __FILE__, __LINE__);
     lws_service_fd_tsi(context, &eventfd, wsi->tsi);
 
     if (pt->destroy_self) {
@@ -185,8 +174,7 @@ bail:
 }
 
 static int sock_accept_sd(struct lws *wsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s entered\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered %s\n", __FILE__, __LINE__, __func__);
 
     struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
 
@@ -215,8 +203,7 @@ static int sock_accept_sd(struct lws *wsi) {
 }
 
 static void io_sd(struct lws *wsi, int flags) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s entered for wsi %p with flags %d\n", __FILE__, __LINE__, pt_id, __func__, wsi, flags);
+    printf("%s(%d) entered %s\n", __FILE__, __LINE__, __func__);
 
     struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
 
@@ -260,8 +247,7 @@ static void io_sd(struct lws *wsi, int flags) {
 }
 
 static void run_pt_sd(struct lws_context *context, int tsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s entered\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered %s\n", __FILE__, __LINE__, __func__);
 
     struct lws_context_per_thread *pt = &context->pt[tsi];
     struct lws_pt_eventlibs_sdevent *ptpriv = pt_to_priv_sd(pt);
@@ -271,13 +257,11 @@ static void run_pt_sd(struct lws_context *context, int tsi) {
 }
 
 static void destroy_pt_sd(struct lws_context *context, int tsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
 }
 
 static void destroy_wsi_sd(struct lws *wsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
 }
 
 const struct lws_event_loop_ops event_loop_ops_sdevent = {

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -142,6 +142,7 @@ static int sock_accept_handler(sd_event_source *s, int fd, uint32_t revents, voi
     sd_event_source_set_time(pt_to_priv_sd(pt)->idletimer, (uint64_t) 0);
     sd_event_source_set_enabled(pt_to_priv_sd(pt)->idletimer, SD_EVENT_ON);
 
+    sd_event_source_set_enabled(s, SD_EVENT_ONESHOT);
     return 0;
 
 bail:

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -38,9 +38,11 @@ static int sultimer_handler(sd_event_source *s, uint64_t usec, void *userdata) {
                                 lws_now_usecs());
     if (us) {
         uint64_t alarmTime;
-        sd_event_source_get_time(pt_to_priv_sd(pt)->sultimer, &alarmTime);
+        sd_event_now(sd_event_source_get_event(s), CLOCK_MONOTONIC, &alarmTime);
         alarmTime += us;
         sd_event_source_set_time(pt_to_priv_sd(pt)->sultimer, alarmTime);
+        sd_event_source_set_enabled(pt_to_priv_sd(pt)->sultimer, SD_EVENT_ONESHOT);
+        printf("%s(%d) self, next in %lu\n", __FILE__, __LINE__, us);
     }
 
     lws_pt_unlock(pt);
@@ -83,6 +85,8 @@ static int idle_handler(sd_event_source *s, uint64_t usec, void *userdata) {
         sd_event_now(sd_event_source_get_event(s), CLOCK_MONOTONIC, &alarmTime);
         alarmTime += us;
         sd_event_source_set_time(pt_to_priv_sd(pt)->sultimer, alarmTime);
+        sd_event_source_set_enabled(pt_to_priv_sd(pt)->sultimer, SD_EVENT_ONESHOT);
+        printf("%s(%d) idle, next in %lu\n", __FILE__, __LINE__, us);
     }
 
     sd_event_source_set_enabled(pt_to_priv_sd(pt)->idletimer, SD_EVENT_OFF);

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -210,10 +210,17 @@ static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
                 loop,
                 &ptpriv->sultimer,
                 CLOCK_MONOTONIC,
-                UINT64_MAX,
+                0,
                 0,
                 sultimer_handler,
                 NULL
+        )) {
+            return -1;
+        }
+
+        if (0 > sd_event_source_set_priority(
+                ptpriv->sultimer,
+                SD_EVENT_PRIORITY_IDLE
         )) {
             return -1;
         }

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -315,7 +315,14 @@ static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
 }
 
 static int wsi_logical_close_sd(struct lws *wsi) {
-    printf("%s(%d) entered (not impl!) %s\n", __FILE__, __LINE__, __func__);
+    printf("%s(%d) entered %s\n", __FILE__, __LINE__, __func__);
+
+    if (wsi_to_priv_sd(wsi)->source) {
+        sd_event_source_set_enabled(wsi_to_priv_sd(wsi)->source, SD_EVENT_OFF);
+        sd_event_source_unref(wsi_to_priv_sd(wsi)->source);
+        wsi_to_priv_sd(wsi)->source = NULL;
+    }
+
     return 0;
 }
 

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -1,5 +1,9 @@
+#include <pthread.h>
 #include <private-lib-core.h>
 #include "private-lib-event-libs-sdevent.h"
+
+#define pt_to_priv_sd(_pt) ((struct lws_pt_eventlibs_sdevent *)(_pt)->evlib_pt)
+#define wsi_to_priv_sd(_w) ((struct lws_wsi_watcher_sdevent *)(_w)->evlib_wsi)
 
 struct lws_context_eventlibs_sdevent {
 };
@@ -10,72 +14,100 @@ struct lws_pt_eventlibs_sdevent {
 struct lws_vh_eventlibs_sdevent {
 };
 
-struct lws_io_watcher_sdevent {
+struct lws_wsi_watcher_sdevent {
 };
 
 static int init_context_sd(struct lws_context *context, const struct lws_context_creation_info *info) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+
+    // extra info, can be removed
+    printf("%s(%d) %s info->signal_cb is %p\n", __FILE__, __LINE__, __func__, info->signal_cb);
+    printf("%s(%d) %s context->count_threads is %d\n", __FILE__, __LINE__, __func__, context->count_threads);
+
     return 0;
 }
 
 static int destroy_context1_sd(struct lws_context *context) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return 0;
 }
 
 static int destroy_context2_sd(struct lws_context *context) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return 0;
 }
 
 static int init_vhost_listen_wsi_sd(struct lws *wsi) {
-printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
-return 0;
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    return 0;
 }
 
 static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+
+    // extra info, can be removed
+    printf("%s(%d) %s _loop is %p\n", __FILE__, __LINE__, __func__, _loop);
+    printf("%s(%d) %s tsi is %d\n", __FILE__, __LINE__, __func__, tsi);
+
     return 0;
 }
 
 static int wsi_logical_close_sd(struct lws *wsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return 0;
 }
 
 static int check_client_connect_ok_sd(struct lws *wsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return 0;
 }
 
 static void close_handle_manually_sd(struct lws *wsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return;
 }
 
 static int sock_accept_sd(struct lws *wsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return 0;
 }
 
 static void io_sd(struct lws *wsi, int flags) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+
+    // extra info, can be removed
+    printf("%s(%d) %s wsi is %p\n", __FILE__, __LINE__, __func__, wsi);
+    printf("%s(%d) %s flags is %x\n", __FILE__, __LINE__, __func__, flags);
+
     return;
 }
 
 static void run_pt_sd(struct lws_context *context, int tsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     sleep(1);
     return;
 }
 
 static void destroy_pt_sd(struct lws_context *context, int tsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return;
 }
 
 static void destroy_wsi_sd(struct lws *wsi) {
-    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return;
 }
 
@@ -100,7 +132,7 @@ const struct lws_event_loop_ops event_loop_ops_sdevent = {
         .evlib_size_ctx = sizeof(struct lws_context_eventlibs_sdevent),
         .evlib_size_pt = sizeof(struct lws_pt_eventlibs_sdevent),
         .evlib_size_vh = sizeof(struct lws_vh_eventlibs_sdevent),
-        .evlib_size_wsi = sizeof(struct lws_io_watcher_sdevent),
+        .evlib_size_wsi = sizeof(struct lws_wsi_watcher_sdevent),
 };
 
 #if defined(LWS_WITH_EVLIB_PLUGINS)

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -13,6 +13,7 @@ struct lws_context_eventlibs_sdevent {
 struct lws_pt_eventlibs_sdevent {
     struct lws_context_per_thread *pt;
     struct sd_event *io_loop;
+    struct sd_event_source *sultimer;
 };
 
 struct lws_vh_eventlibs_sdevent {
@@ -47,6 +48,12 @@ static int destroy_context2_sd(struct lws_context *context) {
 }
 
 static int init_vhost_listen_wsi_sd(struct lws *wsi) {
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
+    return 0;
+}
+
+static int sultimer_handler(sd_event_source *s, uint64_t usec, void *userdata) {
     pthread_t pt_id = pthread_self();
     printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     return 0;
@@ -95,6 +102,17 @@ static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
 
     if (first) {
         // TODO init sultimer
+        if (0 > sd_event_add_time(
+                loop,
+                &ptpriv->sultimer,
+                CLOCK_MONOTONIC,
+                UINT64_MAX,
+                0,
+                sultimer_handler,
+                NULL
+        )) {
+            return -1;
+        }
     }
 
     return 0;

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -13,21 +13,87 @@ struct lws_vh_eventlibs_sdevent {
 struct lws_io_watcher_sdevent {
 };
 
+static int init_context_sd(struct lws_context *context, const struct lws_context_creation_info *info) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static int destroy_context1_sd(struct lws_context *context) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static int destroy_context2_sd(struct lws_context *context) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static int init_vhost_listen_wsi_sd(struct lws *wsi) {
+printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+return 0;
+}
+
+static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static int wsi_logical_close_sd(struct lws *wsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static int check_client_connect_ok_sd(struct lws *wsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static void close_handle_manually_sd(struct lws *wsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return;
+}
+
+static int sock_accept_sd(struct lws *wsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return 0;
+}
+
+static void io_sd(struct lws *wsi, int flags) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return;
+}
+
+static void run_pt_sd(struct lws_context *context, int tsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    sleep(1);
+    return;
+}
+
+static void destroy_pt_sd(struct lws_context *context, int tsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return;
+}
+
+static void destroy_wsi_sd(struct lws *wsi) {
+    printf("%s(%d) %s not implemented\n", __FILE__, __LINE__, __func__);
+    return;
+}
+
 const struct lws_event_loop_ops event_loop_ops_sdevent = {
         .name = "sdevent",
-        .init_context = NULL,
-        .destroy_context1 = NULL,
-        .destroy_context2 = NULL,
-        .init_vhost_listen_wsi = NULL,
-        .init_pt = NULL,
-        .wsi_logical_close = NULL,
-        .check_client_connect_ok = NULL,
-        .close_handle_manually = NULL,
-        .sock_accept = NULL,
-        .io = NULL,
-        .run_pt = NULL,
-        .destroy_pt = NULL,
-        .destroy_wsi = NULL,
+        .init_context = init_context_sd,
+        .destroy_context1 = destroy_context1_sd,
+        .destroy_context2 = destroy_context2_sd,
+        .init_vhost_listen_wsi = init_vhost_listen_wsi_sd,
+        .init_pt = init_pt_sd,
+        .wsi_logical_close = wsi_logical_close_sd,
+        .check_client_connect_ok = check_client_connect_ok_sd,
+        .close_handle_manually = close_handle_manually_sd,
+        .sock_accept = sock_accept_sd,
+        .io = io_sd,
+        .run_pt = run_pt_sd,
+        .destroy_pt = destroy_pt_sd,
+        .destroy_wsi = destroy_wsi_sd,
 
         .flags = 0,
 

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -1,0 +1,51 @@
+#include <private-lib-core.h>
+#include "private-lib-event-libs-sdevent.h"
+
+struct lws_context_eventlibs_sdevent {
+};
+
+struct lws_pt_eventlibs_sdevent {
+};
+
+struct lws_vh_eventlibs_sdevent {
+};
+
+struct lws_io_watcher_sdevent {
+};
+
+const struct lws_event_loop_ops event_loop_ops_sdevent = {
+        .name = "sdevent",
+        .init_context = NULL,
+        .destroy_context1 = NULL,
+        .destroy_context2 = NULL,
+        .init_vhost_listen_wsi = NULL,
+        .init_pt = NULL,
+        .wsi_logical_close = NULL,
+        .check_client_connect_ok = NULL,
+        .close_handle_manually = NULL,
+        .sock_accept = NULL,
+        .io = NULL,
+        .run_pt = NULL,
+        .destroy_pt = NULL,
+        .destroy_wsi = NULL,
+
+        .flags = 0,
+
+        .evlib_size_ctx = sizeof(struct lws_context_eventlibs_sdevent),
+        .evlib_size_pt = sizeof(struct lws_pt_eventlibs_sdevent),
+        .evlib_size_vh = sizeof(struct lws_vh_eventlibs_sdevent),
+        .evlib_size_wsi = sizeof(struct lws_io_watcher_sdevent),
+};
+
+#if defined(LWS_WITH_EVLIB_PLUGINS)
+LWS_VISIBLE
+#endif
+const lws_plugin_evlib_t evlib_sd = {
+        .hdr = {
+                "systemd event loop",
+                "lws_evlib_plugin",
+                LWS_PLUGIN_API_MAGIC
+        },
+
+        .ops	= &event_loop_ops_sdevent
+};

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -1,4 +1,6 @@
 #include <pthread.h>
+#include <systemd/sd-event.h>
+
 #include <private-lib-core.h>
 #include "private-lib-event-libs-sdevent.h"
 
@@ -9,6 +11,8 @@ struct lws_context_eventlibs_sdevent {
 };
 
 struct lws_pt_eventlibs_sdevent {
+    struct lws_context_per_thread *pt;
+    struct sd_event *io_loop;
 };
 
 struct lws_vh_eventlibs_sdevent {
@@ -47,12 +51,46 @@ static int init_vhost_listen_wsi_sd(struct lws *wsi) {
 }
 
 static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
-    pthread_t pt_id = pthread_self();
-    printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
 
-    // extra info, can be removed
-    printf("%s(%d) %s _loop is %p\n", __FILE__, __LINE__, __func__, _loop);
-    printf("%s(%d) %s tsi is %d\n", __FILE__, __LINE__, __func__, tsi);
+    struct lws_context_per_thread *pt = &context->pt[tsi];
+    struct lws_pt_eventlibs_sdevent *ptpriv = pt_to_priv_sd(pt);
+
+    struct sd_event *loop = (struct sd_event *)_loop;
+    int first = 1;  // we are the first that create and initialize the loop
+
+    ptpriv->pt = pt;
+
+    // make sure we have an event loop
+    if (!ptpriv->io_loop) {
+        if (!loop) {
+            if (sd_event_default(&loop) < 0) {
+                lwsl_err("cannot get/create event loop, possibly out-of-memory\n");
+                return -1;
+            }
+            pt->event_loop_foreign = 0;
+        } else {
+            pt->event_loop_foreign = 1;
+        }
+
+        ptpriv->io_loop = loop;
+
+        // TODO for full libwebsockets support, add handling for  LWS_SERVER_OPTION_UV_NO_SIGSEGV_SIGFPE_SPIN
+
+    } else {
+        first = 0;  // the loop was initialized before, we do not need to do full initialization
+    }
+
+    // initialize accept/read for vhosts
+    for (struct lws_vhost *vh = context->vhost_list; vh; vh = vh->vhost_next) {
+        // call lws_event_loop_ops->init_vhost_listen_wsi
+        if (init_vhost_listen_wsi_sd(vh->lserv_wsi) == -1) {
+            return -1;
+        }
+    }
+
+    if (first) {
+        // TODO init sultimer
+    }
 
     return 0;
 }
@@ -72,7 +110,6 @@ static int check_client_connect_ok_sd(struct lws *wsi) {
 static void close_handle_manually_sd(struct lws *wsi) {
     pthread_t pt_id = pthread_self();
     printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
-    return;
 }
 
 static int sock_accept_sd(struct lws *wsi) {
@@ -88,27 +125,22 @@ static void io_sd(struct lws *wsi, int flags) {
     // extra info, can be removed
     printf("%s(%d) %s wsi is %p\n", __FILE__, __LINE__, __func__, wsi);
     printf("%s(%d) %s flags is %x\n", __FILE__, __LINE__, __func__, flags);
-
-    return;
 }
 
 static void run_pt_sd(struct lws_context *context, int tsi) {
     pthread_t pt_id = pthread_self();
     printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
     sleep(1);
-    return;
 }
 
 static void destroy_pt_sd(struct lws_context *context, int tsi) {
     pthread_t pt_id = pthread_self();
     printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
-    return;
 }
 
 static void destroy_wsi_sd(struct lws *wsi) {
     pthread_t pt_id = pthread_self();
     printf("%s(%d) [%lu] %s not implemented\n", __FILE__, __LINE__, pt_id, __func__);
-    return;
 }
 
 const struct lws_event_loop_ops event_loop_ops_sdevent = {

--- a/lib/event-libs/sdevent/sdevent.c
+++ b/lib/event-libs/sdevent/sdevent.c
@@ -51,6 +51,8 @@ static int init_vhost_listen_wsi_sd(struct lws *wsi) {
 }
 
 static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
+    pthread_t pt_id = pthread_self();
+    printf("%s(%d) [%lu] %s entered\n", __FILE__, __LINE__, pt_id, __func__);
 
     struct lws_context_per_thread *pt = &context->pt[tsi];
     struct lws_pt_eventlibs_sdevent *ptpriv = pt_to_priv_sd(pt);
@@ -81,6 +83,7 @@ static int init_pt_sd(struct lws_context *context, void *_loop, int tsi) {
     }
 
     // initialize accept/read for vhosts
+    // Note: default vhost usually not included here
     for (struct lws_vhost *vh = context->vhost_list; vh; vh = vh->vhost_next) {
         // call lws_event_loop_ops->init_vhost_listen_wsi
         if (init_vhost_listen_wsi_sd(vh->lserv_wsi) == -1) {


### PR DESCRIPTION
Hello @lws-team 

(This is not yet a pull request.)

We want to use libwebsockets for some application that mandates [sd-event](https://man7.org/linux/man-pages/man3/sd-event.3.html) as event loop. To that purpose, I have added a rudimentary `lib/event-libs/sdevent/sdevent.c` based your v4.1-stable branch. So far this is neither mature nor well-tested, but the software we need it for is (without libwebsockets) already in production and will remain so for the next few years.

Is there something similar (support for sd-event) in preparation yet? Would you consider adding support for sd-event in the future? What are your requirements for merging a change like this into libwebsockets?

Best regards
Christian Fuchs (cfuchs@scs.ch)