### PR TITLE
core-net: Remove unused variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ option(LWS_SSL_CLIENT_USE_OS_CA_CERTS "SSL support should make use of the OS-ins
 option(LWS_TLS_LOG_PLAINTEXT_RX "For debugging log the received plaintext as soon as decrypted" OFF)
 option(LWS_TLS_LOG_PLAINTEXT_TX "For debugging log the transmitted plaintext just before encryption" OFF)
 option(LWS_WITH_TLS_SESSIONS "Enable persistent, resumable TLS sessions" ON)
+option(LWS_WITH_TLS_JIT_TRUST "Enable dynamically computing which trusted TLS CA is needed to be instantiated" OFF)
 
 #
 # Event library options (may select multiple, or none for default poll()

--- a/READMEs/README.jit-trust.md
+++ b/READMEs/README.jit-trust.md
@@ -1,0 +1,178 @@
+# JIT trust
+
+## Background
+
+Most systems using openssl rely on a system trust bundle that openssl
+was compiled to load at library init.  This is a bit expensive, since
+it instantiates over 100 CA X.509 certs, but most modern Linux systems
+don't really notice the expense, the advantage is client connections
+have all the trusted root certs available in memory to perform
+validation.
+
+For mbedtls, it does not support cert bundle autoload out of the box
+and for the kind of systems using mbedtls, for the kind of systems that
+choose mbedtls, they don't want to permanently dedicate the heap needed
+to hold over 100 CAs in memory all the time.
+
+If the device only connects to endpoints that are signed by a specific
+CA, you can just prepare the connection with the known trusted CA, that's
+the approach the examples take.
+
+However if you have a browser type application that could connect
+anywhere, but you don't have heap spare to preload all the CAs, you need
+something like "JIT trust".
+
+## JIT trust overview
+
+The basic approach is to connect to the server to retrieve its certificates,
+then study the certificates to determine the identity of the missing
+trusted cert we should be trying to validate with.
+
+We attempt to get the trusted cert from some local or remote store, and
+retry the connection having instnatiated the missing CA cert as trusted 
+for that connection, if it is one that we do actually trust.
+
+If the relationship was valid, the tls negotiation should then complete
+successfully, and we can cache the CA cert and the host -> CA cert
+pre-trust requirement so future connections can work first time.
+
+## Subject Key Id and Authority Key Id
+
+When a certificate is issued, it is signed by a parent certificate key
+to prove it was issued by the owner of that parent's private key.  At
+the same time, the certificate is marked with an "Authority Key ID"
+(AKID) blob, that is usually hashed down from the parent certificate's
+public key.
+
+All of the certificates also publish their personal "Subject Key ID" or
+SKID, so you can bind one certifcate's AKID to the certificate it
+refers to by searching for one that has the same SKID.
+
+Basically this AKID on a certificate is guiding the validator with
+information about which certificate is next in the chain of trust
+leading back to a trusted CA.  (Lying about it doesn't help an attacker,
+because we're only using the AKID to get the CA certificate and then
+try to do the full signature check using it, if it's not really
+signed by the AKID cert it told, validation will just fail.)
+
+## Converting the Mozilla trust bundle for JIT trust
+
+Lws provides a bash script `./scripts/mozilla-trust-gen.sh` that can fetch the
+latest Mozilla CA trust bundle for certs usable for tls validation, and convert
+it to three different forms to allow maintaining the trust bundle in different
+ways for different kinds of device to consume.
+
+ - as a webroot directory, so you can server trusted DERs, with
+   symlink indexes to the CA certs by SKID and issuer/serial
+
+ - as an atomic binary blob, currently about 143KB, with structure
+   at the start pointing to DER certs and indexes inside
+
+ - a C-compiler friendly `uint8_t` array version of the blob,
+   so it can be compiled into .rodata directly if necessary.
+
+Currently there are 127 certs in the trust bundle, and the whole
+blob is about 143KB uncompressed.
+
+## Considerations about maintaining the trust blob
+
+Mozilla update their trust bundle at intervals, and there have
+been at least three cases where they have removed or distrusted CAs
+from it, because they have issued dangerous certificates, (like
+one for `*` that will validate anything at all).
+
+The certs in the trust bundle expire, currently 10/127 will expire
+within 3 years and 50/127 over the next 10 years.
+
+So part of using the trust bundle is building in some way to update
+what is trusted over the lifetime of the device, which may exceed
+10 years.
+
+Depending on the device, it may not be any problem to
+keep the trust blob in the firmware, and update the firmware ongoing
+every few months.  So you could build it into the firmware using
+the C array include file.
+
+Another device may have difficulty updating the firmware outside of
+emergencies, it could keep the trust blob in a separate area and
+update it separately.  Having it as a single blob makes it easy to
+fetch and update.
+
+Finally other devices, say in ESP32 class, may not have space or desire
+to store the trust blob in the device at all, it could query a remote
+server on demand to check for any trusted CA matching a given AKID and
+retrieve and cache it in volatile ram.  This would use the webroot
+produced by the script, via tls and a fixed CA cert outside this system.
+
+## Format of the JIT trust blob
+
+The trust blob layout is currently
+
+```
+00:  54 42 4c 42     Magic "TBLB"
+04:  00 01           MSB-first trust blob layout version
+06:  XX XX           MSB-first count of certificates
+08:  XX XX XX XX     MSB-first trust blob generation unix time
+0c:  XX XX XX XX     MSB-first offset from blob start of cert length table
+10:  XX XX XX XX     MSB-first offset from blob start of SKID length table
+14:  XX XX XX XX     MSB-first offset from blob start of SKID table
+18:  XX XX XX XX     MSB-first total blob length
+
+1c:  XX .. XX        DER certs (start at +0x1c)
+  :  XX .. XX        DER cert length table (MSB-first 16-bit per cert)
+  :  XX .. XX        SKID length table (8-bit per cert)
+  :  XX .. XX        SKID table (variable per cert)
+```
+
+## Enabling JIT Trust
+
+```
+$ cmake .. -DLWS_WITH_TLS_JIT_TRUST=1
+```
+
+## Processing of x509 AKID and SKIDs
+
+With mbedtls, we use a callback offered by the library to study each
+x509 cert sent by the server in turn.  We parse out the SKID and AKID
+on each one and stash them (up to 4 deep).
+
+After the validation fails, lws has collected all the AKID and SKIDs
+that were in certs sent by the server.  Since these may be sent in any
+order, may be malicious, and may even contain the (untrusted) root CA,
+they are sorted into a trust path using the AKID and SKID relationships
+to end up with the identity of the needed CA cert in the first entry's
+AKID.
+
+There's also a case where the root cert was wrongly sent by the server
+that we need to use the first entry's SKID, to get our own trusted
+copy of the same root cert, if we do trust it.
+
+We query an `lws_system_ops` handler which does whatever the policy is
+to query for a trusted CA and get the DER, if found, it is cached so
+it will be preloaded next time.
+
+## APIs related to JIT Trust 
+
+Systems that support JIT trust define an `lws_system_ops` callback
+that does whatever the system needs to do for attempting to acquire
+a trusted cert with a specified SKID or issuer/serial.
+
+```
+int (*jit_trust_query)(struct lws_context *cx, const uint8_t *skid, size_t skid_len, void *got_opaque);
+```
+
+The ops handler doesn't have to find the trusted cert immediately
+before returning, it is OK starting the process and later if successful
+calling a helper `lws_tls_jit_trust_got_cert_cb()` with the `got_opaque`
+from the query.  This will cache the CA cert so it's available at the
+next connection retry for preloading.
+
+An implementation suitable for `ops->jit_trust_query` using trust blob lookup
+in .rodata will be provided.
+
+
+## Modifications needed for mbedtls
+
+A patch is provided in `../contrib/mbedtls-akid-skid.patch` that currently has to
+be applied to mbedtls to add the necessary apis for AKID and SKID querying.
+

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -72,10 +72,13 @@
 #cmakedefine LWS_HAVE_mbedtls_ssl_set_hs_ca_chain
 #cmakedefine LWS_HAVE_mbedtls_ssl_set_hs_own_cert
 #cmakedefine LWS_HAVE_mbedtls_ssl_set_hs_authmode
+#cmakedefine LWS_HAVE_mbedtls_ssl_set_verify
 #cmakedefine LWS_HAVE_mbedtls_x509_crt_parse_file
 #cmakedefine LWS_HAVE_MBEDTLS_NET_SOCKETS
+#cmakedefine LWS_HAVE_MBEDTLS_AUTH_KEY_ID
 #cmakedefine LWS_HAVE_NEW_UV_VERSION_H
 #cmakedefine LWS_HAVE_OPENSSL_ECDH_H
+#cmakedefine LWS_HAVE_OPENSSL_STACK
 #cmakedefine LWS_HAVE_PIPE2
 #cmakedefine LWS_HAVE_EVENTFD
 #cmakedefine LWS_HAVE_PTHREAD_H
@@ -211,6 +214,7 @@
 #cmakedefine LWS_WITH_SYS_STATE
 #cmakedefine LWS_WITH_THREADPOOL
 #cmakedefine LWS_WITH_TLS
+#cmakedefine LWS_WITH_TLS_JIT_TRUST
 #cmakedefine LWS_WITH_TLS_SESSIONS
 #cmakedefine LWS_WITH_UDP
 #cmakedefine LWS_WITH_ULOOP

--- a/contrib/mbedtls-akid-skid.patch
+++ b/contrib/mbedtls-akid-skid.patch
@@ -1,0 +1,549 @@
+commit b3c47b33fba59d12933e03484346c86ab9ee3ea5
+Author: Gábor Tóth <toth92g@gmail.com>
+Date:   Fri May 21 11:54:11 2021 +0100
+
+        From https://github.com/ARMmbed/mbedtls/pull/4161
+
+diff --git a/ChangeLog.d/X509Parse_SignatureKeyId_AuthorityKeyId.txt b/ChangeLog.d/X509Parse_SignatureKeyId_AuthorityKeyId.txt
+new file mode 100644
+index 000000000..9aa3ff91d
+--- /dev/null
++++ b/ChangeLog.d/X509Parse_SignatureKeyId_AuthorityKeyId.txt
+@@ -0,0 +1,3 @@
++Features
++   * When parsing X.509 certificates, support the extensions
++     SignatureKeyIdentifier and AuthorityKeyIdentifier.
+diff --git a/include/mbedtls/x509.h b/include/mbedtls/x509.h
+index 3091de1d1..77333965e 100644
+--- a/include/mbedtls/x509.h
++++ b/include/mbedtls/x509.h
+@@ -226,6 +226,18 @@ typedef mbedtls_asn1_named_data mbedtls_x509_name;
+  */
+ typedef mbedtls_asn1_sequence mbedtls_x509_sequence;
+ 
++/*
++ * Container for the fields of the Authority Key Identifier object
++ */
++typedef struct mbedtls_x509_authority
++{
++    mbedtls_x509_buf keyIdentifier;
++    mbedtls_x509_sequence authorityCertIssuer;
++    mbedtls_x509_buf authorityCertSerialNumber;
++    mbedtls_x509_buf raw;
++}
++mbedtls_x509_authority;
++
+ /** Container for date and time (precision in seconds). */
+ typedef struct mbedtls_x509_time
+ {
+diff --git a/include/mbedtls/x509_crt.h b/include/mbedtls/x509_crt.h
+index 23a20d10b..9a9b9e220 100644
+--- a/include/mbedtls/x509_crt.h
++++ b/include/mbedtls/x509_crt.h
+@@ -75,6 +75,9 @@ typedef struct mbedtls_x509_crt
+     mbedtls_x509_buf issuer_id;         /**< Optional X.509 v2/v3 issuer unique identifier. */
+     mbedtls_x509_buf subject_id;        /**< Optional X.509 v2/v3 subject unique identifier. */
+     mbedtls_x509_buf v3_ext;            /**< Optional X.509 v3 extensions.  */
++    mbedtls_x509_buf subject_key_id;    /**< Optional X.509 v3 extension subject key identifier. */
++    mbedtls_x509_authority authority_key_id;    /**< Optional X.509 v3 extension authority key identifier. */
++
+     mbedtls_x509_sequence subject_alt_names;    /**< Optional list of raw entries of Subject Alternative Names extension (currently only dNSName and OtherName are listed). */
+ 
+     mbedtls_x509_sequence certificate_policies; /**< Optional list of certificate policies (Only anyPolicy is printed and enforced, however the rest of the policies are still listed). */
+@@ -557,7 +560,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path );
+  * \param san      The target structure to populate with the parsed presentation
+  *                 of the subject alternative name encoded in \p san_raw.
+  *
+- * \note           Only "dnsName" and "otherName" of type hardware_module_name
++ * \note           Only "dnsName" and "otherName" and "rfc822Name" of type hardware_module_name
+  *                 as defined in RFC 4180 is supported.
+  *
+  * \note           This function should be called on a single raw data of
+@@ -575,7 +578,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path );
+  *                 SAN type.
+  * \return         Another negative value for any other failure.
+  */
+-int mbedtls_x509_parse_subject_alt_name( const mbedtls_x509_buf *san_buf,
++int mbedtls_x509_parse_general_name( const mbedtls_x509_buf *san_buf,
+                                          mbedtls_x509_subject_alternative_name *san );
+ 
+ #if !defined(MBEDTLS_X509_REMOVE_INFO)
+diff --git a/library/oid.c b/library/oid.c
+index eb15a41b2..e74a31633 100644
+--- a/library/oid.c
++++ b/library/oid.c
+@@ -289,9 +289,14 @@ static const oid_x509_ext_t oid_x509_ext[] =
+         MBEDTLS_OID_X509_EXT_CERTIFICATE_POLICIES,
+     },
+     {
+-        NULL_OID_DESCRIPTOR,
+-        0,
++    { ADD_LEN( MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ), "id-ce-subjectKeyIdentifier",           "Subject Key Identifier" },
++        MBEDTLS_OID_X509_EXT_SUBJECT_KEY_IDENTIFIER,
++    },
++    {
++        { ADD_LEN( MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER ), "id-ce-authorityKeyIdentifier",       "Authority Key Identifier" },
++        MBEDTLS_OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER,
+     },
++    { NULL_OID_DESCRIPTOR, 0 },
+ };
+ 
+ FN_OID_TYPED_FROM_ASN1(oid_x509_ext_t, x509_ext, oid_x509_ext)
+diff --git a/library/x509_crt.c b/library/x509_crt.c
+index b4fe8863a..79d0f62de 100644
+--- a/library/x509_crt.c
++++ b/library/x509_crt.c
+@@ -596,8 +596,38 @@ static int x509_get_ext_key_usage( unsigned char **p,
+ }
+ 
+ /*
+- * SubjectAltName ::= GeneralNames
+- *
++* SubjectKeyIdentifier ::= KeyIdentifier
++*
++* KeyIdentifier ::= OCTET STRING
++*/
++static int x509_get_subject_key_id( unsigned char** p,
++    const unsigned char* end,
++    mbedtls_x509_buf* subject_key_id )
++{
++    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
++    size_t len = 0u;
++
++    if ( ( ret = mbedtls_asn1_get_tag( p, end, &len,
++        MBEDTLS_ASN1_OCTET_STRING ) ) != 0 )
++    {
++        return( ret );
++    }
++    else
++    {
++        subject_key_id->len = len;
++        subject_key_id->tag = MBEDTLS_ASN1_OCTET_STRING;
++        subject_key_id->p = *p;
++        *p += len;
++    }
++
++    if( *p != end )
++        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
++            MBEDTLS_ERR_ASN1_LENGTH_MISMATCH ) );
++
++    return( 0 );
++}
++
++/*
+  * GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+  *
+  * GeneralName ::= CHOICE {
+@@ -622,7 +652,7 @@ static int x509_get_ext_key_usage( unsigned char **p,
+  * NOTE: we list all types, but only use dNSName and otherName
+  * of type HwModuleName, as defined in RFC 4108, at this point.
+  */
+-static int x509_get_subject_alt_name( unsigned char **p,
++static int x509_get_general_names( unsigned char **p,
+                                       const unsigned char *end,
+                                       mbedtls_x509_sequence *subject_alt_name )
+ {
+@@ -651,17 +681,19 @@ static int x509_get_subject_alt_name( unsigned char **p,
+         if( ( ret = mbedtls_asn1_get_len( p, end, &tag_len ) ) != 0 )
+             return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_X509_INVALID_EXTENSIONS, ret ) );
+ 
++        /* Tag shall be CONTEXT_SPECIFIC or SET */
+         if( ( tag & MBEDTLS_ASN1_TAG_CLASS_MASK ) !=
+                 MBEDTLS_ASN1_CONTEXT_SPECIFIC )
+         {
+-            return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
+-                    MBEDTLS_ERR_ASN1_UNEXPECTED_TAG ) );
++            if( ( tag & (MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) ) != ( MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) )
++                return( MBEDTLS_ERROR_ADD(MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
++                        MBEDTLS_ERR_ASN1_UNEXPECTED_TAG ));
+         }
+ 
+         /*
+          * Check that the SAN is structured correctly.
+          */
+-        ret = mbedtls_x509_parse_subject_alt_name( &(cur->buf), &dummy_san_buf );
++        ret = mbedtls_x509_parse_general_name( &(cur->buf), &dummy_san_buf );
+         /*
+          * In case the extension is malformed, return an error,
+          * and clear the allocated sequences.
+@@ -714,6 +746,96 @@ static int x509_get_subject_alt_name( unsigned char **p,
+     return( 0 );
+ }
+ 
++/*
++ * AuthorityKeyIdentifier ::= SEQUENCE {
++ *        keyIdentifier [0] KeyIdentifier OPTIONAL,
++ *        authorityCertIssuer [1] GeneralNames OPTIONAL,
++ *        authorityCertSerialNumber [2] CertificateSerialNumber OPTIONAL }
++ *
++ *    KeyIdentifier ::= OCTET STRING
++ */
++static int x509_get_authority_key_id( unsigned char** p,
++    unsigned char* end,
++    mbedtls_x509_authority* authority_key_id )
++{
++    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
++    size_t len = 0u;
++
++    if ( ( ret = mbedtls_asn1_get_tag( p, end, &len,
++        MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE | 0 ) ) != 0 )
++    {
++        return( ret );
++    }
++
++    if ( (ret = mbedtls_asn1_get_tag( p, end, &len,
++        MBEDTLS_ASN1_CONTEXT_SPECIFIC ) ) != 0 )
++    {
++        /* KeyIdentifier is an OPTIONAL field */
++    }
++    else
++    {
++        authority_key_id->keyIdentifier.len = len;
++        authority_key_id->keyIdentifier.p = *p;
++        /* Setting tag of the keyIdentfier intentionally to 0x04.
++         * Although the .keyIdentfier field is CONTEXT_SPECIFIC ([0] OPTIONAL),
++         * its tag with the content is the payload of on OCTET STRING primitive   */
++        authority_key_id->keyIdentifier.tag = MBEDTLS_ASN1_OCTET_STRING;
++
++        *p += len;
++    }
++
++    if ( *p < end )
++    {
++        /* Getting authorityCertIssuer using the required specific class tag [1] */
++        if ((ret = mbedtls_asn1_get_tag(p, end, &len,
++            MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_CONSTRUCTED | 1 ) ) != 0)
++        {
++            /* authorityCertIssuer is an OPTIONAL field */
++        }
++        else
++        {
++            /* Getting directoryName using the required specific class tag [4] */
++            if ((ret = mbedtls_asn1_get_tag(p, end, &len,
++                MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_CONSTRUCTED | 4 ) ) != 0)
++            {
++                return(ret);
++            }
++            else
++            {
++                /* "end" also includes the CertSerialNumber field so "len" shall be used */
++                ret = x509_get_general_names( p,
++                    (*p+len),
++                    &authority_key_id->authorityCertIssuer );
++            }
++        }
++    }
++
++    if ( *p < end )
++    {
++        if ( ( ret = mbedtls_asn1_get_tag( p, end, &len,
++            MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_INTEGER ) ) != 0 )
++        {
++            /* authorityCertSerialNumber is an OPTIONAL field, but if there are still data it must be the serial number */
++            return( ret );
++        }
++        else
++        {
++            authority_key_id->authorityCertSerialNumber.len = len;
++            authority_key_id->authorityCertSerialNumber.p = *p;
++            authority_key_id->authorityCertSerialNumber.tag = MBEDTLS_ASN1_OCTET_STRING;
++            *p += len;
++        }
++    }
++
++    if ( *p != end )
++    {
++        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
++            MBEDTLS_ERR_ASN1_LENGTH_MISMATCH ) );
++    }
++
++    return( 0 );
++}
++
+ /*
+  * id-ce-certificatePolicies OBJECT IDENTIFIER ::=  { id-ce 32 }
+  *
+@@ -1001,9 +1123,28 @@ static int x509_get_crt_ext( unsigned char **p,
+                 return( ret );
+             break;
+ 
++        case MBEDTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER:
++            /* Parse subject key identifier */
++            if ( ( ret = x509_get_subject_key_id( p, end_ext_data,
++                    &crt->subject_key_id ) ) != 0 )
++            {
++                return ( ret );
++            }
++            break;
++
++        case MBEDTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER:
++            /* Parse authority key identifier */
++            if ( ( ret = x509_get_authority_key_id( p, end_ext_octet,
++                    &crt->authority_key_id ) ) != 0 )
++            {
++                return ( ret );
++            }
++            break;
+         case MBEDTLS_X509_EXT_SUBJECT_ALT_NAME:
+-            /* Parse subject alt name */
+-            if( ( ret = x509_get_subject_alt_name( p, end_ext_octet,
++            /* Parse subject alt name
++             * SubjectAltName ::= GeneralNames
++             */
++            if( ( ret = x509_get_general_names( p, end_ext_octet,
+                     &crt->subject_alt_names ) ) != 0 )
+                 return( ret );
+             break;
+@@ -1767,10 +1908,11 @@ static int x509_get_other_name( const mbedtls_x509_buf *subject_alt_name,
+     return( 0 );
+ }
+ 
+-int mbedtls_x509_parse_subject_alt_name( const mbedtls_x509_buf *san_buf,
++int mbedtls_x509_parse_general_name( const mbedtls_x509_buf *san_buf,
+                                          mbedtls_x509_subject_alternative_name *san )
+ {
+     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
++
+     switch( san_buf->tag &
+             ( MBEDTLS_ASN1_TAG_CLASS_MASK |
+               MBEDTLS_ASN1_TAG_VALUE_MASK ) )
+@@ -1794,6 +1936,31 @@ int mbedtls_x509_parse_subject_alt_name( const mbedtls_x509_buf *san_buf,
+         }
+         break;
+ 
++	/*
++         * RFC822 Name
++         */
++        case( MBEDTLS_ASN1_SEQUENCE | MBEDTLS_X509_SAN_RFC822_NAME ):
++        {
++            mbedtls_x509_name rfc822Name;
++            unsigned char* bufferPointer = san_buf->p;
++            unsigned char** p = &bufferPointer;
++            const unsigned char* end = san_buf->p + san_buf->len;
++
++            /* The leading ASN1 tag and length has been processed. Stepping back with 2 bytes, because mbedtls_x509_get_name expects the beginning of the SET tag */
++            *p = *p - 2;
++
++            ret = mbedtls_x509_get_name( p, end, &rfc822Name );
++            if ( ret != 0 )
++                return( ret );
++
++            memset( san, 0, sizeof( mbedtls_x509_subject_alternative_name ) );
++            san->type = MBEDTLS_X509_SAN_OTHER_NAME;
++            memcpy( &san->san.unstructured_name,
++                &rfc822Name, sizeof( rfc822Name ) );
++        }
++        break;
++
++
+         /*
+          * dNSName
+          */
+@@ -1833,7 +2000,7 @@ static int x509_info_subject_alt_name( char **buf, size_t *size,
+     while( cur != NULL )
+     {
+         memset( &san, 0, sizeof( san ) );
+-        parse_ret = mbedtls_x509_parse_subject_alt_name( &cur->buf, &san );
++        parse_ret = mbedtls_x509_parse_general_name( &cur->buf, &san );
+         if( parse_ret != 0 )
+         {
+             if( parse_ret == MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE )
+@@ -3329,6 +3496,16 @@ void mbedtls_x509_crt_free( mbedtls_x509_crt *crt )
+             mbedtls_free( seq_prv );
+         }
+ 
++        seq_cur = cert_cur->authority_key_id.authorityCertIssuer.next;
++        while ( seq_cur != NULL )
++        {
++            seq_prv = seq_cur;
++            seq_cur = seq_cur->next;
++            mbedtls_platform_zeroize( seq_prv,
++                sizeof( mbedtls_x509_sequence ) );
++            mbedtls_free( seq_prv );
++        }
++
+         if( cert_cur->raw.p != NULL && cert_cur->own_buffer )
+         {
+             mbedtls_platform_zeroize( cert_cur->raw.p, cert_cur->raw.len );
+diff --git a/programs/ssl/ssl_client2.c b/programs/ssl/ssl_client2.c
+index 2ce858837..bf29a3883 100644
+--- a/programs/ssl/ssl_client2.c
++++ b/programs/ssl/ssl_client2.c
+@@ -35,7 +35,7 @@ int main( void )
+ 
+ /* Size of memory to be allocated for the heap, when using the library's memory
+  * management and MBEDTLS_MEMORY_BUFFER_ALLOC_C is enabled. */
+-#define MEMORY_HEAP_SIZE      120000
++#define MEMORY_HEAP_SIZE      180000
+ 
+ #define MAX_REQUEST_SIZE      20000
+ #define MAX_REQUEST_SIZE_STR "20000"
+diff --git a/programs/ssl/ssl_server2.c b/programs/ssl/ssl_server2.c
+index 1ff27fb8b..2a44ded2a 100644
+--- a/programs/ssl/ssl_server2.c
++++ b/programs/ssl/ssl_server2.c
+@@ -65,7 +65,7 @@ int main( void )
+ 
+ /* Size of memory to be allocated for the heap, when using the library's memory
+  * management and MBEDTLS_MEMORY_BUFFER_ALLOC_C is enabled. */
+-#define MEMORY_HEAP_SIZE        120000
++#define MEMORY_HEAP_SIZE        180000
+ 
+ #define DFL_SERVER_ADDR         NULL
+ #define DFL_SERVER_PORT         "4433"
+diff --git a/tests/data_files/Makefile b/tests/data_files/Makefile
+index f3cba5acb..df156b588 100644
+--- a/tests/data_files/Makefile
++++ b/tests/data_files/Makefile
+@@ -315,6 +315,15 @@ rsa_pkcs8_2048_public.der: rsa_pkcs8_2048_public.pem
+ 	$(OPENSSL) rsa -pubin -in $< -outform DER -pubout -out $@
+ all_final += rsa_pkcs8_2048_public.der
+ 
++authorityKeyId_subjectKeyId.crt:
++	$(OPENSSL) req -x509 -nodes -days 7300 -newkey rsa:2048 -keyout authorityKeyId_subjectKeyId.crt -out authorityKeyId_subjectKeyId.crt -config authorityKeyId_subjectKeyId.conf -extensions 'v3_req'
++# The listed certificates are the copies of authorityKeyId_subjectKeyId.crt with error injections
++# authorityKeyId_subjectKeyId_wrong_SubjectKeyId.crt              The TAG marking the beginning of SubjectKeyId is set to 0x00
++# authorityKeyId_subjectKeyId_wrong_AuthorityKeyId_KeyId.crt      The TAG marking the beginning of AuthorityKeyId field is set to 0x00
++# authorityKeyId_subjectKeyId_wrong_AuthorityKeyId_Sequence.crt   The TAG marking that AuthorityKeyId is a sequence is set to 0x00
++# authorityKeyId_subjectKeyId_wrong_IssuerN.crt                   There are 5 different TAGs based on the x509 doc under AuthorityKeyId(keyId, Dir, Seqence of Dir, serial)
++#                                                                 Each test inject error to one of these
++
+ ################################################################
+ #### Generate various RSA keys
+ ################################################################
+diff --git a/tests/suites/test_suite_x509parse.data b/tests/suites/test_suite_x509parse.data
+index 8b7b09aad..1d29a96fc 100644
+--- a/tests/suites/test_suite_x509parse.data
++++ b/tests/suites/test_suite_x509parse.data
+@@ -2847,3 +2847,39 @@ x509_verify_restart:"data_files/server10_int3-bs.pem":"data_files/test-int-ca2.c
+ X509 CRT verify restart: one int, int badsign, max_ops=500
+ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_ECDSA_C:MBEDTLS_SHA256_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_ECP_DP_SECP384R1_ENABLED:MBEDTLS_RSA_C
+ x509_verify_restart:"data_files/server10_int3-bs.pem":"data_files/test-int-ca2.crt":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_NOT_TRUSTED:500:25:100
++
++X509 CRT parse Subject Key Id - Correct Subject Key ID
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_subjectkeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":20:0
++
++X509 CRT parse Subject Key Id - Wrong OCTET_STRING tag
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_subjectkeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
++
++X509 CRT parse Authority Key Id - Correct Authority Key ID
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":20:"NL/PolarSSL/PolarSSL Test CA/":1:0
++
++X509 CRT parse Authority Key Id - Wrong Sequence tag
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c005a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:"":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
++
++X509 CRT parse Authority Key Id - Wrong KeyId Tag
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a0014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:"":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
++
++X509 CRT parse Authority Key Id - Wrong Issuer Tag 1
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff003fa43d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:"":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
++
++X509 CRT parse Authority Key Id - Wrong Issuer Tag 2
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13f003d303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:"":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
++
++X509 CRT parse Authority Key Id - Wrong Issuer Tag 3
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d003b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:"":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
++
++X509 CRT parse Authority Key Id - Wrong Issuer Tag 4
++depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C
++x509_crt_parse_authoritykeyid:"308203873082026fa003020102020100300d06092a864886f70d0101050500303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341301e170d3131303231323134343430305a170d3231303231323134343430305a303b310b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c205465737420434130820122300d06092a864886f70d01010105000382010f003082010a0282010100c0df37fc17bbe0969d3f86de96327d44a516a0cd21f199d4eceacb7c18580894a5ec9bc58bdf1a1e993899871e7bc08d39df385d707807d39ed993e8b97251c5cea33052a9f2e7407014cb44a2720bc2e540f93ee5a60eb3f9ec4a63c0b82900749c573ba8a5049071f1bd83d93fd6a5e23c2a8fef2760c3c69fcbbaec607db7e68432be4ffb582622035bd4b4d5fbf5e3962e70c0e42ebdfc2eeee24155c0342e7d247269cb47b11440837d67f486f631abf179a4b2b52e12f98417f0626f273e1358b1540d219a7337a130cf6f92dcf6e9fcacdb2e28d17e024b23a015f238656409ea0c6e8e1b17a071c8b39bc9abe9c3f2cf87968f8002329e99586fa2d50203010001a38195308192300c0603551d13040530030101ff301d0603551d0e04160414b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff30630603551d23045c305a8014b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdffa13fa43d303b000b3009060355040613024e4c3111300f060355040a1308506f6c617253534c3119301706035504031310506f6c617253534c2054657374204341820100300d06092a864886f70d01010505000382010100b8fd54d80054908b25b027dd95cda2f784071d87894ac47811d807b5d722508e48eb627a3289be634753ffb6bef12e8c54c0993fa0b93723725f0d46598fd847cd974c9f070c1262093a24e436d9e92cda38d0737561d7c16c268b9be0d5dc67ed8c6b33d774223c4cdbb58d2ace2c0d0859050905a6399fb3671be283e5e18f53f66793c7f96f76445812e83ad497e7e9c03ea87a723d87531fe52c8484e79a9e7f66d91f9bf51348b04d14d1deb224d9787df535cc5819d1d299ef4d73f81f89d45ad052ce09f5b146516a008e3bcc6f63010099ed9da60860cd3218d073e05871d9e5d253d78dd0cae95d2a0a0d5d55ec21501716e6064acd5edef7e0e954":0:"":0:MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
+diff --git a/tests/suites/test_suite_x509parse.function b/tests/suites/test_suite_x509parse.function
+index a6361d83a..d1d446727 100644
+--- a/tests/suites/test_suite_x509parse.function
++++ b/tests/suites/test_suite_x509parse.function
+@@ -421,7 +421,7 @@ void x509_parse_san( char * crt_file, char * result_str )
+         cur = &crt.subject_alt_names;
+         while( cur != NULL )
+         {
+-            ret = mbedtls_x509_parse_subject_alt_name( &cur->buf, &san );
++            ret = mbedtls_x509_parse_general_name( &cur->buf, &san );
+             TEST_ASSERT( ret == 0 || ret == MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE );
+             /*
+              * If san type not supported, ignore.
+@@ -1267,3 +1267,78 @@ exit:
+     ;;
+ }
+ /* END_CASE */
++
++/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C */
++void x509_crt_parse_subjectkeyid( data_t * buf, unsigned int subjectKeyIdLength, int ref_ret )
++{
++    mbedtls_x509_crt crt;
++
++    mbedtls_x509_crt_init( &crt );
++
++    TEST_ASSERT( mbedtls_x509_crt_parse_der( &crt, buf->x, buf->len ) == ref_ret );
++
++    if( ref_ret == 0 )
++    {
++        TEST_ASSERT( crt.subject_key_id.tag == MBEDTLS_ASN1_OCTET_STRING );
++        TEST_ASSERT( crt.subject_key_id.len == subjectKeyIdLength );
++    }
++    else
++    {
++        TEST_ASSERT( crt.subject_key_id.tag == 0 );
++        TEST_ASSERT( crt.subject_key_id.len == 0 );
++    }
++
++exit:
++    mbedtls_x509_crt_free( &crt );
++}
++/* END_CASE */
++
++/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_CERTS_C:MBEDTLS_SHA1_C:MBEDTLS_RSA_C */
++void x509_crt_parse_authoritykeyid( data_t * buf, unsigned int keyIdLength, char *authorityKeyId_issuer, unsigned int serialLength , int ref_ret)
++{
++    mbedtls_x509_crt crt;
++    int bufferCounter = 0;
++    size_t issuerCounter = 0;
++    unsigned int result = 0;
++
++    mbedtls_x509_crt_init( &crt );
++
++    TEST_ASSERT( mbedtls_x509_crt_parse_der( &crt, buf->x, buf->len ) == ref_ret );
++
++    if( ref_ret == 0 )
++    {
++        /* KeyId test */
++        TEST_ASSERT( crt.authority_key_id.keyIdentifier.tag == MBEDTLS_ASN1_OCTET_STRING );
++        TEST_ASSERT( crt.authority_key_id.keyIdentifier.len == keyIdLength );
++
++        /* Issuer test */
++        mbedtls_x509_sequence* issuerPtr = &crt.authority_key_id.authorityCertIssuer;
++        while ( issuerPtr != NULL )
++        {
++            /* First 9 bytes are always ASN1 coding related information that does not matter right now. Only the values are asserted */
++            for ( issuerCounter = 9u; issuerCounter < issuerPtr->buf.len; issuerCounter++ )
++            {
++                result |= ( authorityKeyId_issuer[bufferCounter++] != issuerPtr->buf.p[issuerCounter] );
++            }
++            bufferCounter++; /* Skipping the slash */
++            issuerPtr = issuerPtr->next;
++        }
++        TEST_ASSERT( result == 0 );
++
++        /* Serial test */
++        TEST_ASSERT( crt.authority_key_id.authorityCertSerialNumber.tag == MBEDTLS_ASN1_OCTET_STRING );
++        TEST_ASSERT( crt.authority_key_id.authorityCertSerialNumber.len == serialLength );
++    }
++    else
++    {
++        TEST_ASSERT( crt.authority_key_id.keyIdentifier.tag == 0 );
++        TEST_ASSERT( crt.authority_key_id.keyIdentifier.len == 0 );
++
++        TEST_ASSERT( crt.authority_key_id.authorityCertSerialNumber.tag == 0 );
++        TEST_ASSERT( crt.authority_key_id.authorityCertSerialNumber.len == 0 );
++    }
++
++exit:
++    mbedtls_x509_crt_free( &crt );
++}
++/* END_CASE */

--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -568,6 +568,7 @@ struct lws;
 #include <libwebsockets/lws-dll2.h>
 #include <libwebsockets/lws-fault-injection.h>
 #include <libwebsockets/lws-timeout-timer.h>
+#include <libwebsockets/lws-cache-ttl.h>
 #if defined(LWS_WITH_SYS_SMD)
 #include <libwebsockets/lws-smd.h>
 #endif

--- a/include/libwebsockets/lws-cache-ttl.h
+++ b/include/libwebsockets/lws-cache-ttl.h
@@ -1,0 +1,164 @@
+/*
+ * libwebsockets - small server side websockets and web server implementation
+ *
+ * Copyright (C) 2010 - 2021 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** \defgroup lws_cache_ttl Cache supporting expiry
+ * ##Cache supporting expiry
+ *
+ * These apis let you quickly and reliably implement caches of named objects,
+ * that have a "destroy-by date" and cache limits that will be observed.
+ *
+ * You can instantiate as many caches as you need.
+ *
+ * Allocated object memory is entirely for the use of user code, up to the
+ * requested size.
+ *
+ * The key name for the listed objects may be any string chosen by the user,
+ * there is no special length limit as it is also allocated.
+ *
+ * Both expiry and LRU orderings are kept so it is easy to find out usage
+ * ordering and when the next object that will expire.
+ *
+ * Cached objects may be destroyed any time you go around the event loop, when
+ * you allocate new objects (to keep the whole cache under the specified limit),
+ * or when their expiry time arrives.  So you shouldn't keep copies of pointers
+ * to cached objects after returning to the event loop.
+ *
+ * Caches may be layered...
+ */
+///@{
+
+
+struct lws_cache_ttl_lru;
+
+/**
+ * lws_cache_item_alloc() - allocate a new cache item object and bind to a cache
+ *
+ * \param cache: the existing cache to allocate the object in
+ * \param key: a key string that identifies the item in the cache
+ * \param size: the size of the object to allocate
+ * \param expiry: the usec time that the object will autodestroy
+ *
+ * If an item with the key already exists, it is destroyed before allocating a
+ * new one.
+ *
+ * The allocated user space is not zeroed down, just malloc'd.
+ *
+ * Returns NULL if unable to allocate, or a pointer to \p size bytes dedicated
+ * to this cache item, available for any use until it is destroyed.  It will be
+ * scheduled to be auto-destroyed when \p expiry occurs.  And it can be
+ * destroyed at any time we return to the event loop, so this pointer cannot
+ * be stored.
+ */
+void * /* only valid until return to event loop */
+lws_cache_item_alloc(struct lws_cache_ttl_lru *cache, const char *key,
+		     size_t size, lws_usec_t expiry);
+
+/**
+ * lws_cache_item_find() - get a pointer by key string to existing item, if any
+ *
+ * \param cache: the cache to search for the key
+ * \param key: the item key string
+ * \param size: the size of the user area pointed to by the returned pointer
+ *
+ * If the cache still has an item matching the key string, a pointer to the
+ * user allocation is returned and *len is set to its length.  If not, then
+ * NULL is returned.
+ *
+ * The LRU ordering is updated when calling this if an item matches, it is
+ * moved to the head of the recently used list.
+ */
+void * /* only valid until return to event loop */
+lws_cache_item_find(struct lws_cache_ttl_lru *cache, const char *key, size_t *size);
+
+/**
+ * lws_cache_item_destroy_by_key() - destroy a cache item allocated by lws_cache_item_alloc()
+ *
+ * \param cache: the cache to search for the key
+ * \param key: the item key string
+ *
+ * If the cache still has an item matching the key string, it will be destroyed.
+ */
+void
+lws_cache_item_destroy_by_key(struct lws_cache_ttl_lru *cache, const char *key);
+
+struct lws_cache_ops {
+	void (*item_alloc)(struct lws_cache_ttl_lru *cache, const char *key,
+			   size_t size, lws_usec_t expiry);
+};
+
+typedef void (*lws_cache_item_destroy_cb)(void *item, size_t size);
+struct lws_cache_creation_info {
+	struct lws_context		*cx;
+	/**< Mandatory: the lws_context */
+	lws_cache_item_destroy_cb	cb;
+	/**< NULL, or a callback that can hook cache item destory */
+	struct lws_cache_ttl_lru	*parent;
+	/**< NULL, or next cache level */
+	const struct lws_cache_ops	*ops;
+	/**< NULL for default, heap-based ops, else custom cache storage and
+	 * query implementation */
+
+	size_t				max_footprint;
+	/**< 0, or the max heap allocation allowed before destroying
+	 *   lru items to keep it under the limit */
+	size_t				max_items;
+	/**< 0, or the max number of items allowed in the cache before
+	 *   destroying lru items to keep it under the limit */
+	int				tsi;
+	/**< 0 unless using SMP, then tsi to bind sul to */
+};
+
+/**
+ * lws_cache_create() - create an empty cache you can allocate items in
+ *
+ * \param info: a struct describing the cache to create
+ *
+ * Create an empty cache you can allocate items in.  The cache will be kept
+ * below the max_footprint and max_items limits if they are nonzero, by destroying
+ * least-recently-used items until it remains below the limits.
+ *
+ * Items will auto-destroy when their expiry time is reached.
+ *
+ * When items are destroyed from the cache, if \p cb is non-NULL, it will be
+ * called back with the item pointer after it has been removed from the cache,
+ * but before it is deallocated and destroyed.
+ *
+ * context and tsi are used when scheduling expiry callbacks
+ */
+struct lws_cache_ttl_lru *
+lws_cache_create(const struct lws_cache_creation_info *info);
+
+/**
+ * lws_cache_destroy() - destroy a previously created cache
+ *
+ * \param cache: pointer to the cache
+ *
+ * Everything in the cache is destroyed, then the cache itself is destroyed,
+ * and *cache set to NULL.
+ */
+void
+lws_cache_destroy(struct lws_cache_ttl_lru **cache);
+
+///@}
+

--- a/include/libwebsockets/lws-system.h
+++ b/include/libwebsockets/lws-system.h
@@ -154,6 +154,8 @@ typedef enum {
 typedef void (*lws_attach_cb_t)(struct lws_context *context, int tsi, void *opaque);
 struct lws_attach_item;
 
+int lws_tls_jit_trust_got_cert_cb(void *got_opaque, const uint8_t *der, size_t der_len);
+
 typedef struct lws_system_ops {
 	int (*reboot)(void);
 	int (*set_clock)(lws_usec_t us);
@@ -185,6 +187,15 @@ typedef struct lws_system_ops {
 	/**< metric \p item is reporting an event of kind \p rpt,
 	 * held in \p mdata... return 0 to leave the metric object as it is,
 	 * or nonzero to reset it. */
+
+	int (*jit_trust_query)(struct lws_context *cx, const uint8_t *skid,
+			       size_t skid_len, void *got_opaque);
+	/**< user defined trust store search, if we do trust a cert with SKID
+	 * matching skid / skid_len, then it should get hold of the DER for the
+	 * matching root CA and call
+	 * lws_tls_jit_trust_got_cert_cb(..., got_opaque) before cleaning up and
+	 * returning.  The DER should be destroyed if in heap before returning.
+	 */
 
 	uint32_t	wake_latency_us;
 	/**< time taken for this device to wake from suspend, in us

--- a/include/libwebsockets/lws-x509.h
+++ b/include/libwebsockets/lws-x509.h
@@ -47,6 +47,14 @@ enum lws_tls_cert_info {
 	 * -1 is returned and the size will be returned in buf->ns.len.
 	 * If the certificate cannot be found -1 is returned and 0 in
 	 * buf->ns.len. */
+	LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID,
+	/**< If the cert has one, the key ID responsible for the signature */
+	LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID_ISSUER,
+	/**< If the cert has one, the issuer responsible for the signature */
+	LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID_SERIAL,
+	/**< If the cert has one, serial number responsible for the signature */
+	LWS_TLS_CERT_INFO_SUBJECT_KEY_ID,
+	/**< If the cert has one, the cert's subject key ID */
 };
 
 union lws_tls_cert_info_results {

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -247,7 +247,6 @@ struct client_info_stash {
 
 #define LWS_H2_FRAME_HEADER_LENGTH 9
 
-
 lws_usec_t
 __lws_sul_service_ripe(lws_dll2_owner_t *own, int num_own, lws_usec_t usnow);
 

--- a/lib/core-net/route.c
+++ b/lib/core-net/route.c
@@ -38,23 +38,22 @@ void
 _lws_routing_entry_dump(lws_route_t *rou)
 {
 	char sa[48], fin[192], *end = &fin[sizeof(fin)];
-	int n = 0;
 
 	if (rou->dest.sa4.sin_family) {
 		lws_sa46_write_numeric_address(&rou->dest, sa, sizeof(sa));
-		n += lws_snprintf(fin, lws_ptr_diff_size_t(end, fin),
+		lws_snprintf(fin, lws_ptr_diff_size_t(end, fin),
 				  "dst: %s/%d, ", sa, rou->dest_len);
 	}
 
 	if (rou->src.sa4.sin_family) {
 		lws_sa46_write_numeric_address(&rou->src, sa, sizeof(sa));
-		n += lws_snprintf(fin, lws_ptr_diff_size_t(end, fin),
+		lws_snprintf(fin, lws_ptr_diff_size_t(end, fin),
 				  "src: %s/%d, ", sa, rou->src_len);
 	}
 
 	if (rou->gateway.sa4.sin_family) {
 		lws_sa46_write_numeric_address(&rou->gateway, sa, sizeof(sa));
-		n += lws_snprintf(fin, lws_ptr_diff_size_t(end, fin),
+		lws_snprintf(fin, lws_ptr_diff_size_t(end, fin),
 				  "gw: %s, ", sa);
 	}
 

--- a/lib/misc/CMakeLists.txt
+++ b/lib/misc/CMakeLists.txt
@@ -36,6 +36,11 @@ list(APPEND SOURCES
 	misc/prng.c
 	misc/lws-ring.c)
 
+if (LWS_WITH_NETWORK)
+	list(APPEND SOURCES
+		misc/lws-cache-ttl.c)
+endif()
+
 if (LWS_WITH_FTS)
 	list(APPEND SOURCES
 		misc/fts/trie.c

--- a/lib/misc/lws-cache-ttl.c
+++ b/lib/misc/lws-cache-ttl.c
@@ -1,0 +1,298 @@
+/*
+ * libwebsockets - small server side websockets and web server implementation
+ *
+ * Copyright (C) 2010 - 2021 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <private-lib-core.h>
+
+typedef struct lws_cache_ttl_item {
+	lws_dll2_t			list_expiry;
+	lws_dll2_t			list_lru;
+
+	lws_usec_t			expiry;
+	size_t				key_len;
+	size_t				size;
+
+	/*
+	 * len + key_len + 1 bytes of data overcommitted, user object first
+	 * so it is well-aligned, then the NUL-terminated key name
+	 */
+} lws_cache_ttl_item_t;
+
+typedef struct lws_cache_ttl_lru {
+	lws_dll2_owner_t		items_expiry;
+	lws_dll2_owner_t		items_lru;
+
+	struct lws_cache_creation_info	info;
+
+	lws_sorted_usec_list_t		sul;
+
+	size_t				current_footprint;
+
+} lws_cache_ttl_lru_t;
+
+static void
+expiry_cb(lws_sorted_usec_list_t *sul);
+
+
+//static const struct lws_cache_ops lws_cache_ops_heap = {
+	// .item_alloc			= lws_cache_heap_item_alloc,
+//};
+
+static int
+earliest_expiry(struct lws_cache_ttl_lru *cache, lws_usec_t *pearliest)
+{
+	lws_cache_ttl_item_t *item;
+
+	if (!cache->items_expiry.head)
+		return 1;
+
+	item = lws_container_of(cache->items_expiry.head,
+				lws_cache_ttl_item_t, list_expiry);
+
+	*pearliest = item->expiry;
+
+	return 0;
+}
+
+static void
+update_sul(struct lws_cache_ttl_lru *cache)
+{
+	lws_usec_t earliest;
+
+	if (earliest_expiry(cache, &earliest)) {
+		lws_sul_cancel(&cache->sul);
+		return;
+	}
+
+	lwsl_debug("%s: setting exp %llu\n", __func__,
+			(unsigned long long)earliest);
+
+	lws_sul_schedule(cache->info.cx, cache->info.tsi, &cache->sul,
+			 expiry_cb, earliest - lws_now_usecs());
+}
+
+
+static void
+lws_cache_item_destroy_by_item(struct lws_cache_ttl_lru *cache,
+			       lws_cache_ttl_item_t *item, int parent_too)
+{
+	lws_dll2_remove(&item->list_expiry);
+	lws_dll2_remove(&item->list_lru);
+
+	cache->current_footprint -= item->size;
+
+	update_sul(cache);
+
+	//if (parent_too && cache->parent)
+	//	cache->parent->
+
+	if (cache->info.cb)
+		cache->info.cb((void *)((uint8_t *)&item[1]), item->size);
+
+	lws_free(item);
+}
+
+static void
+lws_cache_item_evict_lru(lws_cache_ttl_lru_t *cache)
+{
+	lws_cache_ttl_item_t *ei;
+
+	if (!cache->items_lru.head)
+		return;
+
+	ei = lws_container_of(cache->items_lru.head,
+			      lws_cache_ttl_item_t, list_lru);
+	lws_cache_item_destroy_by_item(cache, ei, 0);
+}
+
+static void
+expiry_cb(lws_sorted_usec_list_t *sul)
+{
+	lws_cache_ttl_lru_t *cache = lws_container_of(sul, lws_cache_ttl_lru_t, sul);
+
+	while (cache->items_expiry.head) {
+		lws_cache_ttl_item_t *item;
+
+		item = lws_container_of(cache->items_expiry.head,
+					lws_cache_ttl_item_t, list_expiry);
+
+		if (lws_now_usecs() < item->expiry)
+			return;
+
+		lws_cache_item_destroy_by_item(cache, item, 1);
+	}
+}
+
+static int
+lws_sort_expiry(const lws_dll2_t *a, const lws_dll2_t *b)
+{
+	const lws_cache_ttl_item_t
+		*c = lws_container_of(a, lws_cache_ttl_item_t, list_expiry),
+		*d = lws_container_of(b, lws_cache_ttl_item_t, list_expiry);
+
+	if (c->expiry > d->expiry)
+		return 1;
+	if (c->expiry < d->expiry)
+		return -1;
+
+	return 0;
+}
+
+void *
+lws_cache_item_alloc(struct lws_cache_ttl_lru *cache, const char *key,
+		     size_t size, lws_usec_t expiry)
+{
+	lws_cache_ttl_item_t *item, *ei;
+	size_t kl = strlen(key);
+	char *p;
+
+	/*
+	 * Make space if space is limited
+	 */
+
+	if (cache->info.max_footprint)
+		while (cache->current_footprint + size > cache->info.max_footprint)
+			lws_cache_item_evict_lru(cache);
+
+	if (cache->info.max_items)
+		while (cache->items_lru.count + 1 > cache->info.max_items)
+			lws_cache_item_evict_lru(cache);
+
+	/* remove any existing entry of the same key */
+
+	lws_cache_item_destroy_by_key(cache, key);
+
+	item = lws_malloc(sizeof(*item) + kl + 1u + size, __func__);
+	if (!item)
+		return NULL;
+
+	cache->current_footprint += item->size;
+
+	/* only need to zero down our item object */
+	memset(item, 0, sizeof(*item));
+
+	p = ((char *)&item[1]);
+	/* copy the key string into place, with terminating NUL */
+	memcpy(p + size, key, kl + 1);
+
+	item->expiry = expiry;
+	item->key_len = kl;
+	item->size = size;
+
+	if (expiry) {
+		/* adding to expiry is optional, on nonzero expiry */
+		lws_dll2_add_sorted(&item->list_expiry, &cache->items_expiry,
+				    lws_sort_expiry);
+		ei = lws_container_of(cache->items_expiry.head,
+				      lws_cache_ttl_item_t, list_expiry);
+		lwsl_debug("%s: setting exp %llu\n", __func__,
+				(unsigned long long)ei->expiry);
+		lws_sul_schedule(cache->info.cx, cache->info.tsi, &cache->sul,
+				 expiry_cb, ei->expiry - lws_now_usecs());
+	}
+
+	/* always add outselves to head of lru list */
+	lws_dll2_add_head(&item->list_lru, &cache->items_lru);
+
+	return (void *)p;
+}
+
+void *
+lws_cache_item_find(struct lws_cache_ttl_lru *cache, const char *key, size_t *size)
+{
+	lws_start_foreach_dll(struct lws_dll2 *, d, cache->items_lru.head) {
+		lws_cache_ttl_item_t *item =
+			lws_container_of(d, lws_cache_ttl_item_t, list_lru);
+
+		if (!strcmp(key, ((char *)&item[1]) + item->size)) {
+			*size = item->size;
+
+			return (void *)&item[1];
+		}
+
+	} lws_end_foreach_dll(d);
+
+	// if (cache->parent)
+
+
+	return NULL;
+}
+
+void
+lws_cache_item_destroy_by_key(struct lws_cache_ttl_lru *cache, const char *key)
+{
+	lws_cache_ttl_item_t *item;
+	size_t size;
+	void *user;
+
+	user = lws_cache_item_find(cache, key, &size);
+
+	if (!user)
+		return;
+
+	item = (lws_cache_ttl_item_t *)(((uint8_t *)user) - sizeof(*item));
+
+	lws_cache_item_destroy_by_item(cache, item, 1);
+}
+
+struct lws_cache_ttl_lru *
+lws_cache_create(const struct lws_cache_creation_info *info)
+{
+	lws_cache_ttl_lru_t *cache = lws_zalloc(sizeof(*cache), __func__);
+
+	if (!cache)
+		return NULL;
+
+	cache->info		= *info;
+//	if (!cache->info.ops)
+//		cache->info.ops = &lws_cache_ops_heap;
+
+	return cache;
+}
+
+static int
+destroy_dll(struct lws_dll2 *d, void *user)
+{
+	lws_cache_ttl_lru_t *cache = (struct lws_cache_ttl_lru *)user;
+	lws_cache_ttl_item_t *item = lws_container_of(d, lws_cache_ttl_item_t,
+						      list_lru);
+
+	lws_cache_item_destroy_by_item(cache, item, 0);
+
+	return 0;
+}
+
+void
+lws_cache_destroy(struct lws_cache_ttl_lru **_cache)
+{
+	lws_cache_ttl_lru_t *cache = *_cache;
+
+	if (!cache)
+		return;
+
+	lws_dll2_foreach_safe(&cache->items_lru, cache, destroy_dll);
+
+	lws_sul_cancel(&cache->sul);
+
+	lws_free_set_NULL(*_cache);
+}

--- a/lib/tls/CMakeLists.txt
+++ b/lib/tls/CMakeLists.txt
@@ -117,6 +117,10 @@ if (LWS_WITH_SSL)
 		list(APPEND SOURCES
 			tls/tls-sessions.c)
 	endif()
+	if (LWS_WITH_TLS_JIT_TRUST)
+		list(APPEND SOURCES
+			tls/tls-jit-trust.c)
+	endif()
 	
 	if (LWS_WITH_MBEDTLS)
 		list(APPEND SOURCES
@@ -335,6 +339,7 @@ if (LWS_WITH_SSL AND NOT LWS_WITH_MBEDTLS)
 	# what's in an openssl also installed on the build host
 CHECK_C_SOURCE_COMPILES("#include <openssl/ssl.h>\nint main(void) { STACK_OF(X509) *c = NULL; SSL_CTX *ctx = NULL; return (int)SSL_CTX_get_extra_chain_certs_only(ctx, &c); }\n" LWS_HAVE_SSL_EXTRA_CHAIN_CERTS)
 CHECK_C_SOURCE_COMPILES("#include <openssl/ssl.h>\nint main(void) { EVP_MD_CTX *md_ctx = NULL; EVP_MD_CTX_free(md_ctx); return 0; }\n" LWS_HAVE_EVP_MD_CTX_free)
+CHECK_C_SOURCE_COMPILES("#include <openssl/ssl.h>\nint main(void) { OPENSSL_STACK *x = NULL; return !x; } \n" LWS_HAVE_OPENSSL_STACK)
 set(LWS_HAVE_SSL_EXTRA_CHAIN_CERTS ${LWS_HAVE_SSL_EXTRA_CHAIN_CERTS} PARENT_SCOPE)
 set(LWS_HAVE_EVP_MD_CTX_free ${LWS_HAVE_EVP_MD_CTX_free} PARENT_SCOPE)
 CHECK_FUNCTION_EXISTS(${VARIA}ECDSA_SIG_set0 LWS_HAVE_ECDSA_SIG_set0 PARENT_SCOPE)
@@ -352,6 +357,8 @@ if (LWS_WITH_MBEDTLS)
 		set(LWS_HAVE_X509_VERIFY_PARAM_set1_host 1 PARENT_SCOPE)
 	endif()
 
+	CHECK_C_SOURCE_COMPILES("#include <mbedtls/x509_crt.h>\nint main(void) { struct mbedtls_x509_crt c; c.authority_key_id.keyIdentifier.tag = MBEDTLS_ASN1_OCTET_STRING; return c.authority_key_id.keyIdentifier.tag; }\n" LWS_HAVE_MBEDTLS_AUTH_KEY_ID)
+	CHECK_C_SOURCE_COMPILES("#include <mbedtls/ssl.h>\nint main(void) { void *v = (void *)mbedtls_ssl_set_verify; return !!v; }\n" LWS_HAVE_mbedtls_ssl_set_verify)
 	CHECK_FUNCTION_EXISTS(mbedtls_ssl_conf_alpn_protocols LWS_HAVE_mbedtls_ssl_conf_alpn_protocols PARENT_SCOPE)
 	CHECK_FUNCTION_EXISTS(mbedtls_ssl_get_alpn_protocol LWS_HAVE_mbedtls_ssl_get_alpn_protocol PARENT_SCOPE)
 	CHECK_FUNCTION_EXISTS(mbedtls_ssl_conf_sni LWS_HAVE_mbedtls_ssl_conf_sni PARENT_SCOPE)

--- a/lib/tls/mbedtls/wrapper/include/internal/ssl_types.h
+++ b/lib/tls/mbedtls/wrapper/include/internal/ssl_types.h
@@ -31,6 +31,10 @@
 
 #include "ssl_code.h"
 
+#include <mbedtls/x509_crt.h>
+
+#include "private-jit-trust.h"
+
 typedef void SSL_CIPHER;
 
 typedef void X509_STORE_CTX;
@@ -183,7 +187,7 @@ struct ssl_ctx_st
 
     int verify_mode;
 
-    int (*default_verify_callback) (int ok, X509_STORE_CTX *ctx);
+    int (*default_verify_callback) (SSL *, mbedtls_x509_crt *);
 
     long session_timeout;
 
@@ -223,7 +227,11 @@ struct ssl_st
 
     int verify_mode;
 
-    int (*verify_callback) (int ok, X509_STORE_CTX *ctx);
+    int (*verify_callback) (SSL *, mbedtls_x509_crt *);
+
+#if defined(LWS_WITH_TLS_JIT_TRUST)
+    lws_tls_kid_chain_t		kid_chain;
+#endif
 
     int rwstate;
     int interrupted_remaining_write;

--- a/lib/tls/mbedtls/wrapper/include/openssl/ssl.h
+++ b/lib/tls/mbedtls/wrapper/include/openssl/ssl.h
@@ -708,7 +708,7 @@ int SSL_CTX_get_verify_depth(const SSL_CTX *ctx);
  *
  * @return none
  */
-void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*verify_callback)(int, X509_STORE_CTX *));
+void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*verify_callback)(SSL *, mbedtls_x509_crt *));
 
 /**
  * @brief set the SSL verifying of the SSL context
@@ -719,7 +719,7 @@ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*verify_callback)(int, X509
  *
  * @return none
  */
-void SSL_set_verify(SSL *s, int mode, int (*verify_callback)(int, X509_STORE_CTX *));
+void SSL_set_verify(SSL *s, int mode, int (*verify_callback)(SSL *, mbedtls_x509_crt *));
 
 /**
  * @brief set the SSL verify depth of the SSL context
@@ -739,7 +739,7 @@ void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
  *
  * @return verifying result
  */
-int verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx);
+int verify_callback(SSL *, mbedtls_x509_crt *);
 
 /**
  * @brief set the session timeout time

--- a/lib/tls/mbedtls/wrapper/library/ssl_lib.c
+++ b/lib/tls/mbedtls/wrapper/library/ssl_lib.c
@@ -1078,7 +1078,7 @@ void SSL_set_verify_depth(SSL *ssl, int depth)
 /**
  * @brief set the SSL context verifying of the SSL context
  */
-void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*verify_callback)(int, X509_STORE_CTX *))
+void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*verify_callback)(SSL *, mbedtls_x509_crt *))
 {
     SSL_ASSERT3(ctx);
 
@@ -1089,7 +1089,7 @@ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*verify_callback)(int, X509
 /**
  * @brief set the SSL verifying of the SSL context
  */
-void SSL_set_verify(SSL *ssl, int mode, int (*verify_callback)(int, X509_STORE_CTX *))
+void SSL_set_verify(SSL *ssl, int mode, int (*verify_callback)(SSL *, mbedtls_x509_crt *))
 {
     SSL_ASSERT3(ssl);
 

--- a/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
+++ b/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
@@ -27,7 +27,7 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/error.h"
-//#include "mbedtls/certs.h"
+
 
 #include "private-lib-core.h"
 
@@ -96,6 +96,19 @@ static void ssl_platform_debug(void *ctx, int level,
 }
 //#endif
 
+#if defined(LWS_HAVE_mbedtls_ssl_set_verify)
+static int
+lws_mbedtls_f_vrfy(void *opaque, mbedtls_x509_crt *x509, int state, uint32_t *pflags)
+{
+	struct ssl_pm *ssl_pm = (struct ssl_pm *)opaque;
+
+	if (ssl_pm->owner->verify_callback)
+		(ssl_pm->owner->verify_callback)(ssl_pm->owner, x509);
+
+	return 0;
+}
+#endif
+
 /**
  * @brief create SSL low-level object
  */
@@ -133,6 +146,10 @@ int ssl_pm_new(SSL *ssl)
     mbedtls_ctr_drbg_init(&ssl_pm->ctr_drbg);
     mbedtls_entropy_init(&ssl_pm->entropy);
     mbedtls_ssl_init(&ssl_pm->ssl);
+
+#if defined(LWS_HAVE_mbedtls_ssl_set_verify)
+    mbedtls_ssl_set_verify(&ssl_pm->ssl, lws_mbedtls_f_vrfy, ssl_pm);
+#endif
 
     ret = mbedtls_ctr_drbg_seed(&ssl_pm->ctr_drbg, mbedtls_entropy_func, &ssl_pm->entropy, pers, pers_len);
     if (ret) {

--- a/lib/tls/openssl/openssl-x509.c
+++ b/lib/tls/openssl/openssl-x509.c
@@ -71,17 +71,33 @@ lws_tls_openssl_asn1time_to_unix(ASN1_TIME *as)
 #endif
 }
 
+#if defined(USE_WOLFSSL)
+#define AUTHORITY_KEYID WOLFSSL_AUTHORITY_KEYID
+#endif
+
 int
 lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
 			  union lws_tls_cert_info_results *buf, size_t len)
 {
+#ifndef USE_WOLFSSL
+	const unsigned char *dp;
+	ASN1_OCTET_STRING *val;
+	AUTHORITY_KEYID *akid;
+	X509_EXTENSION *ext;
+	int tag, xclass;
+	long xlen, loc;
+#endif
 	X509_NAME *xn;
 #if !defined(LWS_PLAT_OPTEE)
 	char *p;
 #endif
 
+	buf->ns.len = 0;
+
 	if (!x509)
 		return -1;
+	if (!len)
+		len = sizeof(buf->ns.name);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(X509_get_notBefore)
 #define X509_get_notBefore(x)	X509_getm_notBefore(x)
@@ -180,6 +196,141 @@ lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
 
 		return 0;
 	}
+
+#ifndef USE_WOLFSSL
+
+	case LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID:
+		loc = X509_get_ext_by_NID(x509, NID_authority_key_identifier, -1);
+		if (loc < 0)
+			return 1;
+
+		ext = X509_get_ext(x509, (int)loc);
+		if (!ext)
+			return 1;
+#ifndef USE_WOLFSSL
+		akid = (AUTHORITY_KEYID *)X509V3_EXT_d2i(ext);
+#else
+		akid = (AUTHORITY_KEYID *)wolfSSL_X509V3_EXT_d2i(ext);
+#endif
+		if (!akid || !akid->keyid)
+			return 1;
+		val = akid->keyid;
+		dp = (const unsigned char *)val->data;
+		xlen = val->length;
+
+		goto handle_octet_ext;
+
+	case LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID_ISSUER:
+		loc = X509_get_ext_by_NID(x509, NID_authority_key_identifier, -1);
+		if (loc < 0)
+			return 1;
+
+		ext = X509_get_ext(x509, (int)loc);
+		if (!ext)
+			return 1;
+
+#ifndef USE_WOLFSSL
+		akid = (AUTHORITY_KEYID *)X509V3_EXT_d2i(ext);
+#else
+		akid = (AUTHORITY_KEYID *)wolfSSL_X509V3_EXT_d2i(ext);
+#endif
+		if (!akid || !akid->issuer)
+			return 1;
+
+#if defined(LWS_HAVE_OPENSSL_STACK)
+		{
+			const X509V3_EXT_METHOD* method = X509V3_EXT_get(ext);
+			STACK_OF(CONF_VALUE) *cv;
+			int j;
+
+			cv = i2v_GENERAL_NAMES((X509V3_EXT_METHOD*)method, akid->issuer, NULL);
+			if (!cv)
+				return 1;
+
+		        for (j = 0; j < OPENSSL_sk_num((const OPENSSL_STACK *)&cv); j++) {
+		            CONF_VALUE *nval = OPENSSL_sk_value((const OPENSSL_STACK *)&cv, j);
+		            size_t ln = (nval->name ? strlen(nval->name) : 0),
+		        	   lv = (nval->value ? strlen(nval->value) : 0),
+		        	   l = ln + lv;
+
+		            if (len > l) {
+		        	    if (nval->name)
+		        		    memcpy(buf->ns.name + buf->ns.len, nval->name, ln);
+		        	    if (nval->value)
+		        		    memcpy(buf->ns.name + buf->ns.len + ln, nval->value, lv);
+		        	    buf->ns.len = (int)((size_t)buf->ns.len + l);
+		        	    len -= l;
+		        	    buf->ns.name[buf->ns.len] = '\0';
+		            }
+		        }
+		}
+#else
+		return 1;
+#endif
+		break;
+
+	case LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID_SERIAL:
+		loc = X509_get_ext_by_NID(x509, NID_authority_key_identifier, -1);
+		if (loc < 0)
+			return 1;
+
+		ext = X509_get_ext(x509, (int)loc);
+		if (!ext)
+			return 1;
+		akid = (AUTHORITY_KEYID *)X509V3_EXT_d2i(ext);
+		if (!akid || !akid->serial)
+			return 1;
+
+#if 0
+		// need to handle blobs, and ASN1_INTEGER_get_uint64 not
+		// available on older openssl
+		{
+			uint64_t res;
+			if (ASN1_INTEGER_get_uint64(&res, akid->serial) != 1)
+				break;
+			buf->ns.len = lws_snprintf(buf->ns.name, len, "%llu",
+					(unsigned long long)res);
+		}
+#endif
+		break;
+
+	case LWS_TLS_CERT_INFO_SUBJECT_KEY_ID:
+
+		loc = X509_get_ext_by_NID(x509, NID_subject_key_identifier, -1);
+		if (loc < 0)
+			return 1;
+
+		ext = X509_get_ext(x509, (int)loc);
+		if (!ext)
+			return 1;
+
+		val = X509_EXTENSION_get_data(ext);
+		if (!val)
+			return 1;
+
+#if defined(USE_WOLFSSL)
+		return 1;
+#else
+		dp = (const unsigned char *)val->data;
+
+		if (ASN1_get_object(&dp, &xlen,
+				    &tag, &xclass, val->length) & 0x80)
+			return -1;
+
+		if (tag != V_ASN1_OCTET_STRING) {
+			lwsl_notice("not octet string %d\n", (int)tag);
+			return 1;
+		}
+#endif
+handle_octet_ext:
+		buf->ns.len = (int)xlen;
+		if (len < (size_t)buf->ns.len)
+			return -1;
+
+		memcpy(buf->ns.name, dp, (size_t)buf->ns.len);
+		break;
+#endif
+
 	default:
 		return -1;
 	}

--- a/lib/tls/private-jit-trust.h
+++ b/lib/tls/private-jit-trust.h
@@ -1,7 +1,7 @@
  /*
  * libwebsockets - small server side websockets and web server implementation
  *
- * Copyright (C) 2010 - 2019 Andy Green <andy@warmcat.com>
+ * Copyright (C) 2010 - 2021 Andy Green <andy@warmcat.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -21,25 +21,25 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- *  gencrypto mbedtls-specific helper declarations
+ *  This is included from private-lib-core.h if LWS_WITH_TLS
  */
 
-#include <mbedtls/x509_crl.h>
-#include <errno.h>
+#if !defined(__LWS_TLS_PRIVATE_JIT_TRUST_H__)
+#define __LWS_TLS_PRIVATE_JIT_TRUST_H__
 
-struct lws_x509_cert {
-	mbedtls_x509_crt cert; /* has a .next for linked-list / chain */
-};
+typedef struct {
+	uint8_t		kid[20];
+	uint8_t		kid_len;
+} lws_tls_kid_t;
 
-mbedtls_md_type_t
-lws_gencrypto_mbedtls_hash_to_MD_TYPE(enum lws_genhash_types hash_type);
-
-int
-lws_gencrypto_mbedtls_rngf(void *context, unsigned char *buf, size_t len);
-
-int
-lws_tls_session_new_mbedtls(struct lws *wsi);
+typedef struct {
+	lws_tls_kid_t	akid[4];
+	lws_tls_kid_t	skid[4];
+	uint8_t		count;
+} lws_tls_kid_chain_t;
 
 int
-lws_tls_mbedtls_cert_info(mbedtls_x509_crt *x509, enum lws_tls_cert_info type,
-			  union lws_tls_cert_info_results *buf, size_t len);
+lws_tls_jit_trust_sort_kids(lws_tls_kid_chain_t *ch);
+
+#endif
+

--- a/lib/tls/private-lib-tls.h
+++ b/lib/tls/private-lib-tls.h
@@ -30,6 +30,8 @@
 
 #if defined(LWS_WITH_TLS)
 
+#include "private-jit-trust.h"
+
 #if defined(USE_WOLFSSL)
  #if defined(USE_OLD_CYASSL)
   #if defined(_WIN32)

--- a/lib/tls/tls-jit-trust.c
+++ b/lib/tls/tls-jit-trust.c
@@ -1,0 +1,135 @@
+/*
+ * libwebsockets - small server side websockets and web server implementation
+ *
+ * Copyright (C) 2010 - 2021 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "private-lib-core.h"
+
+static int
+lws_tls_kid_cmp(const lws_tls_kid_t *a, const lws_tls_kid_t *b)
+{
+	if (a->kid_len != b->kid_len)
+		return 1;
+
+	return memcmp(a->kid, b->kid, a->kid_len);
+}
+
+/*
+ * We have the SKID and AKID for every peer cert captured, but they may be
+ * in any order, and eg, falsely have sent the root CA, or an attacker may
+ * send unresolveable self-referencing loops of KIDs.
+ *
+ * Let's sort them into the SKID -> AKID hierarchy, so the last entry is the
+ * server cert and the first entry is the highest parent that the server sent.
+ * Normally the top one will be an intermediate, and its AKID is the ID of the
+ * root CA cert we would need to trust to validate the chain.
+ *
+ * It's not unknown the server is misconfigured to also send the root CA, if so
+ * the top slot's AKID is empty and we should look for its SKID in the trust
+ * blob.
+ *
+ * If we return 0, we succeeded and the AKID of ch[0] is the SKID we want to see
+ * try to import from the trust blob.
+ *
+ * If we return nonzero, we can't identify what we want and should abandon the
+ * connection.
+ */
+
+int
+lws_tls_jit_trust_sort_kids(lws_tls_kid_chain_t *ch)
+{
+	int n, m, sanity = 10;
+	char more = 1;
+
+	/* something to work with? */
+
+	if (!ch->count)
+		return 1;
+
+	/* do we need to sort? */
+
+	if (ch->count > 1) {
+
+		/* okie... */
+
+		while (more) {
+
+			if (!sanity--)
+				/* let's not get fooled into spinning */
+				return 1;
+
+			more = 0;
+			for (n = 0; n < ch->count - 1; n++) {
+
+				if (!lws_tls_kid_cmp(&ch->skid[n],
+						     &ch->akid[n + 1]))
+					/* next belongs with this one */
+					continue;
+
+				/*
+				 * next doesn't belong with this one, let's
+				 * try to figure out where this one does belong
+				 * then
+				 */
+
+				for (m = 0; m < ch->count; m++) {
+					if (n == m)
+						continue;
+					if (!lws_tls_kid_cmp(&ch->skid[n],
+							     &ch->akid[m])) {
+						lws_tls_kid_t t;
+
+						/*
+						 * m references us, so we
+						 * need to go one step above m,
+						 * swap m and n
+						 */
+
+						more = 1;
+						t = ch->akid[m];
+						ch->akid[m] = ch->akid[n];
+						ch->akid[n] = t;
+						t = ch->skid[m];
+						ch->skid[m] = ch->skid[n];
+						ch->skid[n] = t;
+
+						break;
+					}
+				}
+
+				if (more)
+					n = -1;
+			}
+		}
+
+		/* then we should be sorted */
+	}
+
+	for (n = 0; n < ch->count; n++) {
+		lwsl_notice("%s: AKID[%d]\n", __func__, n);
+		lwsl_hexdump_notice(ch->akid[n].kid, ch->akid[n].kid_len);
+		lwsl_notice("%s: SKID[%d]\n", __func__, n);
+		lwsl_hexdump_notice(ch->skid[n].kid, ch->skid[n].kid_len);
+	}
+
+	return !ch->akid[0].kid_len;
+}

--- a/minimal-examples/http-client/minimal-http-client-certinfo/minimal-http-client-certinfo.c
+++ b/minimal-examples/http-client/minimal-http-client-certinfo/minimal-http-client-certinfo.c
@@ -78,6 +78,28 @@ callback_http(struct lws *wsi, enum lws_callback_reasons reason,
 			lwsl_notice(" Peer Cert public key:\n");
 			lwsl_hexdump_notice(ci->ns.name, (unsigned int)ci->ns.len);
 		}
+
+		if (!lws_tls_peer_cert_info(wsi, LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID,
+					    ci, 0)) {
+			lwsl_notice(" AUTHORITY_KEY_ID\n");
+			lwsl_hexdump_notice(ci->ns.name, (size_t)ci->ns.len);
+		}
+		if (!lws_tls_peer_cert_info(wsi, LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID_ISSUER,
+					    ci, 0)) {
+			lwsl_notice(" AUTHORITY_KEY_ID ISSUER\n");
+			lwsl_hexdump_notice(ci->ns.name, (size_t)ci->ns.len);
+		}
+		if (!lws_tls_peer_cert_info(wsi, LWS_TLS_CERT_INFO_AUTHORITY_KEY_ID_SERIAL,
+					    ci, 0)) {
+			lwsl_notice(" AUTHORITY_KEY_ID SERIAL\n");
+			lwsl_hexdump_notice(ci->ns.name, (size_t)ci->ns.len);
+		}
+		if (!lws_tls_peer_cert_info(wsi, LWS_TLS_CERT_INFO_SUBJECT_KEY_ID,
+					    ci, 0)) {
+			lwsl_notice(" AUTHORITY_KEY_ID SUBJECT_KEY_ID\n");
+			lwsl_hexdump_notice(ci->ns.name, (size_t)ci->ns.len);
+		}
+
 		break;
 
 	/* chunks of chunked content, with header removed */
@@ -207,6 +229,10 @@ int main(int argc, const char **argv)
 		i.port = 443;
 		i.address = "warmcat.com";
 	}
+
+	if ((p = lws_cmdline_option(argc, argv, "-s")))
+		i.address = p;
+
 	i.path = "/";
 	i.host = i.address;
 	i.origin = i.address;

--- a/scripts/mozilla-trust-gen.sh
+++ b/scripts/mozilla-trust-gen.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+# This script fetches the current list of trusted CAs blessed by Mozilla
+# for web tls validation, and processes it into two outputs
+#
+# - ./trust/webroot/* consisting of ./_trust/webroot/der  a static, serveable set
+#     of trusted DER certs, with symlinks in ./_trust/webroot/by-skid and
+#     ./_trust/webroot/by-iss allowing serving the DER matching a given
+#     SubjectKeyIdentifier or Issuer + serial combination (suitably encoded)
+#
+# - ./_trust/blob-XXXX.bin  a single blob containing indexes and DER CA certs
+#
+# - ./_trust/trust_blob.h   a C uint8_t array formatted copy of blob-XXXX.bin
+
+# The trust blob layout is currently
+#
+# 54 42 4c 42     Magic "TBLB"
+# 00 01           MSB-first trust blob layout version
+# XX XX           MSB-first count of certificates
+# XX XX XX XX     MSB-first trust blob generation unix time
+# XX XX XX XX     MSB-first offset of cert length table (MSB-first 16-bit length-per-cert)
+# XX XX XX XX     MSB-first offset of SKID length table (8-bit length-per-cert)
+# XX XX XX XX     MSB-first offset of SKID table
+# XX XX XX XX     MSB-first total blob length
+#
+# XX .. XX        DER certs (start at +0x1c)
+# XX .. XX        DER cert length table (MSB-first 16-bit per cert)
+# XX .. XX        SKID length table (8-bit per cert)
+# XX .. XX        SKID table (variable per cert)
+#
+
+echo "Mozilla trust bundle for TLS validation processing  Andy Green <andy@warmcat.com>"
+echo
+
+rm -rf _trust
+mkdir _trust
+
+wget -O _trust/trusted.txt "https://ccadb-public.secure.force.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites"
+#cp ~/Downloads/IncludedRootsPEM.txt _trust/trusted.txt
+
+if [ $? -ne 0 ]; then
+	echo "Failed to get current website trust bundle"
+	exit 1
+fi
+
+mkdir -p _trust/webroot/by-skid _trust/webroot/by-iss _trust/webroot/der
+
+echo 0 > _trust/ofs
+echo 0 > _trust/count
+echo 0 > _trust/skidtab
+
+GT=`date +%s`
+BN=_trust/blob-$GT.bin
+
+cat _trust/trusted.txt | while read _line ; do
+	line=`echo -n $_line | sed 's/\r$//g'`
+	if [ "$line" == "-----BEGIN CERTIFICATE-----" ] ; then
+		echo $line > _trust/single
+	else
+		echo $line >> _trust/single
+
+		if [ "$line" == "-----END CERTIFICATE-----" ] ; then
+			openssl x509 -in _trust/single -text -noout > _trust/c1
+			if [ $? -ne 0 ] ; then
+				echo "FAILED"
+				exit 1
+			fi
+
+			ISS=`cat _trust/c1 | grep Issuer: | sed "s/.*://g" | sed "s/^\ *//g"`
+			SER=`cat _trust/c1 | grep "Serial Number:" | sed "s/.*://g" | sed "s/^\ *//g" | sed "s/\ .*//g"`
+			if [ -z "$SER" ] ; then
+				SER=`cat _trust/c1 | sed -e "1,/.*Serial Number:/ d" | head -n 1 | sed "s/^\ *//g" | sed "s/\ .*//g"`
+			fi
+			SKID=`cat _trust/c1 | sed -e '1,/.*X509v3 Subject Key Identifier:/ d' | sed -n '/Signature.*/q;p' | \
+				grep ':' | grep -v ': ' | grep -v ':$' | grep -v U | grep -v k | grep -v T | grep -v "i" | \
+				grep -v "S" | grep -v "V" | sed "s/^\ *//g"`
+			SKID_NO_COLONS=`echo -n $SKID | sed "s/://g"`
+
+			na=`cat _trust/c1 | grep "Not\ After\ :" | sed "s/.*\ :\ //g"`
+			ct=`date +%s`
+			ts=`date --date="$na" +%s`
+			life_days=`echo -n "$(( ( $ts - $ct ) / 86400 ))"`
+
+			echo "$life_days $safe" >> _trust/life
+			if [ $life_days -lt 1095 ] ; then
+				echo "$life_days $safe" >> _trust/life_lt_3y
+			fi
+
+			echo "issuer=\"$ISS\", serial=\"${SER^^}\", skid=\"${SKID_NO_COLONS^^}\", life_days=\"${life_days}\""
+
+			issname=`echo -n "$ISS"_"$SER" | tr -cd '[a-zA-Z0-9]_'`
+			skidname=`echo -n "$SKID_NO_COLONS" | tr -cd '[a-zA-Z0-9]_'`
+			safe=$issname"_"$skidname
+
+			cat _trust/single | grep -v -- '---' | base64 -d > _trust/webroot/der/$safe
+			cd _trust/webroot/by-skid
+			ln -sf ../der/$safe $SKID_NO_COLONS
+			cd ../../..
+			cd _trust/webroot/by-iss
+			ln -sf ../der/$safe $issname
+			cd ../../..
+
+			DERSIZ=`cat _trust/single | grep -v -- '---' | base64 -d | wc -c | cut -d' ' -f1`
+
+			cat _trust/single | grep -v -- '---' | base64 -d | hexdump -C | tr -s ' ' | sed 's/\ $//g' | \
+				cut -d' ' -f 2-17 | cut -d'|' -f1 | grep -v 000 | sed "s/\ //g" | sed ':a;N;$!ba;s/\n//g' | xxd -r -p >> _trust/_ders
+
+			printf "%04x" $DERSIZ | xxd -r -p  >> _trust/_derlens
+
+echo $SKID
+
+			if [ ! -z "$SKID" ] ; then
+				echo -n "$SKID_NO_COLONS" | xxd -r -p >> _trust/_skid
+			fi
+			SKIDSIZ=`echo -n $SKID_NO_COLONS | xxd -r -p | wc -c | cut -d' ' -f1`
+			printf "%04x" $SKIDSIZ | xxd -r -p  >> _trust/_skidlens
+
+			OFS=`cat _trust/ofs`
+			echo -n $(( $OFS + $DERSIZ )) > _trust/ofs
+			COUNT=`cat _trust/count`
+			echo -n $(( $COUNT +1 )) > _trust/count
+			ST=`cat _trust/skidtab`
+			echo -n $(( $ST + ( `echo -n $skidname | wc -c` / 2 ) )) > _trust/skidtab
+
+			#rm -f _trust/single
+		fi
+	fi
+
+done
+
+	COUNT=`cat _trust/count`
+	OFS=`cat _trust/ofs`
+	ST=`cat _trust/skidtab`
+
+	# everything in the layout framing is MSB-first
+
+	# magic
+	echo -n "TBLB" > $BN
+	# blob layout version
+	echo -n 0001 | xxd -r -p >> $BN
+	# number of certs in the blob
+	printf "%04x" $COUNT | xxd -r -p >> $BN
+	# unix time blob was created
+	printf "%08x" $GT | xxd -r -p >> $BN
+
+	POS=28
+	POS=$(( $POS + `cat _trust/_ders | wc -c | cut -d' ' -f1` ))
+
+	# blob offset of start of cert length table
+	printf "%08x" $POS | xxd -r -p >> $BN
+
+	POS=$(( $POS + `cat _trust/_derlens | wc -c | cut -d' ' -f1` ))
+
+	# blob offset of start of SKID length table
+	printf "%08x" $POS | xxd -r -p >> $BN
+
+	POS=$(( $POS + `cat _trust/_skidlens | wc -c | cut -d' ' -f1` ))
+
+	# blob offset of start of SKID table
+	printf "%08x" $POS | xxd -r -p >> $BN
+
+	POS=$(( $POS + `cat _trust/_skid | wc -c | cut -d' ' -f1` ))
+
+	# blob total length
+	printf "%08x" $POS | xxd -r -p >> $BN
+
+
+	# the DER table, start at +0x1c
+	cat _trust/_ders >> $BN
+	# the DER length table
+	cat _trust/_derlens >> $BN
+	# the SKID length table
+	cat _trust/_skidlens >> $BN
+	# the SKID table
+	cat _trust/_skid >> $BN
+
+# produce a C-friendly version of the blob
+
+	cat $BN | hexdump -C | tr -s ' ' | sed 's/\ $//g' | \
+		cut -d' ' -f 2-17 | cut -d'|' -f1 | grep -v 000 | sed "s/\ /,\ 0x/g" | sed "s/^/0x/g" | \
+		sed 's/\, 0x$//g' | sed 's/$/,/g' >> _trust/trust_blob.h
+
+
+	echo
+	echo "$COUNT CA certs, $POS byte blob"
+	echo
+	echo "CAs expiring in less than 3 years (days left):"
+	sort -h _trust/life_lt_3y
+
+	rm -f _trust/count _trust/_idx _trust/_idx_skid _trust/ofs _trust/_skid _trust/skidtab _trust/life _trust/life_lt_3y _trust/c1 _trust/single _trust/_derlens _trust/_ders _trust/_skid _trust/_skidlens
+
+exit 0
+


### PR DESCRIPTION
variable 'n' is being set but it is not used anywhere, latest clang is
able to detect this and flags it

Fixes

lib/core-net/route.c:41:6: error: variable 'n' set but not used [-Werror,-Wunused-but-set-variable]
|         int n = 0;
|             ^