### PR TITLE
Netlink: fix of wrong processing of the attr from the RTM_NEWLINK message

### DIFF
--- a/lib/roles/netlink/ops-netlink.c
+++ b/lib/roles/netlink/ops-netlink.c
@@ -125,7 +125,6 @@ rops_handle_POLLIN_netlink(struct lws_context_per_thread *pt, struct lws *wsi,
 
 		struct ifinfomsg *ifi;
 		struct rtattr *attribute;
-		lws_sockaddr46 *sa46;
 		unsigned int len;
 
 		lwsl_netlink("%s: RTM %d\n", __func__, h->nlmsg_type);
@@ -158,19 +157,6 @@ rops_handle_POLLIN_netlink(struct lws_context_per_thread *pt, struct lws *wsi,
 					lwsl_netlink("NETLINK ifidx %d : %s\n",
 						     ifi->ifi_index,
 						     (char *)RTA_DATA(attribute));
-					break;
-				case RTA_SRC:
-					sa46 = (lws_sockaddr46 *)RTA_DATA(attribute);
-					if (sa46->sa4.sin_family == 0xffff) {
-						lwsl_netlink("%s: down %d\n",
-							     __func__,
-							     ifi->ifi_index);
-						lws_pt_lock(pt, __func__);
-						_lws_route_table_ifdown(pt,
-								ifi->ifi_index);
-						_lws_route_pt_close_unroutable(pt);
-						lws_pt_unlock(pt);
-					}
 					break;
 				default:
 					break;

--- a/lib/tls/mbedtls/mbedtls-session.c
+++ b/lib/tls/mbedtls/mbedtls-session.c
@@ -268,6 +268,28 @@ bail:
 	return 0;
 }
 
+#if defined(LWS_TLS_SYNTHESIZE_CB)
+
+/*
+ * On openssl, there is an async cb coming when the server issues the session
+ * information on the link, so we can pick it up and update the cache at the
+ * right time.
+ *
+ * On mbedtls and some version at least of borning ssl, this cb is either not
+ * part of the tls library apis or fails to arrive.
+ */
+
+void
+lws_sess_cache_synth_cb(lws_sorted_usec_list_t *sul)
+{
+	struct lws_lws_tls *tls = lws_container_of(sul, struct lws_lws_tls,
+						   sul_cb_synth);
+	struct lws *wsi = lws_container_of(tls, struct lws, tls);
+
+	lws_tls_session_new_mbedtls(wsi);
+}
+#endif
+
 void
 lws_tls_session_cache(struct lws_vhost *vh, uint32_t ttl)
 {

--- a/lib/tls/mbedtls/mbedtls-ssl.c
+++ b/lib/tls/mbedtls/mbedtls-ssl.c
@@ -255,6 +255,10 @@ lws_ssl_close(struct lws *wsi)
 		SSL_set_info_callback(wsi->tls.ssl, NULL);
 #endif
 
+#if defined(LWS_TLS_SYNTHESIZE_CB)
+	lws_sul_cancel(&wsi->tls.sul_cb_synth);
+#endif
+
 	n = SSL_get_fd(wsi->tls.ssl);
 	if (!wsi->socket_is_permanently_unusable)
 		SSL_shutdown(wsi->tls.ssl);

--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -499,6 +499,12 @@ lws_tls_client_connect(struct lws *wsi, char *errbuf, size_t elen)
 
 		lws_role_call_alpn_negotiated(wsi, (const char *)a);
 #endif
+#if defined(LWS_TLS_SYNTHESIZE_CB)
+		lws_sul_schedule(wsi->a.context, wsi->tsi,
+				 &wsi->tls.sul_cb_synth,
+				 lws_sess_cache_synth_cb, 500 * LWS_US_PER_MS);
+#endif
+
 		lwsl_info("client connect OK\n");
 		lws_openssl_describe_cipher(wsi);
 		return LWS_SSL_CAPABLE_DONE;

--- a/lib/tls/openssl/openssl-session.c
+++ b/lib/tls/openssl/openssl-session.c
@@ -93,7 +93,21 @@ lws_tls_reuse_session(struct lws *wsi)
 	lwsl_tlssess("%s: %s\n", __func__, (const char *)&ts[1]);
 	wsi->tls_session_reused = 1;
 
-	SSL_set_session(wsi->tls.ssl, ts->session);
+	if (!SSL_set_session(wsi->tls.ssl, ts->session)) {
+		lwsl_err("%s: session not set for %s\n", __func__, tag);
+		goto bail;
+	}
+
+#if !defined(USE_WOLFSSL)
+	/* extend session lifetime */
+	SSL_SESSION_set_time(ts->session,
+#if defined(OPENSSL_IS_BORINGSSL)
+			(unsigned long)
+#else
+			(long)
+#endif
+			time(NULL));
+#endif
 
 	/* keep our session list sorted in lru -> mru order */
 
@@ -279,6 +293,37 @@ bail:
 
 	return 0;
 }
+
+#if defined(LWS_TLS_SYNTHESIZE_CB)
+
+/*
+ * On openssl, there is an async cb coming when the server issues the session
+ * information on the link, so we can pick it up and update the cache at the
+ * right time.
+ *
+ * On mbedtls and some version at least of borning ssl, this cb is either not
+ * part of the tls library apis or fails to arrive.
+ *
+ *
+ */
+
+void
+lws_sess_cache_synth_cb(lws_sorted_usec_list_t *sul)
+{
+	struct lws_lws_tls *tls = lws_container_of(sul, struct lws_lws_tls,
+						   sul_cb_synth);
+	struct lws *wsi = lws_container_of(tls, struct lws, tls);
+	SSL_SESSION *sess;
+
+	if (lws_tls_session_is_reused(wsi))
+		return;
+
+	sess = SSL_get1_session(tls->ssl);
+
+	if (SSL_SESSION_is_resumable(sess))
+		lws_tls_session_new_cb(tls->ssl, sess);
+}
+#endif
 
 void
 lws_tls_session_cache(struct lws_vhost *vh, uint32_t ttl)

--- a/lib/tls/openssl/openssl-ssl.c
+++ b/lib/tls/openssl/openssl-ssl.c
@@ -449,6 +449,10 @@ lws_ssl_close(struct lws *wsi)
 		SSL_set_info_callback(wsi->tls.ssl, NULL);
 #endif
 
+#if defined(LWS_TLS_SYNTHESIZE_CB)
+	lws_sul_cancel(&wsi->tls.sul_cb_synth);
+#endif
+
 	n = SSL_get_fd(wsi->tls.ssl);
 	if (!wsi->socket_is_permanently_unusable)
 		SSL_shutdown(wsi->tls.ssl);

--- a/lib/tls/private-lib-tls.h
+++ b/lib/tls/private-lib-tls.h
@@ -118,6 +118,11 @@ enum lws_tls_extant {
 
 #if defined(LWS_WITH_TLS)
 
+#if defined(LWS_WITH_TLS_SESSIONS) && defined(LWS_WITH_CLIENT) && \
+	(defined(LWS_WITH_MBEDTLS) || defined(OPENSSL_IS_BORINGSSL))
+#define LWS_TLS_SYNTHESIZE_CB 1
+#endif
+
 int
 lws_tls_restrict_borrow(struct lws_context *context);
 

--- a/lib/tls/private-network.h
+++ b/lib/tls/private-network.h
@@ -75,12 +75,15 @@ struct lws_vhost_tls {
 };
 
 struct lws_lws_tls {
-	lws_tls_conn *ssl;
-	lws_tls_bio *client_bio;
-	struct lws_dll2 dll_pending_tls;
-	char err_helper[32];
-	unsigned int use_ssl;
-	unsigned int redirect_to_https:1;
+	lws_tls_conn		*ssl;
+	lws_tls_bio		*client_bio;
+#if defined(LWS_TLS_SYNTHESIZE_CB)
+	lws_sorted_usec_list_t	sul_cb_synth;
+#endif
+	struct lws_dll2		dll_pending_tls;
+	char			err_helper[32];
+	unsigned int		use_ssl;
+	unsigned int		redirect_to_https:1;
 };
 
 
@@ -95,6 +98,10 @@ lws_ssl_pending(struct lws *wsi);
 int LWS_WARN_UNUSED_RESULT
 lws_server_socket_service_ssl(struct lws *new_wsi, lws_sockfd_type accept_fd,
 				char is_pollin);
+
+void
+lws_sess_cache_synth_cb(lws_sorted_usec_list_t *sul);
+
 int
 lws_ssl_close(struct lws *wsi);
 void


### PR DESCRIPTION
**Brief**
There is wrong logic of processing of the `RTA_SRC` attr from the `RTM_NEWLINK` message. In fact it is the `IFLA_BROADCAST` attr which provides 6-bytes broadcast hardware address. So here we have a wrong pointer cast and the whole logic under the `case RTA_SRC` block is useless because there's no possibility to get network address family type (AF_INET, AF_INET6, etc..) from the `RTM_NEWLINK` message.

For more details see the corresponding [issue#2287](https://github.com/warmcat/libwebsockets/issues/2287)