### PR TITLE
Handle all instances of lost precision as gracefully as practical.

### DIFF
--- a/lib/plat/unix/unix-file.c
+++ b/lib/plat/unix/unix-file.c
@@ -46,9 +46,9 @@ int lws_plat_apply_FD_CLOEXEC(int n)
 int
 lws_plat_write_file(const char *filename, void *buf, int len)
 {
-	int m, fd;
+	ssize_t m;
 
-	fd = lws_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	int fd = lws_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 
 	if (fd == -1)
 		return 1;
@@ -62,14 +62,17 @@ lws_plat_write_file(const char *filename, void *buf, int len)
 int
 lws_plat_read_file(const char *filename, void *buf, int len)
 {
-	int n, fd = lws_open(filename, O_RDONLY);
+        ssize_t n;
+	int fd = lws_open(filename, O_RDONLY);
 	if (fd == -1)
 		return -1;
 
 	n = read(fd, buf, len);
 	close(fd);
 
-	return n;
+        if (n <= INT_MAX)
+            return (int)n;
+        return -1;
 }
 
 lws_fop_fd_t

--- a/lib/plat/unix/unix-misc.c
+++ b/lib/plat/unix/unix-misc.c
@@ -97,7 +97,7 @@ int
 lws_plat_write_cert(struct lws_vhost *vhost, int is_key, int fd, void *buf,
 			int len)
 {
-	int n;
+	ssize_t n;
 
 	n = write(fd, buf, len);
 

--- a/lib/plat/unix/unix-pipe.c
+++ b/lib/plat/unix/unix-pipe.c
@@ -55,7 +55,7 @@ lws_plat_pipe_signal(struct lws_context *ctx, int tsi)
 	return eventfd_write(pt->dummy_pipe_fds[0], value);
 #else
 	char buf = 0;
-	int n;
+	ssize_t n;
 
 	n = write(pt->dummy_pipe_fds[1], &buf, 1);
 

--- a/lib/plat/unix/unix-service.c
+++ b/lib/plat/unix/unix-service.c
@@ -131,7 +131,7 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 
 	vpt->inside_poll = 1;
 	lws_memory_barrier();
-	n = poll(pt->fds, pt->fds_count, timeout_us /* ms now */ );
+	n = poll(pt->fds, pt->fds_count, (int)timeout_us /* ms now */ );
 	vpt->inside_poll = 0;
 	lws_memory_barrier();
 

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -41,7 +41,7 @@ lws_http_client_socket_service(struct lws *wsi, struct lws_pollfd *pollfd)
 #endif
 	const char *cce = NULL;
 	char *sb = p;
-	int n = 0;
+	ssize_t n = 0;
 
 	switch (lwsi_state(wsi)) {
 

--- a/lib/roles/http/server/lejp-conf.c
+++ b/lib/roles/http/server/lejp-conf.c
@@ -930,7 +930,8 @@ lwsws_get_config(void *user, const char *f, const char * const *paths,
 {
 	unsigned char buf[128];
 	struct lejp_ctx ctx;
-	int n, m = 0, fd;
+    ssize_t n = 0;
+	int m = 0, fd;
 
 	fd = lws_open(f, O_RDONLY);
 	if (fd < 0) {
@@ -942,18 +943,18 @@ lwsws_get_config(void *user, const char *f, const char * const *paths,
 
 	do {
 		n = read(fd, buf, sizeof(buf));
-		if (!n)
+		if (!n || n > INT_MAX)
 			break;
 
-		m = lejp_parse(&ctx, buf, n);
+		m = lejp_parse(&ctx, buf, (int)n);
 	} while (m == LEJP_CONTINUE);
 
 	close(fd);
-	n = ctx.line;
+	n = (ssize_t)ctx.line;
 	lejp_destruct(&ctx);
 
 	if (m < 0) {
-		lwsl_err("%s(%u): parsing error %d: %s\n", f, n, m,
+		lwsl_err("%s(%zd): parsing error %d: %s\n", f, n, m,
 			 lejp_error_to_string(m));
 		return 2;
 	}

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -831,7 +831,8 @@ static int
 lws_find_string_in_file(const char *filename, const char *string, int stringlen)
 {
 	char buf[128];
-	int fd, match = 0, pos = 0, n = 0, hit = 0;
+        ssize_t n =0;
+	int fd, match = 0, pos = 0, hit = 0;
 
 	fd = lws_open(filename, O_RDONLY);
 	if (fd < 0) {

--- a/lib/roles/pipe/ops-pipe.c
+++ b/lib/roles/pipe/ops-pipe.c
@@ -40,7 +40,7 @@ rops_handle_POLLIN_pipe(struct lws_context_per_thread *pt, struct lws *wsi,
 	}
 #elif !defined(WIN32) && !defined(_WIN32)
 	char s[100];
-	int n;
+	ssize_t n;
 
 	/*
 	 * discard the byte(s) that signaled us

--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -457,13 +457,13 @@ lws_tls_client_confirm_peer_cert(struct lws *wsi, char *ebuf, int ebuf_len)
 	struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
 	char *p = (char *)&pt->serv_buf[0];
 	char *sb = p;
-	int n;
+	long n;
 
 	errno = 0;
 	ERR_clear_error();
 	n = SSL_get_verify_result(wsi->tls.ssl);
 
-	lwsl_debug("get_verify says %d\n", n);
+	lwsl_debug("get_verify says %zd\n", n);
 
 	if (n == X509_V_OK)
 		return 0;
@@ -487,7 +487,7 @@ lws_tls_client_confirm_peer_cert(struct lws *wsi, char *ebuf, int ebuf_len)
 		return 0;
 	}
 	lws_snprintf(ebuf, ebuf_len,
-		"server's cert didn't look good, X509_V_ERR = %d: %s\n",
+		"server's cert didn't look good, X509_V_ERR = %ld: %s\n",
 		 n, ERR_error_string(n, sb));
 	lwsl_info("%s\n", ebuf);
 	lws_tls_err_describe_clear();

--- a/lib/tls/tls-server.c
+++ b/lib/tls/tls-server.c
@@ -130,7 +130,7 @@ lws_server_socket_service_ssl(struct lws *wsi, lws_sockfd_type accept_fd, char f
 	struct lws_context *context = wsi->a.context;
 	struct lws_context_per_thread *pt = &context->pt[(int)wsi->tsi];
 	struct lws_vhost *vh;
-	int n;
+	ssize_t n;
 
 	if (!LWS_SSL_ENABLED(wsi->a.vhost))
 		return 0;
@@ -325,13 +325,13 @@ punt:
 		errno = 0;
 		lws_stats_bump(pt, LWSSTATS_C_SSL_ACCEPT_SPIN, 1);
 		n = lws_tls_server_accept(wsi);
-		lwsl_info("SSL_accept says %d\n", n);
+		lwsl_info("SSL_accept says %zd\n", n);
 		switch (n) {
 		case LWS_SSL_CAPABLE_DONE:
 			break;
 		case LWS_SSL_CAPABLE_ERROR:
 			lws_stats_bump(pt, LWSSTATS_C_SSL_CONNECTIONS_FAILED, 1);
-	                lwsl_info("%s: SSL_accept failed socket %u: %d\n",
+	                lwsl_info("%s: SSL_accept failed socket %u: %zd\n",
 	                		__func__, wsi->desc.sockfd, n);
 			wsi->socket_is_permanently_unusable = 1;
 			goto fail;

--- a/lib/tls/tls.c
+++ b/lib/tls/tls.c
@@ -352,7 +352,8 @@ static int
 lws_tls_extant(const char *name)
 {
 	/* it exists if we can open it... */
-	int fd = open(name, O_RDONLY), n;
+        ssize_t n;
+	int fd = open(name, O_RDONLY);
 	char buf[1];
 
 	if (fd < 0)

--- a/plugins/protocol_post_demo.c
+++ b/plugins/protocol_post_demo.c
@@ -68,7 +68,7 @@ file_upload_cb(void *data, const char *name, const char *filename,
 	struct per_session_data__post_demo *pss =
 			(struct per_session_data__post_demo *)data;
 #if !defined(LWS_WITH_ESP32)
-	int n;
+	ssize_t n;
 
 	(void)n;
 #endif
@@ -95,7 +95,7 @@ file_upload_cb(void *data, const char *name, const char *filename,
 
 #if !defined(LWS_WITH_ESP32)
 			n = write((int)(lws_intptr_t)pss->fd, buf, len);
-			lwsl_info("%s: write %d says %d\n", __func__, len, n);
+			lwsl_info("%s: write %d says %zd\n", __func__, len, n);
 #else
 			lwsl_notice("%s: Received chunk size %d\n", __func__, len);
 #endif

--- a/test-apps/test-client.c
+++ b/test-apps/test-client.c
@@ -281,7 +281,7 @@ callback_dumb_increment(struct lws *wsi, enum lws_callback_reasons reason,
 			/* Enable CRL checking of the server certificate */
 			X509_STORE *store;
 			X509_LOOKUP *lookup;
-			int n;
+			unsigned long n;
 			X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new();
 			X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_CRL_CHECK);
 			SSL_CTX_set1_param((SSL_CTX*)user, param);
@@ -295,7 +295,7 @@ callback_dumb_increment(struct lws *wsi, enum lws_callback_reasons reason,
 				char errbuf[256];
 				n = ERR_get_error();
 				lwsl_err("EXTRA_CLIENT_VERIFY_CERTS: "
-					 "SSL error: %s (%d)\n",
+					 "SSL error: %s (%lu)\n",
 					 ERR_error_string(n, errbuf), n);
 				return 1;
 			}
@@ -567,7 +567,7 @@ static int ratelimit_connects(unsigned int *last, unsigned int secs)
 	if (tv.tv_sec - (*last) < secs)
 		return 0;
 
-	*last = tv.tv_sec;
+	*last = (unsigned int)tv.tv_sec;
 
 	return 1;
 }

--- a/test-apps/test-lejp.c
+++ b/test-apps/test-lejp.c
@@ -88,7 +88,8 @@ cb(struct lejp_ctx *ctx, char reason)
 int
 main(int argc, char *argv[])
 {
-	int fd, n = 1, ret = 1, m = 0;
+    ssize_t n = 1;
+	int fd, ret = 1, m = 0;
 	struct lejp_ctx ctx;
 	char buf[128];
 
@@ -103,10 +104,10 @@ main(int argc, char *argv[])
 
 	while (n > 0) {
 		n = read(fd, buf, sizeof(buf));
-		if (n <= 0)
+		if (n <= 0 || n > INT_MAX)
 			continue;
 
-		m = lejp_parse(&ctx, (uint8_t *)buf, n);
+		m = lejp_parse(&ctx, (uint8_t *)buf, (int)n);
 		if (m < 0 && m != LEJP_CONTINUE) {
 			lwsl_err("parse failed %d\n", m);
 			goto bail;


### PR DESCRIPTION
Types with increased precision are used where possible and in cases where adding increased precision wasn't practical, bounds checks were added. The behavior of the program should remain exactly the same unless side effects from implicit, lossy, type conversions were being relied upon. This is part of an effort to enable compilation with `-Werror` that will require several more patches, but this one is the largest.