### PR TITLE
fix the overflow and the control of private key when using mbedtls.

### DIFF
--- a/lib/tls/mbedtls/mbedtls-client.c
+++ b/lib/tls/mbedtls/mbedtls-client.c
@@ -401,9 +401,6 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 
 		buf[amount++] = '\0';
 
-		SSL_CTX_use_PrivateKey_ASN1(0, vh->tls.ssl_client_ctx,
-				buf, (long)amount);
-
 		n = SSL_CTX_use_certificate_ASN1(vh->tls.ssl_client_ctx,
 				(int)amount, buf);
 		lws_free(buf);
@@ -418,8 +415,6 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 #endif
 	} else if (cert_mem && cert_mem_len) {
 		/* lwsl_hexdump_notice(cert_mem, cert_mem_len - 1); */
-		SSL_CTX_use_PrivateKey_ASN1(0, vh->tls.ssl_client_ctx,
-				cert_mem, (long)cert_mem_len - 1);
 		n = SSL_CTX_use_certificate_ASN1(vh->tls.ssl_client_ctx,
 						 (int)cert_mem_len, cert_mem);
 		if (n < 1) {
@@ -432,6 +427,47 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 			    __func__, cert_mem_len);
 	}
 
+	if (private_key_filepath) {
+#if !defined(LWS_PLAT_OPTEE)
+
+		uint8_t *buf;
+		lws_filepos_t amount;
+
+		lwsl_notice("%s: doing private key filepath %s\n", __func__,
+				private_key_filepath);
+		if (alloc_file(vh->context, private_key_filepath, &buf, &amount))
+			return 1;
+
+		buf[amount++] = '\0';
+
+		n = SSL_CTX_use_PrivateKey_ASN1(0, vh->tls.ssl_client_ctx,
+				buf, amount);
+
+		lws_free(buf);
+		if (n < 1) {
+			lwsl_err("problem %d getting private key '%s'\n", n,
+				 private_key_filepath);
+			lws_tls_err_describe_clear();
+			return 1;
+		}
+
+		lwsl_notice("Loaded private key %s\n", private_key_filepath);
+#endif
+	} else if (key_mem && key_mem_len) {
+		/* lwsl_hexdump_notice(cert_mem, cert_mem_len - 1); */
+		n = SSL_CTX_use_PrivateKey_ASN1(0, vh->tls.ssl_client_ctx,
+				key_mem, (long)key_mem_len - 1);
+
+		if (n < 1) {
+			lwsl_err("%s: (mbedtls) problem interpreting private key\n",
+				 __func__);
+			lws_tls_err_describe_clear();
+			return 1;
+		}
+		lwsl_info("%s: using mem private key %d\n",
+			    __func__, key_mem_len);
+
+	}
 	return 0;
 }
 

--- a/lib/tls/tls.c
+++ b/lib/tls/tls.c
@@ -208,7 +208,7 @@ int alloc_file(struct lws_context *context, const char *filename, uint8_t **buf,
 		goto bail;
 	}
 
-	*buf = lws_malloc(s, "alloc_file");
+	*buf = lws_malloc(s + 1, "alloc_file");
 	if (!*buf) {
 		n = 2;
 		goto bail;


### PR DESCRIPTION
When using mbedtls with cert_filepath, it may causes memory corruption. Not sure the "buf[amount++] = '\0';" is necessary so I add one byte in alloc_file(). 
And add the implementation of private_key_filepath. 
Please give me some feedback since I am not familiar with this codebase. Just tried the private-key, cert, and cacert, and found that it did not work yesterday.
thanks.