### PR TITLE
cmake: also set LWS_BUILD_HASH to unknown if no git is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,11 +366,11 @@ if(GIT_EXECUTABLE)
 		set(LWS_BUILD_HASH ${GIT_USER}@${GIT_HOST}-${GIT_HASH})
 	endif()
 
-	if ("${LWS_BUILD_HASH}" STREQUAL "")
-		set(LWS_BUILD_HASH "unknown")
-	endif()
-
 	message("Git commit hash: ${LWS_BUILD_HASH}")
+endif()
+
+if ("${LWS_BUILD_HASH}" STREQUAL "")
+	set(LWS_BUILD_HASH "unknown")
 endif()
 
 set(PACKAGE "libwebsockets")


### PR DESCRIPTION
If there isn't any reason for a build to fail on a system with no git, I'd suggest setting the LWS_BUILD_HASH to unknown in a case where no git found.