### PR TITLE
cmake: export include directory

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -161,6 +161,9 @@ if (LWS_WITH_STATIC)
 	add_library(websockets STATIC ${SOURCES})# ${HDR_PUBLIC})
 	set_target_properties(websockets PROPERTIES LINKER_LANGUAGE C)
 	list(APPEND LWS_LIBRARIES websockets)
+	target_include_directories(websockets INTERFACE
+		$<INSTALL_INTERFACE:${LWS_INSTALL_INCLUDE_DIR}>
+	)
 	target_include_directories(websockets PRIVATE ${LWS_LIB_BUILD_INC_PATHS})
 	target_compile_definitions(websockets PRIVATE LWS_BUILDING_STATIC)
 
@@ -182,6 +185,9 @@ if (LWS_WITH_SHARED)
 	add_library(websockets_shared SHARED ${SOURCES} ${RESOURCES})# ${HDR_PUBLIC})
 	set_target_properties(websockets_shared PROPERTIES LINKER_LANGUAGE C)
 	list(APPEND LWS_LIBRARIES websockets_shared)
+	target_include_directories(websockets_shared INTERFACE
+		$<INSTALL_INTERFACE:${LWS_INSTALL_INCLUDE_DIR}>
+	)
 	target_include_directories(websockets_shared PRIVATE ${LWS_LIB_BUILD_INC_PATHS})
 	target_compile_definitions(websockets_shared PRIVATE LWS_BUILDING_SHARED)
 


### PR DESCRIPTION
This patch adds an the appropriate include directory to the CMake exported library targets. Without this, the exported targets fail to provide the include path to the consuming project when the library is installed outside of system directories.

`LWS_INSTALL_INCLUDE_DIR` is defined here as the installed location of the include files: https://github.com/warmcat/libwebsockets/blob/0d06d4bad28a6692a1a9e4d4fb651a0dfbcf94b8/CMakeLists.txt#L444

The use of `$<INSTALL_INTERFACE:...>` prevents this addition from having any possibility of affecting the build process, and will only effect exported targets. This feature is compatible with the currently specified minimum CMake version of 2.8.12.

Diff of installed file `lib/cmake/libwebsockets/LibwebsocketsTargets.cmake`:

```diff

 add_library(websockets STATIC IMPORTED)
 
 set_target_properties(websockets PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
 )
 
 # Create imported target websockets_shared
 add_library(websockets_shared SHARED IMPORTED)
 
 set_target_properties(websockets_shared PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
 )
 
 if(CMAKE_VERSION VERSION_LESS 2.8.12)
```
