### PR TITLE
Add client support for reusing sessions (OpenSSL)

### DIFF
--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -514,6 +514,9 @@ struct lws_context_creation_info {
 	/**< VHOST: Client SSL context init: length of client_ssl_key_mem in
 	 * bytes */
 
+	int client_ssl_reuse_sessions;
+	/**< VHOST: Client SSL context init: 0 = default, do not use session
+	 * cache; 1 = cache and attempt to reuse sessions */
 #endif
 
 #if !defined(LWS_WITH_MBEDTLS)

--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -261,6 +261,14 @@ typedef struct lws_attach_item {
  *  - contextwide headers pool
  */
 
+#if defined(LWS_WITH_NETWORK) && defined(LWS_WITH_TLS) && defined(LWS_WITH_CLIENT)
+struct lws_session_cache {
+	char* name;
+	SSL_SESSION* session;
+	struct lws_session_cache* next;
+};
+#endif
+
 struct lws_context {
  #if defined(LWS_WITH_SERVER)
 	char canonical_hostname[96];
@@ -365,6 +373,10 @@ struct lws_context {
 
 #if defined(LWS_WITH_TLS)
 	const struct lws_tls_ops	*tls_ops;
+#if defined(LWS_WITH_CLIENT)
+	int				client_ssl_reuse_sessions;
+	struct lws_session_cache	*client_ssl_session_cache;
+#endif
 #endif
 
 #if defined(LWS_WITH_DETAILED_LATENCY)
@@ -543,6 +555,14 @@ signed char char_to_hex(const char c);
 #if defined(LWS_WITH_NETWORK)
 int
 lws_system_do_attach(struct lws_context_per_thread *pt);
+
+#if defined(LWS_WITH_TLS) && defined(LWS_WITH_CLIENT)
+int
+lws_context_cache_session(struct lws_context* ctx, SSL_SESSION* sess, const char* name);
+
+SSL_SESSION*
+lws_context_get_cached_session(const struct lws_context* ctx, const char* name);
+#endif
 #endif
 
 struct lws_buflist {


### PR DESCRIPTION
This is an attempt to allow clients to reuse SSL sessions. Potentially reusable sessions will be kept in a LWS cache.
This can be enabled by setting the new `client_ssl_reuse_sessions` flag in `lws_context_creation_info` to `1`.
The precompiler condition for using the new functionality seemed to be
```
#if defined(LWS_WITH_NETWORK) && defined(LWS_WITH_TLS) && defined(LWS_WITH_CLIENT)
```

A session is identified by a string composed of the "\<IP\>:\<port\>". For an existing sessions identified in this way, after attempting to reuse it, `SSL_session_reused()` did return `1` for it.