### PR TITLE
cmake: check if _GNU_SOURCE is already defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,7 +655,10 @@ if ((CMAKE_C_COMPILER_ID MATCHES "Clang") OR
 endif()
 
 if (LWS_HAVE_PTHREAD_H AND NOT LWS_PLAT_FREERTOS)
-	CHECK_C_SOURCE_COMPILES("#define _GNU_SOURCE
+	CHECK_C_SOURCE_COMPILES("
+		#ifndef _GNU_SOURCE
+		#define _GNU_SOURCE
+		#endif
 		#include <pthread.h>
 		int main(void) {
 			pthread_t th = 0;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -103,7 +103,15 @@ endif()
 
 # ideally we want to use pipe2()
 
-CHECK_C_SOURCE_COMPILES("#define _GNU_SOURCE\n#include <unistd.h>\nint main(void) {int fd[2];\n return pipe2(fd, 0);\n}\n" LWS_HAVE_PIPE2)
+CHECK_C_SOURCE_COMPILES("
+	#ifndef _GNU_SOURCE
+	#define _GNU_SOURCE
+	#endif
+	#include <unistd.h>
+	int main(void) {
+		int fd[2];
+		return pipe2(fd, 0);
+	}" LWS_HAVE_PIPE2)
 
 # tcp keepalive needs this on linux to work practically... but it only exists
 # after kernel 2.6.37


### PR DESCRIPTION
`_GNU_SOURCE` can already be defined in `CMAKE_C_FLAGS`, so instead of redefining it (which will cause an error), check it beforehand.