### PR TITLE
pollfd: Interrupt WSAPoll while event changes

### DIFF
--- a/lib/plat/windows/windows-sockets.c
+++ b/lib/plat/windows/windows-sockets.c
@@ -238,6 +238,7 @@ lws_plat_change_pollfd(struct lws_context *context, struct lws *wsi,
 		       struct lws_pollfd *pfd)
 {
 	//struct lws_context_per_thread *pt = &context->pt[(int)wsi->tsi];
+	lws_plat_pipe_signal(wsi->a.context, wsi->tsi);
 
 	return 0;
 }


### PR DESCRIPTION
Dear Sir:
Since the windows busy loop already fix in 3bf3b540ad8f386095d8fe95ac9b1fe78afcf8e1, it cause another issue.
Because WSAPoll() is blocked so the event change will be ignore.
I don't know if you are still developing on it, but I commit one line to avoid this problem, and it is work for me.

Thanks.