### PR TITLE
lws_struct: fix implicit schema recognition

### DIFF
--- a/lib/misc/lws-struct-lejp.c
+++ b/lib/misc/lws-struct-lejp.c
@@ -51,10 +51,10 @@ lws_struct_schema_only_lejp_cb(struct lejp_ctx *ctx, char reason)
 		 */
 
 		while (n--) {
-			const lws_struct_map_t *child = map->child_map;
 			int m, child_members = (int)map->child_map_size;
 
 			for (m = 0; m < child_members; m++) {
+				const lws_struct_map_t *child = &map->child_map[m];
 				if (!strcmp(ctx->path, child->colname)) {
 					/*
 					 * We matched on him... map is pointing


### PR DESCRIPTION
The current attempt to implicitly match the schema is only working if the first child of the schema struct matches the first encountered key in the JSON object. The code never actually iterates through all entries but uses only the first (m times).

