### PR TITLE
Avoid UB: give variable 'u' an initial value

### DIFF
--- a/lib/drivers/spi/bitbang/lws-bb-spi.c
+++ b/lib/drivers/spi/bitbang/lws-bb-spi.c
@@ -74,7 +74,8 @@ lws_bb_spi_write(lws_bb_spi_t *ctx, const uint8_t *buf, size_t len)
 static void
 lws_bb_spi_read(lws_bb_spi_t *ctx, uint8_t *buf, size_t len)
 {
-	uint8_t u, inv = !!(ctx->bb_ops.bus_mode & LWSSPIMODE_CPOL);
+	uint8_t u = 0;
+	uint8_t inv = !!(ctx->bb_ops.bus_mode & LWSSPIMODE_CPOL);
 
 	while (len--) {
 		int n;


### PR DESCRIPTION
Line 84 in function `lws_bb_spi_read` reads 'u' before it has a value, on 1st for-loop iteration. See comment on line 84 below:

```C
77	uint8_t u, inv = !!(ctx->bb_ops.bus_mode & LWSSPIMODE_CPOL);
  	^^^^^^^^^ -- u is not given a value before use
...
82	for (n = 0; n < 8; n++) {
83		ctx->gpio->set(ctx->clk, inv);
84		u = (u << 1) | !!ctx->gpio->read(ctx->miso);
  		^^^^^^^^^^^^ -- u is used uninitialized here
85		ctx->gpio->set(ctx->mosi, !!(u & 0x80));
86		ctx->gpio->set(ctx->clk, !inv);
87	}
```

To be very specific, the problem is this construct:

```C
u = (u << 1) | ... ; /* read 'u', shift its value, OR with something and write back to 'u' */
```

The initial value of 'u' doesn't seem to make a semantic difference, but optimizing compilers have a nasty habit of taking advantage of undefined behavior in unexpected ways. 

In my opinion, C code should strive to avoid undefined behavior, and an initialization seems a small price to pay for this.


See the links below for more clarification of why the use of uninitialized variable use is problematic and invokes undefined behavior:

https://cwe.mitre.org/data/definitions/457.html
https://wiki.sei.cmu.edu/confluence/display/c/EXP33-C.+Do+not+read+uninitialized+memory
https://en.cppreference.com/book/uninitialized
https://stackoverflow.com/questions/11962457/why-is-using-an-uninitialized-variable-undefined-behavior
