### PR TITLE
Error in lws_tls_server_conn_alpn.

### DIFF
--- a/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
+++ b/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
@@ -888,6 +888,8 @@ void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
 		*len = (unsigned int)strlen(alp);
 	else
 		*len = 0;
+#else
+    *len = 0;
 #endif
 }
 


### PR DESCRIPTION
When using mbedtls and LWS_HAVE_mbedtls_ssl_get_alpn_protocol not defined - lws_tls_server_conn_alpn using unitialized len.
