### PR TITLE
Created separate buffer for pong payload store to avoid intersection between keepalive_ping and pong payload

### DIFF
--- a/lib/roles/h2/ops-h2.c
+++ b/lib/roles/h2/ops-h2.c
@@ -1177,7 +1177,7 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 		 * then logically close ourself
 		 */
 
-		if ((lwsi_role_ws(w) && w->ws->ping_pending_flag) ||
+		if ((lwsi_role_ws(w) && w->ws->pong_pending_flag) ||
 		    (lwsi_state(w) == LRS_RETURNED_CLOSE &&
 		     w->ws->payload_is_close)) {
 
@@ -1185,13 +1185,13 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 				write_type = LWS_WRITE_CLOSE |
 					     LWS_WRITE_H2_STREAM_END;
 
-			n = lws_write(w, &w->ws->ping_payload_buf[LWS_PRE],
-				      w->ws->ping_payload_len, (enum lws_write_protocol)write_type);
+			n = lws_write(w, &w->ws->pong_payload_buf[LWS_PRE],
+				      w->ws->pong_payload_len, (enum lws_write_protocol)write_type);
 			if (n < 0)
 				return -1;
 
 			/* well he is sent, mark him done */
-			w->ws->ping_pending_flag = 0;
+			w->ws->pong_pending_flag = 0;
 			if (w->ws->payload_is_close) {
 				/* oh... a close frame... then we are done */
 				lwsl_debug("Ack'd peer's close packet\n");

--- a/lib/roles/ws/client-parser-ws.c
+++ b/lib/roles/ws/client-parser-ws.c
@@ -445,9 +445,9 @@ spill:
 			if (wsi->ws->close_in_ping_buffer_len)
 				goto ping_drop;
 
-			if (wsi->ws->ping_pending_flag) {
+			if (wsi->ws->pong_pending_flag) {
 				/*
-				 * there is already a pending ping payload
+				 * there is already a pending pong payload
 				 * we should just log and drop
 				 */
 				lwsl_parser("DROP PING since one pending\n");
@@ -461,12 +461,12 @@ spill:
 			}
 
 			/* stash the pong payload */
-			memcpy(wsi->ws->ping_payload_buf + LWS_PRE,
+			memcpy(wsi->ws->pong_payload_buf + LWS_PRE,
 			       &wsi->ws->rx_ubuf[LWS_PRE],
 			       wsi->ws->rx_ubuf_head);
 
-			wsi->ws->ping_payload_len = (uint8_t)wsi->ws->rx_ubuf_head;
-			wsi->ws->ping_pending_flag = 1;
+			wsi->ws->pong_payload_len = (uint8_t)wsi->ws->rx_ubuf_head;
+			wsi->ws->pong_pending_flag = 1;
 
 			/* get it sent as soon as possible */
 			lws_callback_on_writable(wsi);

--- a/lib/roles/ws/ops-ws.c
+++ b/lib/roles/ws/ops-ws.c
@@ -512,9 +512,9 @@ spill:
 			lwsl_info("received %d byte ping, sending pong\n",
 						 (int)wsi->ws->rx_ubuf_head);
 
-			if (wsi->ws->ping_pending_flag) {
+			if (wsi->ws->pong_pending_flag) {
 				/*
-				 * there is already a pending ping payload
+				 * there is already a pending pong payload
 				 * we should just log and drop
 				 */
 				lwsl_parser("DROP PING since one pending\n");
@@ -528,12 +528,12 @@ process_as_ping:
 			}
 
 			/* stash the pong payload */
-			memcpy(wsi->ws->ping_payload_buf + LWS_PRE,
+			memcpy(wsi->ws->pong_payload_buf + LWS_PRE,
 			       &wsi->ws->rx_ubuf[LWS_PRE],
 				wsi->ws->rx_ubuf_head);
 
-			wsi->ws->ping_payload_len = (uint8_t)wsi->ws->rx_ubuf_head;
-			wsi->ws->ping_pending_flag = 1;
+			wsi->ws->pong_payload_len = (uint8_t)wsi->ws->rx_ubuf_head;
+			wsi->ws->pong_pending_flag = 1;
 
 			/* get it sent as soon as possible */
 			lws_callback_on_writable(wsi);
@@ -1294,7 +1294,7 @@ int rops_handle_POLLOUT_ws(struct lws *wsi)
 
 	/* else, the send failed and we should just hang up */
 
-	if ((lwsi_role_ws(wsi) && wsi->ws->ping_pending_flag) ||
+	if ((lwsi_role_ws(wsi) && wsi->ws->pong_pending_flag) ||
 	    (lwsi_state(wsi) == LRS_RETURNED_CLOSE &&
 	     wsi->ws->payload_is_close)) {
 
@@ -1303,20 +1303,20 @@ int rops_handle_POLLOUT_ws(struct lws *wsi)
 		else {
 			if (wsi->wsistate_pre_close) {
 				/* we started close flow, forget pong */
-				wsi->ws->ping_pending_flag = 0;
+				wsi->ws->pong_pending_flag = 0;
 				return LWS_HP_RET_BAIL_OK;
 			}
 			lwsl_info("issuing pong %d on %s\n",
-				  wsi->ws->ping_payload_len, lws_wsi_tag(wsi));
+				  wsi->ws->pong_payload_len, lws_wsi_tag(wsi));
 		}
 
-		n = lws_write(wsi, &wsi->ws->ping_payload_buf[LWS_PRE],
-			      wsi->ws->ping_payload_len, (enum lws_write_protocol)write_type);
+		n = lws_write(wsi, &wsi->ws->pong_payload_buf[LWS_PRE],
+			      wsi->ws->pong_payload_len, (enum lws_write_protocol)write_type);
 		if (n < 0)
 			return LWS_HP_RET_BAIL_DIE;
 
 		/* well he is sent, mark him done */
-		wsi->ws->ping_pending_flag = 0;
+		wsi->ws->pong_pending_flag = 0;
 		if (wsi->ws->payload_is_close) {
 			// assert(0);
 			/* oh... a close frame was it... then we are done */
@@ -1565,8 +1565,8 @@ rops_close_role_ws(struct lws_context_per_thread *pt, struct lws *wsi)
 #endif
 	lws_free_set_NULL(wsi->ws->rx_ubuf);
 
-	wsi->ws->ping_payload_len = 0;
-	wsi->ws->ping_pending_flag = 0;
+	wsi->ws->pong_payload_len = 0;
+	wsi->ws->pong_pending_flag = 0;
 
 	/* deallocate any active extension contexts */
 

--- a/lib/roles/ws/private-lib-roles-ws.h
+++ b/lib/roles/ws/private-lib-roles-ws.h
@@ -87,6 +87,8 @@ struct lws_pt_role_ws {
 };
 #endif
 
+#define PAYLOAD_BUF_SIZE 128 - 3 + LWS_PRE
+
 struct _lws_websocket_related {
 	unsigned char *rx_ubuf;
 #if !defined(LWS_WITHOUT_EXTENSIONS)
@@ -103,7 +105,8 @@ struct _lws_websocket_related {
 #endif
 
 	/* Also used for close content... control opcode == < 128 */
-	uint8_t ping_payload_buf[128 - 3 + LWS_PRE];
+	uint8_t ping_payload_buf[PAYLOAD_BUF_SIZE];
+	uint8_t pong_payload_buf[PAYLOAD_BUF_SIZE];
 
 	unsigned int final:1;
 	unsigned int frame_is_binary:1;
@@ -112,7 +115,7 @@ struct _lws_websocket_related {
 	unsigned int inside_frame:1; /* next write will be more of frame */
 	unsigned int clean_buffer:1; /* buffer not rewritten by extension */
 	unsigned int payload_is_close:1; /* process as PONG, but it is close */
-	unsigned int ping_pending_flag:1;
+	unsigned int pong_pending_flag:1;
 	unsigned int continuation_possible:1;
 	unsigned int owed_a_fin:1;
 	unsigned int check_utf8:1;
@@ -134,7 +137,7 @@ struct _lws_websocket_related {
 	uint32_t rx_ubuf_head;
 	uint32_t rx_ubuf_alloc;
 
-	uint8_t ping_payload_len;
+	uint8_t pong_payload_len;
 	uint8_t mask_idx;
 	uint8_t opcode;
 	uint8_t rsv;


### PR DESCRIPTION
The pong payload is overwritten by the keepalive_ping in case the rops_issue_keepalive_ws function was called earlier than rops_handle_POLLOUT_ws. This issue appears on windows platform. 

Logs that are taken from libwebsockets library:
[2021/09/13 13:59:02:5768] N: received 4 byte ping, sending pong
[2021/09/13 13:59:02:5798] N: ping payload received:
[2021/09/13 13:59:02:5818] N:
[2021/09/13 13:59:02:5828] N: 0000: F5 6E 62 A4                                        .nb.
[2021/09/13 13:59:02:5888] N:
[2021/09/13 13:59:02:5898] N: pong payload in response to ping:
[2021/09/13 13:59:02:5928] N:
[2021/09/13 13:59:02:5938] N: 0000: F5 6E 62 A4                                        .nb.
[2021/09/13 13:59:02:5988] N:
[2021/09/13 13:59:04:6159] N: pollout pong payload:
[2021/09/13 13:59:04:6189] N:
[2021/09/13 13:59:04:6219] N: 0000: 81 D5 5A 5A                                        ..ZZ

"pong payload in response to ping" - the pong payload that should be finally pushed into a wire by using lws_write() inside of the rops_handle_POLLOUT_ws function
"pollout pong payload" - the pong payload that actually pushed into a wire inside of the rops_handle_POLLOUT_ws function (could be corrupted by the keepalive_ping data)

Logs that are taken from the client which doesn't receive correct pong payload:
2021-09-13 13:59:32,601 - websockets.protocol - close_connection - DEBUG - client ! timed out waiting for TCP close
2021-09-13 13:59:32,601 - websockets.protocol - close_connection - DEBUG - client x half-closing TCP connection
2021-09-13 13:59:42,604 - websockets.protocol - close_connection - DEBUG - client ! timed out waiting for TCP close
2021-09-13 13:59:42,604 - websockets.protocol - close_connection - DEBUG - client x closing TCP connection
2021-09-13 13:59:42,606 - websockets.protocol - connection_lost - DEBUG - client - event = connection_lost(None)
2021-09-13 13:59:42,607 - websockets.protocol - connection_lost - DEBUG - client - state = CLOSED
2021-09-13 13:59:42,607 - websockets.protocol - connection_lost - DEBUG - client x code = 1006, reason = [no reason]
2021-09-13 13:59:42,607 - websockets.protocol - abort_pings - DEBUG - client - aborted pending ping: f56e62a4

**wireshark captures**

ping payload:
 
![windows_capture_wireshark_ping](https://user-images.githubusercontent.com/90622995/133112451-d10daaf2-0fb2-47eb-ab0f-45c867cc0a5e.PNG)

pong payload:

![windows_capture_wireshark_pong](https://user-images.githubusercontent.com/90622995/133112487-d3ee3fc4-eee3-473f-92e0-0be95977f499.PNG)
