### PR TITLE
Add borringssl synthetic cb for caching TLS sessions

### DIFF
--- a/lib/roles/ws/client-ws.c
+++ b/lib/roles/ws/client-ws.c
@@ -656,6 +656,14 @@ check_accept:
 
 	lwsl_debug("handshake OK for protocol %s\n", wsi->a.protocol->name);
 
+#if defined(OPENSSL_IS_BORINGSSL)
+	/*
+	 * Newer borringssl versions stopped calling lws_tls_session_new_cb(),
+	 * that is why this synthetic cb is used.
+	 */
+	lws_tls_client_established_cb(wsi);
+#endif
+
 	/* call him back to inform him he is up */
 
 	if (wsi->a.protocol->callback(wsi, LWS_CALLBACK_CLIENT_ESTABLISHED,

--- a/lib/tls/private-lib-tls.h
+++ b/lib/tls/private-lib-tls.h
@@ -189,6 +189,11 @@ int
 lws_genec_confirm_curve_allowed_by_tls_id(const char *allowed, int id,
 					  struct lws_jwk *jwk);
 
+#if defined(OPENSSL_IS_BORINGSSL)
+int
+lws_tls_client_established_cb(struct lws *wsi);
+#endif
+
 void
 lws_tls_reuse_session(struct lws *wsi);
 


### PR DESCRIPTION
This is not exactly what you proposed, because I tried adding the new `sul`, and in its callback I coud not find a way of getting the `SSL`.

I've added this relatively simpler change, because `SSL_SESSION_is_resumable()` always returned true in the synthetic callback, so each new session could be added to the cache directly from that cb. It does not sound completely bullet proof, but so far it worked every time.
It can also be improved later.