### PR TITLE
Fix compilation issue with OpenSSL subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ option(LWS_WITH_SYS_STATE "lws_system state support" ON)
 option(LWS_WITH_SYS_SMD "Lws System Message Distribution" ON)
 option(LWS_WITH_SYS_FAULT_INJECTION "Enable fault injection support" OFF)
 option(LWS_WITH_SYS_METRICS "Lws Metrics API" OFF)
+option(LWS_WITH_UPNG "Enable stateful PNG stream decoder" ON)
 
 #
 # Secure Streams

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ option(LWS_WITH_SYS_SMD "Lws System Message Distribution" ON)
 option(LWS_WITH_SYS_FAULT_INJECTION "Enable fault injection support" OFF)
 option(LWS_WITH_SYS_METRICS "Lws Metrics API" OFF)
 option(LWS_WITH_UPNG "Enable stateful PNG stream decoder" ON)
+option(LWS_WITH_DLO "Enable Display List Objects" ON)
 
 #
 # Secure Streams

--- a/LICENSE
+++ b/LICENSE
@@ -7,7 +7,8 @@ them.
 Original liberal license retained:
 
   - lib/misc/sha-1.c                     - 3-clause BSD license retained, link to original [BSD3]
-  - win32port/zlib                       - ZLIB license (see zlib.h) [ZLIB]
+  - win32port/zlib
+    lib/drivers/display/upng.*		 - ZLIB license (see zlib.h) [ZLIB]
   - lib/tls/mbedtls/wrapper              - Apache 2.0 (only built if linked against mbedtls) [APACHE2]
     lib/tls/mbedtls/mbedtls-extensions.c
   - lib/misc/base64-decode.c             - already MIT

--- a/READMEs/README.display-list.md
+++ b/READMEs/README.display-list.md
@@ -1,0 +1,120 @@
+# lws_display_list
+
+`lws_display_list` is a modernized 1970s-style Display List of graphic
+primitives held in an `lws_dll2` list of Display List Objects (DLOs).
+Provided DLO primitives are:
+
+ - filled rectangle (with controllably-rounded corners)
+ - PNG (1:1 and original orientation only, transparency supported)
+ - utf-8 text areas (using kerned bitmap psfu Unicode fonts)
+
+The aim of it is to process some other representation to describe the
+logical scene completely using DLOs in memory, discard the earlier
+representation and then rasterize the Display List a single line at a
+time from top to bottom, so no backing framebuffer is required at all.
+DLOs are destroyed as they go out of scope during rasterization.
+
+Although the memory required does scale with scene complexity in
+terms of number of DLOs, it hardly scales at all with output
+resolution, allowing modern 32-bpp rendering on very constrained
+devices, if a bit slowly.  Eg, text DLOs hold blocks of UTF-8 text,
+so the number of DLOs only scales slowly for chunks of text too.
+
+## DLO capabilities
+
+DLOs are not as trivial as they sound
+
+ - no floats required (uses `lws_fixed3232` where fractional needed)
+ - 16-bit signed coordinate space with off-surface clipping handled
+ - Internal 32-bpp RGBA colourspace (8-bit opacity)
+ - correct Z-order opacity resolution
+ - Supports arbitrary palette-ization (down to 1bpp) and error diffusion
+ - DLO-private error diffusion for clean opaque overlaid objects
+ - Kerned bitmap text using a variety of standardized unicode fonts
+
+All DLOs in a Display List are consumed as they are rasterized,
+individual DLOs are destroyed as soon as they go out of scope during
+top - bottom rendering, freeing any related resources as soon as possible.
+
+## DLO PNGs
+
+DLOs may point to a compressed PNG, which is decompressed on the fly
+and the decompression context destroyed as the rasterization goes
+beyond its bounding box.  Using the lws stateful rewrite of upng, the
+memory cost of 32-bpp PNG decode of any dimensions is 40K + 16 x width
+bytes, including error diffusion line buffers.  Decoding of the
+compressed PNG data is done statefully on demand as needed to fill an
+output line, so no memory is needed to hold excess decode production.
+
+Multiple PNG DLOs including PNG-over-PNG (with alpha mixing) are
+allowed. PNGs only take heap memory while the current rasterization
+line intersects them, so any number of PNGs that don't intersect
+vertically do not cost any more peak memory allocation than decoding one,
+since the decoding contexts and DLOs of the earlier ones have been
+destroyed before the next one's decoding context is allocated.
+
+## DLO text
+
+Text DLOs are predicated around unicode utf-8 and psfu (unix terminal
+bitmap font standard), a variety of liberally-licensed fonts up to
+32px high are available.
+
+Glyphs are kerned on-the-fly to simulate proportional fonts to make
+best use of horizontal space and read easier.
+
+Wrapping inside a bounding box is supported as is "run-on", where text
+DLOs follow one another inline, used for example to use a bold font
+in part of a text using a different DLO with a different font before
+continuing with another DLO using the non-bold font cleanly.  DLOs
+are marked as running-on or not.
+
+Centering and right-justification is possible by summing run-ons on
+the current line by walking the display list backwards until a non-
+run-on DLO is seen, and adjusting the affected DLOs x position.
+
+## Display List lifecycle
+
+### Create empty display list
+
+Create the display state (the dynamic counterpart of the const, static
+`lws_display` definition) and the empty display list.
+
+```
+	lws_display_state_t lds;
+	lws_displaylist_t dl;
+```
+
+Instantiate the `lws_display` and bind the display list to it
+```
+	lws_display_state_init(&lds, cx, 30000, 10000, lls, &disp.disp);
+
+	lws_display_dl_init(&dl, &lds);
+
+
+
+### Create DLOs into the list
+
+Eg, create a png from `data` / `len`, return NULL if failed.
+
+```
+	if (!lws_display_dlo_png_new(&dl, &box, data, len)) {
+```
+
+Eg, create a white background rectange the size of the `lws_display`
+
+```
+               lws_dlo_rect_t *dr;
+               lws_box_t box = { 0, 0, dl.ds->disp->ic.wh_px[0].whole,
+                                       dl.ds->disp->ic.wh_px[1].whole };
+
+               dr = lws_display_dlo_rect_new(&dl, &box, 0,
+                               LWSDC_RGBA(255, 255, 255, 255));
+               if (!dr)
+                       return 1;
+```
+
+### Rendering into an lws_display
+
+```
+	lds->disp->blit(lds, (uint8_t *)&dl, &box);
+```

--- a/READMEs/README.lws_fixed3232.md
+++ b/READMEs/README.lws_fixed3232.md
@@ -1,0 +1,64 @@
+# lws_fixed3232 Fixed point arithmetic
+
+Lws provides reasonably fast fixed-point 32:32 arithmetic functions so code
+can be designed to work without floating-point support.
+
+The underlying type is
+
+```
+typedef struct lws_fixed3232 {
+        int32_t         whole;  /* signed 32-bit int */
+        uint32_t        frac;   /* proportion from 0 to (100M - 1) */
+} lws_fixed3232_t;
+```
+
+## Fractional representation
+
+The fractional part counts parts per 100M and is restricted to the range
+0 .. 99999999.  For convenience a constant `LWS_F3232_FRACTION_MSD` is
+defined with the value 100M.
+
+It's possible to declare constants naturally, but leading zeroes are not
+valid on the fractional part, since C parses a leading 0 as indicating
+the number is octal.
+
+Eg to declare 12.5 and 6.0
+
+```
+	static const lws_fixed3232_t x[2] = { { 12,50000000 }, { 6,0 } };
+```
+
+## API style
+
+The APIs are given the storage for the result along with the const args.
+The result pointer is also returned from the operation to make operation
+chaining more natural.
+
+## Available operations
+
+```
+const lws_fixed3232_t *
+lws_fixed3232_add(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+const lws_fixed3232_t *
+lws_fixed3232_sub(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+const lws_fixed3232_t *
+lws_fixed3232_mul(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+const lws_fixed3232_t *
+lws_fixed3232_div(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+const lws_fixed3232_t *
+lws_fixed3232_sqrt(lws_fixed3232_t *r, const lws_fixed3232_t *a);
+
+int /* -1 if a < b, 1 if a > b, 0 if exactly equal */
+lws_fixed3232_comp(const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+int /* return whole, or whole + 1 if frac is nonzero */
+lws_fixed3232_roundup(const lws_fixed3232_t *a);
+```
+
+div and sqrt operations are iterative, up to 64 loops.  Multiply is relatively cheap
+since it devolves to four integer multiply-adds.  Add and Sub are trivially cheap.
+

--- a/READMEs/README.png-decoder.md
+++ b/READMEs/README.png-decoder.md
@@ -1,0 +1,54 @@
+# lws_upng stateful PNG decoder
+
+Lws includes a rewrite of UPNG that performs stateful, line-at-a-time decoding.
+
+The memory requirement is fixed at 40KB plus enough buffer for two output
+lines of pixels.  In particular the input PNG data is stream parsed, so there
+is no requirement for it all to be in memory at the same time, and there is
+no framebuffer required either, so there is no requirement for all the output
+to be in memory at the same time, either.
+
+The results in an extremely tight decoder suitable for microcontroller type
+platforms that lack enough memory to hold a framebuffer, but can stream the
+rendered data out over SPI or i2c to a display device that does have its own
+(usually write-only) framebuffer memory.
+
+## Creating and destroying the decoding context
+
+The apis to create and destroy a decoding context are very simple...
+
+```
+LWS_VISIBLE LWS_EXTERN lws_upng_t *
+lws_upng_new(void);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_upng_free(lws_upng_t **upng);
+```
+
+## Performing the decoding
+
+The only decoding API provides input PNG data which may or may not be partly or
+wholly consumed, to produce a line of output pixels that can be found at `*ppix`.
+
+```
+LWS_VISIBLE LWS_EXTERN lws_upng_ret_t
+lws_upng_emit_next_line(lws_upng_t *upng, const uint8_t **ppix,
+			const uint8_t **buf, size_t *size);
+```
+
+If input data is consumed, `*buf` and `*size` are adjusted accordingly.
+This api returns one of
+
+|Return value|Meaning|
+|---|---|
+|`LWS_UPNG_OK`|Completed|
+|`LWS_UPNG_WANT_INPUT`|Decoder needs to be called again with more PNG input before it can produce a line of pixels|
+|`LWS_UPNG_WANT_OUTPUT`|Decoder has paused to emit a line of pixels|
+|`LWS_UPNG_FATAL`|Decoder has encountered a fatal error, any return greater than `LWS_UPNG_FATAL` indicates the type of error|
+
+To get early information about the dimensions and colourspace of the PNG, you
+can call this api initially with the first 33 bytes (`*size` restricted to 33)
+and adjust the true size -33 for further calls.  This will make it return with
+`WANT_INPUT` after having processed the PNG header information but not produced
+any pixel line information.
+

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -237,6 +237,7 @@
 #cmakedefine LWS_WITH_UDP
 #cmakedefine LWS_WITH_ULOOP
 #cmakedefine LWS_WITH_UNIX_SOCK
+#cmakedefine LWS_WITH_UPNG
 #cmakedefine LWS_WITH_ZIP_FOPS
 #cmakedefine USE_OLD_CYASSL
 #cmakedefine USE_WOLFSSL

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -155,6 +155,7 @@
 #cmakedefine LWS_WITH_DEPRECATED_LWS_DLL
 #cmakedefine LWS_WITH_DETAILED_LATENCY
 #cmakedefine LWS_WITH_DIR
+#cmakedefine LWS_WITH_DLO
 #cmakedefine LWS_WITH_DRIVERS
 #cmakedefine LWS_WITH_ESP32
 #cmakedefine LWS_HAVE_EVBACKEND_LINUXAIO

--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -605,6 +605,42 @@ struct lws_tokens;
 struct lws_vhost;
 struct lws;
 
+typedef struct lws_fixed3232 {
+	int32_t		whole;	/* signed 32-bit int */
+	uint32_t	frac;	/* proportion from 0 to (100M - 1) */
+} lws_fixed3232_t;
+
+#define LWS_F3232_FRACTION_MSD 100000000
+#define lws_fixed_set(a, x, y) { a.whole = x; a.frac = y; }
+#define lws_fix64(a) (((int64_t)a->whole << 32) + (((1ll << 32) * (a->frac)) / 100000000))
+#define lws_fix64_abs(a) (((int64_t)(a->whole < 0 ? (-a->whole) : a->whole) << 32) + (((1ll << 32) * (a->frac)) / 100000000))
+#define LWFIX(q) (int)(q).whole, (unsigned int)(q).frac
+
+#define lws_fix3232(a, a64) { a->whole = (int32_t)(a64 >> 32); \
+			      a->frac = (uint32_t)((100000000 * (a64 & 0xffffffff)) >> 32); }
+
+LWS_VISIBLE LWS_EXTERN const lws_fixed3232_t *
+lws_fixed3232_add(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+LWS_VISIBLE LWS_EXTERN const lws_fixed3232_t *
+lws_fixed3232_sub(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+LWS_VISIBLE LWS_EXTERN const lws_fixed3232_t *
+lws_fixed3232_mul(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+LWS_VISIBLE LWS_EXTERN const lws_fixed3232_t *
+lws_fixed3232_div(lws_fixed3232_t *r, const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+LWS_VISIBLE LWS_EXTERN const lws_fixed3232_t *
+lws_fixed3232_sqrt(lws_fixed3232_t *r, const lws_fixed3232_t *a);
+
+LWS_VISIBLE LWS_EXTERN int
+lws_fixed3232_comp(const lws_fixed3232_t *a, const lws_fixed3232_t *b);
+
+LWS_VISIBLE LWS_EXTERN int
+lws_fixed3232_roundup(const lws_fixed3232_t *a);
+
+
 #include <libwebsockets/lws-dll2.h>
 #include <libwebsockets/lws-map.h>
 

--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -752,6 +752,7 @@ lws_fixed3232_roundup(const lws_fixed3232_t *a);
 #include <libwebsockets/lws-led.h>
 #include <libwebsockets/lws-pwm.h>
 #include <libwebsockets/lws-upng.h>
+#include <libwebsockets/lws-dlo.h>
 #include <libwebsockets/lws-display.h>
 #include <libwebsockets/lws-ssd1306-i2c.h>
 #include <libwebsockets/lws-ili9341-spi.h>

--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -751,6 +751,7 @@ lws_fixed3232_roundup(const lws_fixed3232_t *a);
 #include <libwebsockets/lws-button.h>
 #include <libwebsockets/lws-led.h>
 #include <libwebsockets/lws-pwm.h>
+#include <libwebsockets/lws-upng.h>
 #include <libwebsockets/lws-display.h>
 #include <libwebsockets/lws-ssd1306-i2c.h>
 #include <libwebsockets/lws-ili9341-spi.h>

--- a/include/libwebsockets/lws-display.h
+++ b/include/libwebsockets/lws-display.h
@@ -28,6 +28,24 @@
 struct lws_display_state;
 struct lws_display;
 
+typedef enum {
+	LWSSURF_TRUECOLOR32,
+	LWSSURF_565,
+	LWSSURF_PALETTE_4BB,
+} lws_surface_type_t;
+
+typedef struct lws_surface_info {
+	lws_fixed3232_t			wh_px[2];
+	lws_fixed3232_t			wh_mm[2];
+	const lws_display_colour_t	*palette;
+	size_t				palette_depth;
+	lws_surface_type_t		type;
+} lws_surface_info_t;
+
+LWS_VISIBLE LWS_EXTERN void
+lws_surface_set_px(const lws_surface_info_t *ic, uint8_t *line, int x,
+		   const lws_display_colour_t *c, lws_colour_error_t *ce);
+
 /*
  * This is embedded in the actual display implementation object at the top,
  * so a pointer to this can be cast to a pointer to the implementation object
@@ -38,11 +56,6 @@ struct lws_display;
  * way like set oled contrast.  Either way, the pwm level is arrived at via a
  * full set of lws_led_sequences capable of generic lws transitions
  */
-
-typedef struct lhp_init_ctx {
-	lws_fixed3232_t		wh_px[2];
-	lws_fixed3232_t		wh_mm[2];
-} lhp_init_ctx_t;
 
 typedef struct lws_display {
 	int (*init)(struct lws_display_state *lds);
@@ -56,15 +69,11 @@ typedef struct lws_display {
 	const lws_led_sequence_def_t	*bl_dim;
 	const lws_led_sequence_def_t	*bl_transition;
 
-
-	const lws_display_colour_t	*palette;
-	size_t				palette_depth;
-
 	void				*variant;
 
 	int				bl_index;
 
-	lhp_init_ctx_t			ic;
+	lws_surface_info_t			ic;
 
 	uint8_t				latency_wake_ms;
 	/**< ms required after wake from sleep before display usable again...

--- a/include/libwebsockets/lws-display.h
+++ b/include/libwebsockets/lws-display.h
@@ -1,7 +1,7 @@
 /*
  * lws abstract display
  *
- * Copyright (C) 2019 - 2020 Andy Green <andy@warmcat.com>
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -25,9 +25,8 @@
 #if !defined(__LWS_DISPLAY_H__)
 #define __LWS_DISPLAY_H__
 
-#include <stdint.h>
-
-typedef uint16_t lws_display_scalar;
+struct lws_display_state;
+struct lws_display;
 
 /*
  * This is embedded in the actual display implementation object at the top,
@@ -40,27 +39,32 @@ typedef uint16_t lws_display_scalar;
  * full set of lws_led_sequences capable of generic lws transitions
  */
 
+typedef struct lhp_init_ctx {
+	lws_fixed3232_t		wh_px[2];
+	lws_fixed3232_t		wh_mm[2];
+} lhp_init_ctx_t;
+
 typedef struct lws_display {
-	int (*init)(const struct lws_display *disp);
+	int (*init)(struct lws_display_state *lds);
 	const lws_pwm_ops_t		*bl_pwm_ops;
-	int (*contrast)(const struct lws_display *disp, uint8_t contrast);
-	int (*blit)(const struct lws_display *disp, const uint8_t *src,
-		    lws_display_scalar x, lws_display_scalar y,
-		    lws_display_scalar w, lws_display_scalar h);
-	int (*power)(const struct lws_display *disp, int state);
+	int (*contrast)(struct lws_display_state *lds, uint8_t contrast);
+	int (*blit)(struct lws_display_state *lds, const uint8_t *src,
+		    lws_box_t *box);
+	int (*power)(struct lws_display_state *lds, int state);
 
 	const lws_led_sequence_def_t	*bl_active;
 	const lws_led_sequence_def_t	*bl_dim;
 	const lws_led_sequence_def_t	*bl_transition;
 
+
+	const lws_display_colour_t	*palette;
+	size_t				palette_depth;
+
 	void				*variant;
 
 	int				bl_index;
 
-	lws_display_scalar		w;
-	/**< display surface width in pixels */
-	lws_display_scalar		h;
-	/**< display surface height in pixels */
+	lhp_init_ctx_t			ic;
 
 	uint8_t				latency_wake_ms;
 	/**< ms required after wake from sleep before display usable again...
@@ -85,6 +89,8 @@ typedef struct lws_display_state {
 	lws_sorted_usec_list_t		sul_autodim;
 	const lws_display_t		*disp;
 	struct lws_context		*ctx;
+
+	void				*rs; /* subclass driver alloc'd priv */
 
 	int				autodim_ms;
 	int				off_ms;

--- a/include/libwebsockets/lws-dlo.h
+++ b/include/libwebsockets/lws-dlo.h
@@ -1,0 +1,292 @@
+/*
+ * lws abstract display
+ *
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * lws display_list and display_list objects (dlo)
+ */
+
+#include <stdint.h>
+
+typedef int16_t lws_display_list_coord_t;
+typedef uint16_t lws_display_scalar;
+typedef uint16_t lws_display_rotation_t;
+typedef uint32_t lws_display_colour_t;
+typedef uint16_t lws_display_palette_idx_t;
+typedef uint32_t lws_display_gline_t; /* type for 1 line of glyph px */
+
+struct lws_surface_info;
+struct lws_display_state;
+struct lws_display_font;
+struct lws_display;
+struct lws_dlo_text;
+struct lws_dlo;
+
+#define LWSDC_RGBA(_r, _g, _b, _a) \
+		(((uint32_t)(_r) & 0xff) | (((uint32_t)(_g) & 0xff) << 8) | (((uint32_t)(_b) & 0xff) << 16) | (((uint32_t)(_a) & 0xff) << 24))
+
+#define LWSDC_R(_c) ((_c) & 0xff)
+#define LWSDC_G(_c) ((_c >> 8) & 0xff)
+#define LWSDC_B(_c) ((_c >> 16) & 0xff)
+#define LWSDC_ALPHA(_c) ((_c >> 24) & 0xff)
+
+#define MAX_FONT_HEIGHT 32
+
+typedef struct lws_box {
+	lws_fixed3232_t		x;
+	lws_fixed3232_t		y;
+	lws_fixed3232_t		w;
+	lws_fixed3232_t		h;
+} lws_box_t;
+
+typedef struct lws_colour_error {
+	int16_t		rgb[3];
+} lws_colour_error_t;
+
+typedef void (*lws_dlo_renderer_t)(const struct lws_surface_info *ic,
+				   struct lws_dlo *dlo, const lws_box_t *origin,
+				   lws_display_scalar curr,
+				   uint8_t *line,
+				   lws_colour_error_t **nle);
+typedef void (*lws_dlo_destroy_t)(struct lws_dlo *dlo);
+
+/*
+ * Common dlo object that joins the display list, composed into a subclass
+ * object like lws_dlo_rect_t etc
+ */
+
+typedef struct lws_dlo {
+	lws_dll2_t			list;
+
+	lws_colour_error_t		*nle[2];
+
+	/* children are rendered "inside" the parent DLO box after allowing
+	 * for parent padding */
+	lws_dll2_owner_t		children;
+
+	lws_dlo_destroy_t		_destroy;
+	lws_dlo_renderer_t		render;
+
+	lws_box_t			box;
+	lws_display_colour_t		dc;
+
+	uint8_t				flag_runon:1; /* continues same line */
+	uint8_t				flag_done_align:1; /* continues same line */
+
+	/* render-specific members ... */
+} lws_dlo_t;
+
+typedef struct lws_dlo_rect {
+	lws_dlo_t			dlo;
+	lws_fixed3232_t			radius[4]; /* t-l, t-r, b-l, b-r radii */
+} lws_dlo_rect_t;
+
+typedef struct lws_dlo_circle {
+	lws_dlo_t			dlo;
+} lws_dlo_circle_t;
+
+typedef struct lws_font_choice {
+	const char			*family_name;
+	const char			*generic_name;
+	uint16_t			weight;
+	uint16_t			style; /* normal, italic, oblique */
+	uint16_t			fixed_height;
+} lws_font_choice_t;
+
+typedef struct lws_display_font {
+	lws_dll2_t			list;
+
+	lws_font_choice_t		choice;
+
+	const uint8_t			*data;
+	uint8_t				*priv; /* only used by implementation */
+	size_t				data_len;
+	lws_dlo_renderer_t		renderer;
+
+	lws_fixed3232_t			em;	/* 1 em in pixels */
+	lws_fixed3232_t			ex;	/* 1 ex in pixels */
+} lws_display_font_t;
+
+typedef struct lws_display_png {
+	lws_dll2_t			list;
+
+	const char			*name;
+	const void			*data;
+	size_t				len;
+} lws_display_png_t;
+
+#define LWSDLO_TEXT_FLAG_WRAP					(1 << 0)
+
+typedef struct lws_dlo_text {
+	lws_dlo_t			dlo;
+	const lws_display_font_t	*font;
+	lws_box_t			bounding_box; /* { 0, 0, w, h } relative
+						       * to and subject to
+						       * clipping by .dlo.box */
+	char				*text;
+	uint8_t				*kern;
+	size_t				text_len;
+	lws_display_list_coord_t	clkernpx;
+	lws_display_list_coord_t	cwidth;
+
+	uint32_t			flags;
+} lws_dlo_text_t;
+
+typedef struct lws_dlo_png {
+	lws_dlo_t			dlo;
+	lws_upng_t			*png;
+
+	const uint8_t			*data;
+	size_t				len;
+} lws_dlo_png_t;
+
+typedef struct lws_display_state lws_display_state_t;
+
+typedef struct lws_displaylist {
+	lws_dll2_owner_t		dl;
+	struct lws_display_state 	*ds;
+} lws_displaylist_t;
+
+typedef struct lws_dl_rend {
+	lws_displaylist_t		*dl;
+	int				w;
+	int				h;
+} lws_dl_rend_t;
+
+typedef struct lws_display_render_state {
+	lws_sorted_usec_list_t		sul; /* return to event loop statefully */
+	lws_display_state_t		*lds; /* optional, if using lws_display */
+
+	const struct lws_surface_info	*ic; /* display dimensions, palette */
+
+	int				state; /* meaning private to driver */
+
+	uint8_t				*line;
+
+	int				budget;
+
+	lws_displaylist_t		*displaylist;
+	lws_box_t			box;
+	lws_display_scalar		curr;
+} lws_display_render_state_t;
+
+
+/**
+ * lws_display_dl_init() - init display list object
+ *
+ * \param dl: Pointer to the display list
+ * \param ds: Lws display state to bind the list to
+ *
+ * Initializes the display list \p dl and binds it to the display state \p ds.
+ */
+LWS_VISIBLE LWS_EXTERN void
+lws_display_dl_init(lws_displaylist_t *dl, struct lws_display_state  *ds);
+
+/**
+ * lws_display_list_destroy() - destroys display list and objects on it
+ *
+ * \param dl: Pointer to the display list pointer
+ *
+ * Destroys every DLO on the list and sets the list pointer to NULL.
+ */
+LWS_VISIBLE LWS_EXTERN void
+lws_display_list_destroy(lws_displaylist_t **dl);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_display_dlo_destroy(lws_dlo_t **r);
+
+LWS_VISIBLE LWS_EXTERN int
+lws_display_dlo_add(lws_displaylist_t *dl, lws_dlo_t *dlo_parent, lws_dlo_t *dlo);
+
+LWS_VISIBLE LWS_EXTERN lws_display_palette_idx_t
+lws_display_palettize(const struct lws_surface_info *ic, lws_display_colour_t c,
+		       lws_display_colour_t oc, lws_colour_error_t *ectx);
+
+LWS_VISIBLE LWS_EXTERN int
+lws_dlo_ensure_err_diff(lws_dlo_t *dlo);
+
+/*
+ * lws_display_list_render_line() - render a single raster line of the list
+ *
+ * \param rs: prepared render state object
+ *
+ * Allocates a line pair buffer into ds->line if necessary, and renders the
+ * current line (set by ds->curr) of the display list rasterization into it
+ */
+LWS_VISIBLE LWS_EXTERN int
+lws_display_list_render_line(lws_display_render_state_t *rs);
+
+/*
+ * rect
+ */
+
+LWS_VISIBLE LWS_EXTERN lws_dlo_rect_t *
+lws_display_dlo_rect_new(lws_displaylist_t *dl, lws_dlo_t *dlo_parent,
+			 lws_box_t *box,  const lws_fixed3232_t *radii,
+			 lws_display_colour_t dc);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_display_render_rect(const struct lws_surface_info *ic, struct lws_dlo *dlo,
+			const lws_box_t *origin, lws_display_scalar curr,
+			uint8_t *line, lws_colour_error_t **nle);
+
+/*
+ * PSFU (unicode bitmap terminal) fonts + text
+ */
+
+LWS_VISIBLE LWS_EXTERN lws_dlo_text_t *
+lws_display_dlo_text_new(lws_displaylist_t *dl, lws_dlo_t *dlo_parent,
+			 lws_box_t *box, const lws_display_font_t *font);
+
+LWS_VISIBLE LWS_EXTERN int
+lws_display_dlo_text_update(lws_dlo_text_t *text, lws_display_colour_t dc,
+		lws_fixed3232_t indent, const char *utf8, size_t text_len);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_display_font_psfu_bounding(struct lws_dlo *dlo, const char *txt,
+			       lws_box_t *box);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_display_font_psfu_render(const struct lws_surface_info *ic, struct lws_dlo *dlo,
+			     const lws_box_t *origin, lws_display_scalar curr,
+			     uint8_t *line, lws_colour_error_t **nle);
+
+void
+lws_display_dlo_text_destroy(struct lws_dlo *dlo);
+
+/*
+ * PNG
+ */
+
+LWS_VISIBLE LWS_EXTERN lws_dlo_png_t *
+lws_display_dlo_png_new(lws_displaylist_t *dl, lws_dlo_t *dlo_parent,
+			lws_box_t *box, const uint8_t *png, size_t png_size);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_display_render_png(const struct lws_surface_info *ic, struct lws_dlo *dlo,
+		       const lws_box_t *origin, lws_display_scalar curr,
+		       uint8_t *line, lws_colour_error_t **nle);
+
+typedef struct lhp_ctx lhp_ctx_t;
+
+LWS_VISIBLE LWS_EXTERN signed char
+lhp_dl_render(lhp_ctx_t *ctx, char reason);
+

--- a/include/libwebsockets/lws-dlo.h
+++ b/include/libwebsockets/lws-dlo.h
@@ -306,3 +306,15 @@ lws_font_choose(struct lws_context *cx, const lws_font_choice_t *hints);
 LWS_VISIBLE LWS_EXTERN void
 lws_fonts_destroy(struct lws_context *cx);
 
+/*
+ * Static PNG registry (built-in, name-accessible PNGs)
+ */
+
+LWS_VISIBLE LWS_EXTERN int
+lws_pngs_register(struct lws_context *cx, const lws_display_png_t *f);
+
+LWS_VISIBLE LWS_EXTERN const lws_display_png_t *
+lws_pngs_choose(struct lws_context *cx, const char *name);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_pngs_destroy(struct lws_context *cx);

--- a/include/libwebsockets/lws-dlo.h
+++ b/include/libwebsockets/lws-dlo.h
@@ -290,3 +290,19 @@ typedef struct lhp_ctx lhp_ctx_t;
 LWS_VISIBLE LWS_EXTERN signed char
 lhp_dl_render(lhp_ctx_t *ctx, char reason);
 
+/*
+ * Font registry
+ *
+ * Register fonts (currently, psfu) to the lws_context, and select the closest
+ * matching.  Used to pick fonts from whatever CSS information is available.
+ */
+
+LWS_VISIBLE LWS_EXTERN int
+lws_font_register(struct lws_context *cx, const lws_display_font_t *f);
+
+LWS_VISIBLE LWS_EXTERN const lws_display_font_t *
+lws_font_choose(struct lws_context *cx, const lws_font_choice_t *hints);
+
+LWS_VISIBLE LWS_EXTERN void
+lws_fonts_destroy(struct lws_context *cx);
+

--- a/include/libwebsockets/lws-ili9341-spi.h
+++ b/include/libwebsockets/lws-ili9341-spi.h
@@ -1,7 +1,7 @@
 /*
  * lws abstract display implementation for ili9341 on spi
  *
- * Copyright (C) 2019 - 2020 Andy Green <andy@warmcat.com>
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -39,13 +39,12 @@ typedef struct lws_display_ili9341 {
 } lws_display_ili9341_t;
 
 int
-lws_display_ili9341_spi_init(const struct lws_display *disp);
+lws_display_ili9341_spi_init(lws_display_state_t *lds);
 int
-lws_display_ili9341_spi_blit(const struct lws_display *disp, const uint8_t *src,
-                             lws_display_scalar x, lws_display_scalar y,
-                             lws_display_scalar w, lws_display_scalar h);
+lws_display_ili9341_spi_blit(lws_display_state_t *lds, const uint8_t *src,
+                             lws_box_t *box);
 int
-lws_display_ili9341_spi_power(const struct lws_display *disp, int state);
+lws_display_ili9341_spi_power(lws_display_state_t *lds, int state);
 
 #define lws_display_ili9341_ops \
 	.init = lws_display_ili9341_spi_init, \

--- a/include/libwebsockets/lws-secure-streams-policy.h
+++ b/include/libwebsockets/lws-secure-streams-policy.h
@@ -234,6 +234,10 @@ typedef struct lws_ss_policy {
 	const lws_metric_policy_t *metrics; /* linked-list of metric policies */
 	const lws_ss_auth_t	*auth; /* NULL or auth object we bind to */
 
+#if defined(LWS_WITH_SERVER)
+	const struct lws_protocol_vhost_options *pvo;
+#endif
+
 	/* protocol-specific connection policy details */
 
 	union {
@@ -330,6 +334,9 @@ typedef struct lws_ss_policy {
 
 	const lws_retry_bo_t	*retry_bo;   /**< retry policy to use */
 
+	int32_t			txc;
+	int32_t			txc_peer;
+
 	uint32_t		proxy_buflen; /**< max dsh alloc for proxy */
 	uint32_t		proxy_buflen_rxflow_on_above;
 	uint32_t		proxy_buflen_rxflow_off_below;
@@ -337,7 +344,6 @@ typedef struct lws_ss_policy {
 	uint32_t		client_buflen; /**< max dsh alloc for client */
 	uint32_t		client_buflen_rxflow_on_above;
 	uint32_t		client_buflen_rxflow_off_below;
-
 
 	uint32_t		timeout_ms;  /**< default message response
 					      * timeout in ms */

--- a/include/libwebsockets/lws-secure-streams.h
+++ b/include/libwebsockets/lws-secure-streams.h
@@ -172,6 +172,9 @@ enum {
 	LWSSSINFLAGS_ACCEPTED				=	(1 << 3),
 	/**< Set on the accepted object copy of the ssi / info to indicate that
 	 * we are an accepted connection from a server's listening socket */
+	LWSSSINFLAGS_ACCEPTED_SINK			=	(1 << 4),
+	/**< Set on the accepted object copy of the ssi / info to indicate that
+	 * we are an accepted connection from a local sink */
 };
 
 typedef lws_ss_state_return_t (*lws_sscb_rx)(void *userobj, const uint8_t *buf,

--- a/include/libwebsockets/lws-ssd1306-i2c.h
+++ b/include/libwebsockets/lws-ssd1306-i2c.h
@@ -46,15 +46,14 @@ typedef struct lws_display_ssd1306 {
 } lws_display_ssd1306_t;
 
 int
-lws_display_ssd1306_i2c_init(const struct lws_display *disp);
+lws_display_ssd1306_i2c_init(lws_display_state_t *lds);
 int
-lws_display_ssd1306_i2c_contrast(const struct lws_display *disp, uint8_t b);
+lws_display_ssd1306_i2c_contrast(lws_display_state_t *lds, uint8_t b);
 int
-lws_display_ssd1306_i2c_blit(const struct lws_display *disp, const uint8_t *src,
-                             lws_display_scalar x, lws_display_scalar y,
-                             lws_display_scalar w, lws_display_scalar h);
+lws_display_ssd1306_i2c_blit(lws_display_state_t *lds, const uint8_t *src,
+                             lws_box_t *box);
 int
-lws_display_ssd1306_i2c_power(const struct lws_display *disp, int state);
+lws_display_ssd1306_i2c_power(lws_display_state_t *lds, int state);
 
 #define lws_display_ssd1306_ops \
 	.init = lws_display_ssd1306_i2c_init, \

--- a/include/libwebsockets/lws-upng.h
+++ b/include/libwebsockets/lws-upng.h
@@ -1,0 +1,117 @@
+/*
+ * uPNG -- derived from LodePNG version 20100808
+ *
+ * Copyright (c) 2005-2010 Lode Vandevenne
+ * Copyright (c) 2010 Sean Middleditch
+ * Copyright (c) 2021-2022 Andy Green <andy@warmcat.com>
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software
+ *      in a product, an acknowledgment in the product documentation would be
+ *	appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not be
+ *	misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any source
+ *	distribution.
+ *
+ *  The above notice is the ZLIB license, libpng also uses it.
+ *
+ * This version is based on upng project's fork of lodepng and rewritten for
+ * lws, changing the whole approach to decode on demand to issue a line of
+ * output at a time, statefully.
+ */
+
+typedef enum {
+	LWS_UPNG_OK,
+	LWS_UPNG_WANT_INPUT,
+	LWS_UPNG_WANT_OUTPUT,
+	LWS_UPNG_FATAL
+} lws_upng_ret_t;
+
+typedef enum lws_upng_format_t {
+	LWS_UPNG_BADFORMAT,
+	LWS_UPNG_RGB8,
+	LWS_UPNG_RGB16,
+	LWS_UPNG_RGBA8,
+	LWS_UPNG_RGBA16,
+	LWS_UPNG_LUMINANCE1,
+	LWS_UPNG_LUMINANCE2,
+	LWS_UPNG_LUMINANCE4,
+	LWS_UPNG_LUMINANCE8,
+	LWS_UPNG_LUMINANCE_ALPHA1,
+	LWS_UPNG_LUMINANCE_ALPHA2,
+	LWS_UPNG_LUMINANCE_ALPHA4,
+	LWS_UPNG_LUMINANCE_ALPHA8
+} lws_upng_format_t;
+
+typedef struct lws_upng_t lws_upng_t;
+
+/**
+ * lws_upng_new() - Create new UPNG decode object
+ *
+ * Returns a new PNG decoding object, which should be destroyed with
+ * lws_upng_free() when done with, or NULL if OOM.
+ */
+LWS_VISIBLE LWS_EXTERN lws_upng_t *
+lws_upng_new(void);
+
+/**
+ * lws_upng_free() - Destroy a PNG decode object
+ *
+ * \param upng: Pointer to the decode object to destroy and set to NULL
+ *
+ * This also frees any sub-allocations in the object.
+ */
+LWS_VISIBLE LWS_EXTERN void
+lws_upng_free(lws_upng_t **upng);
+
+/**
+ * lws_upng_emit_next_line() - deocde the next line
+ *
+ * \param upng: the decode object
+ * \ppix: pointer to a pointer set to the line's decoded pixel data
+ * \buf: pointer to a const uint8_t array of PNG input
+ * \size: pointer to the count of bytes available at *buf
+ *
+ * Make PNG input available to the decoder so it can issue the next line's
+ * worth of pixels.  If the call consumed any input, *buf and *size are
+ * adjusted accordingly.
+ *
+ * The decoder is stateful so it is not sensitive to the chunk size for the
+ * input.
+ *
+ * Return will be one of LWS_UPNG_WANT_INPUT is the decoder is stalled waiting
+ * for more input to be provided, LWS_UPNG_WANT_OUTPUT is the decoder stopped
+ * because it had produced a whole line of output pixels (which can be found
+ * starting at *ppix), LWS_UPNG_OK is it completed and LWS_UPNG_FATAL or larger
+ * if the decode failed.
+ */
+LWS_VISIBLE LWS_EXTERN lws_upng_ret_t
+lws_upng_emit_next_line(lws_upng_t *upng, const uint8_t **ppix,
+			const uint8_t **buf, size_t *size);
+
+LWS_VISIBLE LWS_EXTERN unsigned int
+lws_upng_get_width(const lws_upng_t *upng);
+LWS_VISIBLE LWS_EXTERN unsigned int
+lws_upng_get_height(const lws_upng_t *upng);
+LWS_VISIBLE LWS_EXTERN unsigned int
+lws_upng_get_bpp(const lws_upng_t *upng);
+LWS_VISIBLE LWS_EXTERN unsigned int
+lws_upng_get_bitdepth(const lws_upng_t *upng);
+LWS_VISIBLE LWS_EXTERN unsigned int
+lws_upng_get_components(const lws_upng_t *upng);
+LWS_VISIBLE LWS_EXTERN unsigned int
+lws_upng_get_pixelsize(const lws_upng_t *upng);
+LWS_VISIBLE LWS_EXTERN lws_upng_format_t
+lws_upng_get_format(const lws_upng_t *upng);
+

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -807,6 +807,11 @@ lws_create_context(const struct lws_context_creation_info *info)
 #endif
 #endif
 
+#if defined(LWS_WITH_SERVER)
+	context->lcg[LWSLCG_WSI_SSP_SINK].tag_prefix = "SSsink";
+	context->lcg[LWSLCG_WSI_SSP_SOURCE].tag_prefix = "SSsrc";
+#endif
+
 
 #if defined(LWS_WITH_SECURE_STREAMS_STATIC_POLICY_ONLY)
 	/* directly use the user-provided policy object list */
@@ -1714,7 +1719,8 @@ lws_pt_destroy(struct lws_context_per_thread *pt)
 	}
 
 #if defined(LWS_WITH_SECURE_STREAMS)
-	lws_dll2_foreach_safe(&pt->ss_owner, NULL, lws_ss_destroy_dll);
+	while (pt->ss_owner.head)
+		lws_ss_destroy_dll(pt->ss_owner.head, NULL);
 
 #if defined(LWS_WITH_SECURE_STREAMS_PROXY_API) && defined(LWS_WITH_CLIENT)
 	lws_dll2_foreach_safe(&pt->ss_client_owner, NULL, lws_sspc_destroy_dll);
@@ -2200,6 +2206,21 @@ next:
 
 		if (context->ac_policy)
 			lwsac_free(&context->ac_policy);
+
+#if defined(LWS_WITH_SERVER)
+		/* ... for every sink... */
+		lws_start_foreach_dll_safe(struct lws_dll2 *, d, d1,
+				      lws_dll2_get_head(&context->sinks)) {
+			lws_ss_sinks_t *sn = lws_container_of(d, lws_ss_sinks_t,
+							      list);
+
+			assert(!sn->accepts.count);
+
+			lws_dll2_remove(&sn->list);
+			lws_free(sn);
+
+		} lws_end_foreach_dll_safe(d, d1);
+#endif
 #endif
 
 		/*

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -2169,6 +2169,10 @@ next:
 		lws_dhcpc_remove(context, NULL);
 #endif
 
+#if defined(LWS_WITH_DLO)
+		lws_fonts_destroy(context);
+#endif
+
 		if (context->pt[0].fds)
 			lws_free_set_NULL(context->pt[0].fds);
 #endif

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -2171,6 +2171,7 @@ next:
 
 #if defined(LWS_WITH_DLO)
 		lws_fonts_destroy(context);
+		lws_pngs_destroy(context);
 #endif
 
 		if (context->pt[0].fds)

--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -539,6 +539,7 @@ struct lws_context {
 #endif
 #if defined(LWS_WITH_DLO)
 	lws_dll2_owner_t		fonts;
+	lws_dll2_owner_t		pngs;
 #endif
 
 #if defined(LWS_WITH_SYS_ASYNC_DNS)

--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -537,6 +537,9 @@ struct lws_context {
 #if defined(LWS_WITH_DRIVERS)
 	lws_netdevs_t			netdevs;
 #endif
+#if defined(LWS_WITH_DLO)
+	lws_dll2_owner_t		fonts;
+#endif
 
 #if defined(LWS_WITH_SYS_ASYNC_DNS)
 	lws_async_dns_t			async_dns;

--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -411,9 +411,22 @@ enum {
 #endif
 #endif
 
+#if defined(LWS_WITH_SERVER)
+	LWSLCG_WSI_SSP_SINK,		/* accepted sink conn */
+	LWSLCG_WSI_SSP_SOURCE,		/* accepted source conn */
+#endif
+
 	/* always last */
 	LWSLCG_COUNT
 };
+
+#if defined(LWS_WITH_SECURE_STREAMS) && defined(LWS_WITH_SERVER)
+typedef struct lws_ss_sinks {
+	lws_dll2_t				list;
+	lws_ss_info_t				info;
+	lws_dll2_owner_t			accepts;
+} lws_ss_sinks_t;
+#endif
 
 /*
  * the rest is managed per-context, that includes
@@ -664,6 +677,9 @@ struct lws_context {
 #endif
 	const lws_ss_policy_t		*pss_policies;
 	const lws_ss_auth_t		*pss_auths;
+#if defined(LWS_WITH_SERVER)
+	lws_dll2_owner_t		sinks;
+#endif
 #if defined(LWS_WITH_SSPLUGINS)
 	const lws_ss_plugin_t		**pss_plugins;
 #endif

--- a/lib/drivers/CMakeLists.txt
+++ b/lib/drivers/CMakeLists.txt
@@ -3,9 +3,9 @@ list(APPEND SOURCES
         drivers/display/ssd1306-i2c.c
         drivers/display/ili9341-spi.c
 	drivers/i2c/lws-i2c.c
-        drivers/i2c/bitbang/lws-bb-i2c.c
-        drivers/spi/lws-spi.c
-        drivers/spi/bitbang/lws-bb-spi.c
+	drivers/i2c/bitbang/lws-bb-i2c.c
+	drivers/spi/lws-spi.c
+	drivers/spi/bitbang/lws-bb-spi.c
 	drivers/button/lws-button.c
 	drivers/led/led-gpio.c
 	drivers/led/led-seq.c

--- a/lib/drivers/display/lws-display.c
+++ b/lib/drivers/display/lws-display.c
@@ -1,7 +1,7 @@
 /*
  * lws abstract display
  *
- * Copyright (C) 2019 - 2020 Andy Green <andy@warmcat.com>
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  */
 
-#include <libwebsockets.h>
+#include <private-lib-core.h>
 
 static void
 sul_autodim_cb(lws_sorted_usec_list_t *sul)
@@ -85,7 +85,7 @@ lws_display_state_init(lws_display_state_t *lds, struct lws_context *ctx,
 	lws_led_transition(lds->bl_lcs, "backlight", &lws_pwmseq_static_off,
 						     &lws_pwmseq_static_on);
 
-	disp->init(disp);
+	disp->init(lds);
 }
 
 void
@@ -103,7 +103,7 @@ lws_display_state_active(lws_display_state_t *lds)
 
 	if (lds->state == LWSDISPS_OFF) {
 		/* power us up */
-		lds->disp->power(lds->disp, 1);
+		lds->disp->power(lds, 1);
 		lds->state = LWSDISPS_BECOMING_ACTIVE;
 		waiting_ms = lds->disp->latency_wake_ms;
 	} else {
@@ -120,13 +120,12 @@ lws_display_state_active(lws_display_state_t *lds)
 	if (waiting_ms >= 0)
 		lws_sul_schedule(lds->ctx, 0, &lds->sul_autodim, sul_autodim_cb,
 				 waiting_ms * LWS_US_PER_MS);
-
 }
 
 void
 lws_display_state_off(lws_display_state_t *lds)
 {
-	lds->disp->power(lds->disp, 0);
+	lds->disp->power(lds, 0);
 	lws_sul_cancel(&lds->sul_autodim);
 	lds->state = LWSDISPS_OFF;
 }

--- a/lib/misc/CMakeLists.txt
+++ b/lib/misc/CMakeLists.txt
@@ -55,6 +55,11 @@ if (LWS_WITH_FTS)
 		misc/fts/trie-fd.c)
 endif()
 
+if (LWS_WITH_UPNG)
+	list(APPEND SOURCES
+		misc/upng.c)
+endif()
+
 # this is an older, standalone hashed disk cache
 # implementation unrelated to lws-cache-ttl
 if (LWS_WITH_DISKCACHE)

--- a/lib/misc/CMakeLists.txt
+++ b/lib/misc/CMakeLists.txt
@@ -60,6 +60,18 @@ if (LWS_WITH_UPNG)
 		misc/upng.c)
 endif()
 
+if (LWS_WITH_DLO)
+	list(APPEND SOURCES
+		misc/dlo/dlo.c
+		misc/dlo/dlo-rect.c
+		misc/dlo/dlo-text.c)
+
+if (LWS_WITH_UPNG)
+	list(APPEND SOURCES
+		misc/dlo/dlo-png.c)
+endif()
+endif()
+
 # this is an older, standalone hashed disk cache
 # implementation unrelated to lws-cache-ttl
 if (LWS_WITH_DISKCACHE)

--- a/lib/misc/dlo/dlo-png.c
+++ b/lib/misc/dlo/dlo-png.c
@@ -145,3 +145,45 @@ bail:
 	return NULL;
 }
 
+int
+lws_pngs_register(struct lws_context *cx, const lws_display_png_t *f)
+{
+	lws_display_png_t *a = lws_malloc(sizeof(*a), __func__);
+	if (!a)
+		return 1;
+
+	*a = *f;
+	lws_dll2_clear(&a->list);
+	lws_dll2_add_tail(&a->list, &cx->pngs);
+
+	return 0;
+}
+
+static int
+lws_png_destroy(struct lws_dll2 *d, void *user)
+{
+	lws_free(d);
+	return 0;
+}
+
+void
+lws_pngs_destroy(struct lws_context *cx)
+{
+	lws_dll2_foreach_safe(&cx->pngs, NULL, lws_png_destroy);
+}
+
+const lws_display_png_t *
+lws_pngs_choose(struct lws_context *cx, const char *name)
+{
+	lws_start_foreach_dll(struct lws_dll2 *, p,
+			      lws_dll2_get_head(&cx->pngs)) {
+		const lws_display_png_t *pn = lws_container_of(p,
+						lws_display_png_t, list);
+
+		if (!strcmp(name, pn->name))
+			return pn;
+
+	} lws_end_foreach_dll(p);
+
+	return NULL;
+}

--- a/lib/misc/dlo/dlo-png.c
+++ b/lib/misc/dlo/dlo-png.c
@@ -1,0 +1,147 @@
+/*
+ * lws abstract display
+ *
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Display List Object: PNG
+ */
+
+#include <private-lib-core.h>
+#include "private-lib-drivers-display-dlo.h"
+
+static void
+lws_display_dlo_png_destroy(struct lws_dlo *dlo)
+{
+	lws_dlo_png_t *dlo_png = lws_container_of(dlo, lws_dlo_png_t, dlo);
+
+	lwsl_err("%s\n", __func__);
+	if (dlo_png->png)
+		lws_upng_free(&dlo_png->png);
+}
+
+void
+lws_display_render_png(const lws_surface_info_t *ic, struct lws_dlo *dlo,
+		       const lws_box_t *origin, lws_display_scalar curr,
+		       uint8_t *line, lws_colour_error_t **nle)
+{
+	lws_dlo_png_t *dlo_png = lws_container_of(dlo, lws_dlo_png_t, dlo);
+	lws_fixed3232_t ax, ay, t, t1;
+	lws_display_colour_t pc;
+	lws_colour_error_t ce;
+	const uint8_t *pix;
+	int s, e;
+
+	lws_fixed3232_add(&ax, &origin->x, &dlo->box.x);
+	lws_fixed3232_add(&t, &ax, &dlo->box.w);
+	lws_fixed3232_add(&ay, &origin->y, &dlo->box.y);
+	lws_fixed3232_add(&t1, &ay, &dlo->box.h);
+
+	s = ax.whole;
+	e = lws_fixed3232_roundup(&t);
+
+	if (curr > lws_fixed3232_roundup(&t1))
+		return;
+
+	if (curr - lws_fixed3232_roundup(&ay) >
+			(int)lws_upng_get_height(dlo_png->png))
+		return;
+
+	if (s < 0)
+		s = 0;
+	if (s > ic->wh_px[0].whole)
+		return; /* off to the right */
+	if (e > ic->wh_px[0].whole)
+		e = ic->wh_px[0].whole - 1;
+	if (e <= 0)
+		return; /* off to the left */
+
+	lws_dlo_ensure_err_diff(dlo);
+
+	if (lws_upng_emit_next_line(dlo_png->png, &pix,
+				    &dlo_png->data, &dlo_png->len) >
+						LWS_UPNG_FATAL || !pix)
+		return;
+
+	pix = pix + (( (unsigned int)(s - ax.whole) * (lws_upng_get_pixelsize(dlo_png->png) / 8)));
+
+	while (s < e && s >= ax.whole && s < lws_fixed3232_roundup(&t) &&
+	       (s - ax.whole) < (int)lws_upng_get_width(dlo_png->png)) {
+		ce = nle[!(curr & 1)][s - ax.whole];
+
+		pc = LWSDC_RGBA(pix[0], pix[1], pix[2], pix[3]);
+		if (pix[3]) {
+			int sx = s - ax.whole;
+
+			lws_surface_set_px(ic, line, s, &pc, &ce);
+
+			if (s != e - 1) {
+				dist_err(&ce, &nle[!(curr & 1)][sx + 1], 7);
+				dist_err(&ce, &nle[curr & 1][sx + 1], 1);
+			}
+			if (s > ax.whole)
+				dist_err(&ce, &nle[curr & 1][sx - 1], 3);
+			dist_err(&ce, &nle[curr & 1][sx], 5);
+		}
+		s++;
+		pix += lws_upng_get_pixelsize(dlo_png->png) / 8;
+	}
+}
+
+lws_dlo_png_t *
+lws_display_dlo_png_new(lws_displaylist_t *dl, lws_dlo_t *dlo_parent,
+			lws_box_t *box, const uint8_t *png, size_t png_size)
+{
+	lws_dlo_png_t *dlo_png = lws_zalloc(sizeof(*dlo_png), __func__);
+	const uint8_t *pix;
+
+	dlo_png->data = png;
+	dlo_png->len = png_size - 33;
+
+	dlo_png->png = lws_upng_new();
+	if (!dlo_png->png)
+		goto bail;
+
+	dlo_png->dlo.box = *box;
+	dlo_png->dlo.render = lws_display_render_png;
+	dlo_png->dlo._destroy = lws_display_dlo_png_destroy;
+
+	/*
+	 * Let's Give it 33 bytes so it can do the header, but nothing else.
+	 */
+
+	png_size = 33;
+	if (lws_upng_emit_next_line(dlo_png->png, &pix, &dlo_png->data,
+					&png_size) >= LWS_UPNG_FATAL)
+		goto bail;
+
+	lwsl_user("png: w %d, h %d\n", lws_upng_get_width(dlo_png->png),
+			lws_upng_get_height(dlo_png->png));
+
+	lws_display_dlo_add(dl, dlo_parent, &dlo_png->dlo);
+
+	return dlo_png;
+
+bail:
+	lws_free(dlo_png);
+
+	return NULL;
+}
+

--- a/lib/misc/dlo/dlo-rect.c
+++ b/lib/misc/dlo/dlo-rect.c
@@ -1,0 +1,138 @@
+/*
+ * lws abstract display
+ *
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Display List Object: rect / rounded rect
+ */
+
+#include <private-lib-core.h>
+#include "private-lib-drivers-display-dlo.h"
+
+void
+lws_display_render_rect(const lws_surface_info_t *ic, struct lws_dlo *dlo,
+			const lws_box_t *origin, lws_display_scalar curr,
+			uint8_t *line, lws_colour_error_t **nle)
+{
+	lws_dlo_rect_t *dlo_rect = lws_container_of(dlo, lws_dlo_rect_t, dlo);
+	lws_fixed3232_t btm, t1, t2, t3, cf, y, ys, w, rsq, trim;
+	int s, e;
+	lws_box_t db;
+
+	lws_fixed3232_add(&db.x, &origin->x, &dlo->box.x);
+	lws_fixed3232_add(&db.y, &origin->y, &dlo->box.y);
+
+	lws_fixed3232_add(&btm, &db.y, &dlo->box.h);
+
+	s = db.x.whole;
+	e = s + lws_fixed3232_roundup(&dlo->box.w);
+
+	if (s > ic->wh_px[0].whole)
+		return; /* off to the right */
+
+	if (curr < db.y.whole || curr > lws_fixed3232_roundup(&btm))
+		return;
+
+	/* account for four independently radiused corners */
+
+	cf.whole = curr;
+	cf.frac = 0;
+
+	lws_fixed3232_add(&t1, &db.y, &dlo_rect->radius[0]);
+	if (curr <= lws_fixed3232_roundup(&t1)) { /* top left trims s */
+		lws_fixed3232_sub(&y, &cf, &t1);
+		lws_fixed3232_mul(&ys, &y, &y);
+		lws_fixed3232_mul(&rsq, &dlo_rect->radius[0],
+					&dlo_rect->radius[0]);
+
+		lws_fixed3232_sqrt(&w, lws_fixed3232_sub(&t3, &rsq, &ys));
+		lws_fixed3232_sub(&trim, &dlo_rect->radius[0], &w);
+		s += lws_fixed3232_roundup(&trim);
+	}
+
+	lws_fixed3232_add(&t1, &db.y, &dlo_rect->radius[1]);
+	if (curr <= lws_fixed3232_roundup(&t1)) { /* top right trims e */
+		lws_fixed3232_sub(&y, &cf, &t1);
+		lws_fixed3232_mul(&ys, &y, &y);
+		lws_fixed3232_mul(&rsq, &dlo_rect->radius[1],
+					&dlo_rect->radius[1]);
+
+		lws_fixed3232_sqrt(&w, lws_fixed3232_sub(&t3, &rsq, &ys));
+		lws_fixed3232_sub(&trim, &dlo_rect->radius[1], &w);
+		e -= lws_fixed3232_roundup(&trim);
+	}
+
+	lws_fixed3232_add(&t2, &db.y, &dlo->box.h);
+	lws_fixed3232_sub(&t1, &t2, &dlo_rect->radius[2]);
+	if (curr >= lws_fixed3232_roundup(&t1)) { /* bottom left trims s */
+		lws_fixed3232_sub(&y, &cf, &t1);
+		lws_fixed3232_mul(&ys, &y, &y);
+		lws_fixed3232_mul(&rsq, &dlo_rect->radius[2],
+					&dlo_rect->radius[2]);
+
+		lws_fixed3232_sqrt(&w, lws_fixed3232_sub(&t3, &rsq, &ys));
+		lws_fixed3232_sub(&trim, &dlo_rect->radius[2], &w);
+		s += lws_fixed3232_roundup(&trim);
+	}
+
+	lws_fixed3232_add(&t2, &db.y, &dlo->box.h);
+	lws_fixed3232_sub(&t1, &t2, &dlo_rect->radius[3]);
+	if (curr >= lws_fixed3232_roundup(&t1)) { /* bottom right trims e */
+		lws_fixed3232_sub(&y, &cf, &t1);
+		lws_fixed3232_mul(&ys, &y, &y);
+		lws_fixed3232_mul(&rsq, &dlo_rect->radius[3],
+					&dlo_rect->radius[3]);
+
+		lws_fixed3232_sqrt(&w, lws_fixed3232_sub(&t3, &rsq, &ys));
+		lws_fixed3232_sub(&trim, &dlo_rect->radius[3], &w);
+		e -= lws_fixed3232_roundup(&trim);
+	}
+
+	if (s < 0)
+		s = 0;
+	if (e > ic->wh_px[0].whole)
+		e = ic->wh_px[0].whole - 1;
+	if (e <= 0 || e < s)
+		return; /* off to the left */
+
+	lws_display_raster(ic, dlo, curr, s, e, line, nle);
+}
+
+lws_dlo_rect_t *
+lws_display_dlo_rect_new(lws_displaylist_t *dl, lws_dlo_t *dlo_parent,
+			 lws_box_t *box, const lws_fixed3232_t *radii,
+			 lws_display_colour_t dc)
+{
+	lws_dlo_rect_t *dlo_rect = lws_zalloc(sizeof(*dlo_rect), __func__);
+
+	if (!dlo_rect)
+		return NULL;
+
+	dlo_rect->dlo.render = lws_display_render_rect;
+	dlo_rect->dlo.box = *box;
+	dlo_rect->dlo.dc = dc;
+	if (radii)
+		memcpy(&dlo_rect->radius, radii, sizeof(dlo_rect->radius));
+
+	lws_display_dlo_add(dl, dlo_parent, &dlo_rect->dlo);
+
+	return dlo_rect;
+}

--- a/lib/misc/dlo/dlo-text.c
+++ b/lib/misc/dlo/dlo-text.c
@@ -1,0 +1,422 @@
+/*
+ * lws abstract display
+ *
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Display List Object: text
+ */
+
+#include <private-lib-core.h>
+#include "private-lib-drivers-display-dlo.h"
+
+static size_t
+utf8_bytes(uint8_t u)
+{
+	if ((u & 0x80) == 0)
+		return 1;
+
+	if ((u & 0xe0) == 0xc0)
+		return 2;
+
+	if ((u & 0xf0) == 0xe0)
+		return 3;
+
+	if ((u & 0xf8) == 0xf0)
+		return 4;
+
+	return 0;
+}
+
+void
+lws_display_dlo_text_destroy(struct lws_dlo *dlo)
+{
+	lws_dlo_text_t *text = lws_container_of(dlo, lws_dlo_text_t, dlo);
+
+	lws_free_set_NULL(text->kern);
+	lws_free_set_NULL(text->text);
+}
+
+static const uint8_t *
+font_psfu_uniglyph(const struct lws_display_font *font, const char *utf8,
+		   size_t *m)
+{
+	const uint8_t *p = font->data, *u, *end = font->data + font->data_len, *ge;
+	uint32_t hdrlen = ntohl(lws_ser_ru32be(p + 8)),
+		 numglyph = ntohl(lws_ser_ru32be(p + 0x10)),
+		 bytesperglyph = ntohl(lws_ser_ru32be(p + 0x14));
+	size_t ulen = utf8_bytes((const uint8_t)*utf8);
+
+	if (!ulen) {
+		utf8 = "?";
+		ulen = 1;
+	}
+
+	assert(hdrlen < 256);
+	assert(numglyph < 65535);
+	assert(bytesperglyph < 65535);
+
+	p += hdrlen;
+	ge = u = p + (numglyph * bytesperglyph);
+	assert(u < end);
+
+	/*
+	 * For each glyph in the main part, there's an entry in the unicode
+	 * table describing its identity as UTF-8.  Each UTF-8 list ends with
+	 * 0xff delimiter
+	 */
+
+	while (p < ge && u < end) {
+		size_t gul = 0;
+
+		gul = utf8_bytes(*u);
+		if (gul >= 1 && gul == ulen && !memcmp(u, utf8, gul)) {
+			*m = gul;
+			return p;
+		}
+
+		while (*u != 0xff && u < end)
+			u++;
+
+		u++;
+
+		p += bytesperglyph;
+	}
+
+	*m = 1;
+
+	return NULL;
+}
+
+static size_t
+image_glyph(lws_dlo_text_t *text, const char *utf8,
+	    lws_display_gline_t *dest, size_t dest_height)
+{
+	size_t glyph_len;
+	const uint8_t *pxd = font_psfu_uniglyph(text->font, utf8, &glyph_len);
+	uint32_t bytesperglyph = ntohl(lws_ser_ru32be(text->font->data + 0x14)),
+		 h_px = ntohl(lws_ser_ru32be(text->font->data + 0x18)),
+		 bytes_per_line = bytesperglyph / h_px,
+		 n, y = 0, r;
+
+	if (h_px > dest_height)
+		h_px = (uint32_t)dest_height;
+
+	while (y < h_px) {
+
+		if (!pxd) {
+			dest[y] = 0;
+		} else {
+			r = (sizeof(dest[0]) * 8) - 8;
+			dest[y] = 0;
+			for (n = 0; n < bytes_per_line; n++) {
+				dest[y] = (unsigned int)(dest[y] | (unsigned int)(*pxd++ << r));
+				r -= 8;
+			}
+		}
+
+		y++;
+	}
+
+	return glyph_len;
+}
+
+int
+lws_display_dlo_text_update(lws_dlo_text_t *text, lws_display_colour_t dc,
+		lws_fixed3232_t indent, const char *utf8, size_t text_len)
+{
+	lws_display_gline_t profile[2][MAX_FONT_HEIGHT], probe;
+	size_t n = 0, f = 0, cw, try, sp,
+	       w_px = ntohl(lws_ser_ru32be(text->font->data + 0x1c)),
+	       h_px = ntohl(lws_ser_ru32be(text->font->data + 0x18)),
+	       last_bp_n = 0;
+	uint8_t *tk, kernable = 0, r = 0;
+	lws_fixed3232_t t1, eff, kern, last_bp_eff;
+
+	if (text->kern)
+		lws_free_set_NULL(text->kern);
+
+	if (text->text)
+		lws_free_set_NULL(text->text);
+
+	text->dlo.dc = dc;
+
+	tk = text->kern = lws_malloc(text_len * 2, __func__);
+	if (!text->kern)
+		return -1;
+
+	if (h_px > MAX_FONT_HEIGHT)
+		h_px = MAX_FONT_HEIGHT;
+
+	try = w_px;
+	lws_fixed_set(eff, 0, 0);
+
+	/*
+	 * Let's go through the new string glyph by glyph, we want to
+	 * calculate effective kerned widths, and optionally deal with wrapping.
+	 */
+
+	while (n < text_len &&
+	       lws_fixed3232_comp(lws_fixed3232_add(&t1, &eff, &indent), &text->dlo.box.w) < 0) {
+
+		cw = image_glyph(text, &utf8[n], &profile[f][0], MAX_FONT_HEIGHT);
+
+		if (utf8[n] == ' ' && kernable)
+			kernable = 2;
+
+		/* ie, we have a previous char to work with */
+
+		lws_fixed_set(kern, 0, 0);
+		if (kernable) {
+
+			/* We want to find "how far left we can shift" the left
+			 * of profile[f] into the right of profile[f ^ 1] */
+
+			/* after the first time, try is the remaining
+			 * width of the previous character after
+			 * trimming empty solumns from the right
+			 */
+
+			probe = kernable == 2 ? 0xffffffff : 0;
+			sp = try;
+
+			while (try > 1) {
+				size_t m, mask = 0;
+
+				for (m = 0; m < h_px; m++)
+					mask |= profile[f ^ 1][m] &
+						((profile[f][m] | probe) >> (try - 1));
+
+				if (mask) {
+					if (try < sp)
+						try++;
+					break;
+				}
+
+				try--;
+			}
+
+			kern.whole = (int32_t)(sp - try); /* px to offset left */
+		}
+
+		/*
+		 * We want to find how many px of this char actually
+		 * have nonblank data (skip if space)
+		 */
+
+		try = w_px;
+		while (try > 1 && kernable != 2) {
+			size_t m, mask = 0;
+
+			for (m = 0; m < h_px; m++)
+				mask |= (profile[f][m] << try);
+
+			if (mask) {
+				if (try < w_px)
+					try++;
+				break;
+			}
+
+			try--;
+		}
+
+		if (n == 0)
+			kern.whole = (int32_t)(w_px - try);
+
+		if (utf8[n] == ' ') {
+			try = w_px / 2;
+			kernable = 0; /* next char can't kern away our space */
+			if (!n)
+				kern.whole = 0;
+		} else
+			kernable = 1;
+
+		*tk++ = (uint8_t)kern.whole;
+		*tk++ = (uint8_t)try;
+
+		if (utf8[n] == ' ') { /* act to skip it */
+			last_bp_n = n + cw;
+			lws_fixed3232_sub(&last_bp_eff, &eff, &kern);
+		}
+
+		lws_fixed3232_sub(&eff, &eff, &kern);
+		eff.whole += (int32_t)(try + 1);
+
+		if (utf8[n] == '-' || utf8[n] == ',' || utf8[n] == ';' ||
+		    utf8[n] == ':') { /* act to leave it in */
+			last_bp_n = n + cw;
+			last_bp_eff = eff;
+		}
+
+		f ^= 1;
+		n += cw;
+	}
+
+	if (last_bp_n &&
+	    lws_fixed3232_comp(lws_fixed3232_add(&t1, &eff, &indent), &text->dlo.box.w) >= 0) {
+		lwsl_notice("%s: last_bp_n %d, eff %d.%u + indent %d.%u >= %d.%u\n",
+				__func__, (int)last_bp_n,
+				LWFIX(eff), LWFIX(indent),
+				LWFIX(text->dlo.box.w));
+		n = last_bp_n;
+		eff = last_bp_eff;
+		r = 1;
+	}
+
+	text->text_len = n;
+	if (!n) {
+		lwsl_notice("we couldn't fit anything in there, newline\n");
+		return 2;
+	}
+
+	text->text = lws_malloc(n + 1, __func__);
+	if (!text->text)
+		return -1;
+
+	memcpy(text->text, utf8, n);
+	text->text[n] = '\0';
+
+	memset(&text->bounding_box, 0, sizeof(text->bounding_box));
+	text->bounding_box.w = eff;
+	text->bounding_box.h.whole = (int32_t)h_px;
+
+//	lwsl_notice("%s: text->bb->w %d, h %d\n", __func__,
+//			text->bounding_box.w.whole, text->bounding_box.h.whole);
+
+	return r;
+}
+
+lws_dlo_text_t *
+lws_display_dlo_text_new(lws_displaylist_t *dl, lws_dlo_t *dlo_parent,
+			 lws_box_t *box, const lws_display_font_t *font)
+{
+	lws_dlo_text_t *text = lws_zalloc(sizeof(*text), __func__);
+
+	if (!text)
+		return NULL;
+
+	text->dlo.render = font->renderer;
+	text->dlo._destroy = lws_display_dlo_text_destroy;
+	text->dlo.box = *box;
+	text->font = font;
+
+	lws_display_dlo_add(dl, dlo_parent, &text->dlo);
+
+	return text;
+}
+
+void
+lws_display_font_psfu_render(const lws_surface_info_t *ic, struct lws_dlo *dlo,
+		const lws_box_t *origin, lws_display_scalar curr, uint8_t *line,
+		lws_colour_error_t **nle)
+{
+	lws_dlo_text_t *text = lws_container_of(dlo, lws_dlo_text_t, dlo);
+	int s, e, s1, r, yo;
+	uint32_t bytesperglyph = ntohl(lws_ser_ru32be(text->font->data + 0x14)),
+		 h_px = ntohl(lws_ser_ru32be(text->font->data + 0x18)),
+		 bytes_per_line = bytesperglyph / h_px,
+		 shf = 0, n, ins = 0;
+	const char *txt = text->text, *txt_end = txt + text->text_len;
+	lws_fixed3232_t ax, ay, t, t1, t2;
+	size_t glyph_len, ci = 0;
+	lws_colour_error_t ce;
+	const uint8_t *pxd;
+
+	lws_fixed3232_add(&ax, &origin->x, &dlo->box.x);
+	lws_fixed3232_add(&t, &ax, &dlo->box.w);
+	lws_fixed3232_add(&ay, &origin->y, &dlo->box.y);
+	lws_fixed3232_add(&t1, &ay, &dlo->box.h);
+
+	lws_fixed3232_add(&t2, &ax, &text->bounding_box.w);
+
+	s = ax.whole;
+	e = lws_fixed3232_roundup(&t2);
+
+	if (e <= 0)
+		return; /* wholly off to the left */
+	if (s >= ic->wh_px[0].whole)
+		return; /* wholly off to the right */
+
+	if (e >= ic->wh_px[0].whole)
+		e = ic->wh_px[0].whole;
+
+	/* figure out our y position inside the glyph */
+	yo = curr - ay.whole;
+	/* if further down than glyph height, nothing to do */
+	if (yo >= (int)h_px)
+		return;
+
+	memset(&ce, 0, sizeof(ce));
+
+	while (txt < txt_end && s < e) {
+
+		lws_dlo_ensure_err_diff(dlo);
+
+		pxd = font_psfu_uniglyph(text->font, txt, &glyph_len);
+		txt += glyph_len;
+
+		if (!pxd) {
+			shf = 0xffffffff;
+		} else {
+			pxd = pxd + (yo * (int)bytes_per_line);
+			r = 24;
+			shf = 0;
+			for (n = 0; n < bytes_per_line; n++) {
+				shf = (unsigned int)(shf | (unsigned int)(*pxd++ << r));
+				r -= 8;
+			}
+		}
+
+		r = 31;
+
+		s1 = s - text->kern[ci];
+		for (ins = 0; ins < (uint32_t)text->kern[ci + 1] + 1; ins++) {
+			lws_display_colour_t c = LWSDC_RGBA(0, 0, 0, 255);
+			int sx = s1 - ax.whole;
+
+			if (s1 < 0 || s1 >= e || !(shf & (unsigned int)(1 << r)) ||
+			     !((shf & (unsigned int)(1 << r)) || ins >= text->kern[ci])) {
+				r--;
+				s1++;
+				continue;
+			}
+			c = dlo->dc;
+			ce = nle[!(curr & 1)][s1 - ax.whole];
+
+			lws_surface_set_px(ic, line, s1, &c, &ce);
+
+			if (s1 != e - 1) {
+				dist_err(&ce, &nle[!(curr & 1)][sx + 1], 7);
+				dist_err(&ce, &nle[curr & 1][sx + 1], 1);
+			}
+			if (s1 > ax.whole)
+				dist_err(&ce, &nle[curr & 1][sx - 1], 3);
+
+			dist_err(&ce, &nle[curr & 1][sx], 5);
+
+			r--;
+			s1++;
+		}
+
+		s = s1;
+		ci += 2;
+	}
+}
+

--- a/lib/misc/dlo/dlo.c
+++ b/lib/misc/dlo/dlo.c
@@ -1,0 +1,356 @@
+/*
+ * lws abstract display
+ *
+ * Copyright (C) 2019 - 2022 Andy Green <andy@warmcat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Display List Object handling
+ */
+
+#include <private-lib-core.h>
+#include "private-lib-drivers-display-dlo.h"
+
+/*
+ * For error disffusion, it's better to use YUV and prioritize reducing error
+ * in Y (lumience)
+ */
+
+#if 0
+static void
+rgb_to_yuv(uint8_t *yuv, const uint8_t *rgb)
+{
+	yuv[0] =  16 + ((257 * rgb[0]) / 1000) + ((504 * rgb[1]) / 1000) +
+						  ((98 * rgb[2]) / 1000);
+	yuv[1] = 128 - ((148 * rgb[0]) / 1000) - ((291 * rgb[1]) / 1000) +
+						 ((439 * rgb[2]) / 1000);
+	yuv[2] = 128 + ((439 * rgb[0]) / 1000) - ((368 * rgb[1]) / 1000) -
+						  ((71 * rgb[2]) / 1000);
+}
+
+static void
+yuv_to_rgb(uint8_t *rgb, const uint8_t *_yuv)
+{
+	unsigned int yuv[3];
+
+	yuv[0] = _yuv[0] - 16;
+	yuv[1] = _yuv[1] - 128;
+	yuv[2] = _yuv[2] - 128;
+
+	rgb[0] = ((1164 * yuv[0]) / 1000) + ((1596 * yuv[2]) / 1000);
+	rgb[1] = ((1164 * yuv[0]) / 1090) -  ((392 * yuv[1]) / 1000) -
+					     ((813 * yuv[2]) / 1000);
+	rgb[2] = ((1164 * yuv[0]) / 1000) + ((2017 * yuv[1]) / 1000);
+}
+#endif
+
+
+void
+lws_display_dl_init(lws_displaylist_t *dl, lws_display_state_t *ds)
+{
+	lws_dll2_owner_clear(&dl->dl);
+	dl->ds = ds;
+}
+
+int
+lws_display_dlo_add(lws_displaylist_t *dl, lws_dlo_t *dlo_parent, lws_dlo_t *dlo)
+{
+	lws_dll2_add_tail(&dlo->list, dlo_parent ? &dlo_parent->children : &dl->dl);
+
+	return 9;
+}
+
+void
+dist_err(const lws_colour_error_t *in, lws_colour_error_t *out, int sixteenths)
+{
+	out->rgb[0] = (int16_t)(out->rgb[0] + (int16_t)((sixteenths * in->rgb[0]) / 16));
+	out->rgb[1] = (int16_t)(out->rgb[1] + (int16_t)((sixteenths * in->rgb[1]) / 16));
+	out->rgb[2] = (int16_t)(out->rgb[2] + (int16_t)((sixteenths * in->rgb[2]) / 16));
+}
+
+void
+lws_surface_set_px(const lws_surface_info_t *ic, uint8_t *line, int x,
+		   const lws_display_colour_t *c, lws_colour_error_t *ce)
+{
+	unsigned int alpha, ialpha;
+	lws_display_colour_t oc;
+	uint8_t rgb[3];
+	uint16_t n;
+
+	switch (ic->type) {
+	case LWSSURF_PALETTE_4BB:
+		oc = ic->palette[get_nyb(line, x) % ic->palette_depth];
+		oc = LWSDC_RGBA(LWSDC_R(oc), LWSDC_G(oc), LWSDC_B(oc), 0xff);
+		n = lws_display_palettize(ic, *c, oc, ce);
+		set_nyb(line, x, (uint8_t)n);
+		break;
+	case LWSSURF_TRUECOLOR32:
+		oc = *(((uint32_t *)line) + x);
+		alpha = LWSDC_ALPHA(*c);
+		ialpha = 255 - alpha;
+
+		rgb[0] = (uint8_t)(((LWSDC_R(*c) * alpha) / 255) +
+			   ((LWSDC_R(oc) * ialpha) / 255));
+		rgb[1] = (uint8_t)(((LWSDC_G(*c) * alpha) / 255) +
+			   ((LWSDC_G(oc) * ialpha) / 255));
+		rgb[2] = (uint8_t)(((LWSDC_B(*c) * alpha) / 255) +
+			   ((LWSDC_B(oc) * ialpha) / 255));
+
+		line += (x * 4);
+		*line++ = rgb[0];
+		*line++ = rgb[1];
+		*line++ = rgb[2];
+		*line++ = 0xff;;
+
+		break;
+	default:
+		break;
+	}
+}
+
+void
+lws_display_raster(const lws_surface_info_t *ic, struct lws_dlo *dlo,
+			lws_display_scalar curr, int s, int e, uint8_t *line,
+			lws_colour_error_t **nle)
+{
+	lws_colour_error_t ce;
+	int os = s;
+
+	if (!LWSDC_ALPHA(dlo->dc))
+		return;
+
+	if (e > ic->wh_px[0].whole)
+		e = ic->wh_px[0].whole - 1;
+
+	while (s < e) {
+		ce = nle[!(curr & 1)][s - os];
+
+		lws_surface_set_px(ic, line, s, &dlo->dc, &ce);
+
+		if (s != e - 1) {
+			dist_err(&ce, &nle[!(curr & 1)][s - os + 1], 7);
+			dist_err(&ce, &nle[curr & 1][s - os + 1], 1);
+		}
+		if (s > os)
+			dist_err(&ce, &nle[curr & 1][s - os- 1], 3);
+
+		dist_err(&ce, &nle[curr & 1][s - os], 5);
+
+		s++;
+	}
+}
+
+int
+lws_dlo_ensure_err_diff(lws_dlo_t *dlo)
+{
+	/* defer creation of dlo's 2px-high dlo-width, 32bpp
+	 * error diffusion buffer */
+
+	if (dlo->nle[0])
+		return 0;
+
+	dlo->nle[0] = lws_zalloc(sizeof(dlo->nle[0][0]) * 2u *
+				(unsigned int)(dlo->box.w.whole + 16 + 4),
+				__func__);
+	if (!dlo->nle[0])
+		return 1;
+
+	/*
+	 * We arrange to have 16px of valid diffusion behind the official lhs,
+	 * this is to manage kerning offsets at the start of line
+	 */
+	dlo->nle[0] += 16;
+
+	dlo->nle[1] = dlo->nle[0] + dlo->box.w.whole + 16 + 4;
+
+	return 0;
+}
+
+static void
+lws_display_list_render_dlo_recursive(lws_display_render_state_t *rs,
+				      lws_dlo_t *dlo, const lws_box_t *origin)
+{
+	lws_fixed3232_t t2;
+	lws_box_t co;
+
+	lws_fixed3232_add(&co.x, &origin->x, &dlo->box.x);
+	lws_fixed3232_add(&co.y, &origin->y, &dlo->box.y);
+	co.w = dlo->box.w;
+	co.h = dlo->box.h;
+
+	lws_fixed3232_add(&t2, &co.y, &dlo->box.h);
+
+	/*
+	 * destroy display list items as soon as we're rendering
+	 * beyond their bottom edge, also destroys error
+	 * diffusion buffer (notice the origin offset of any parent is
+	 * accounted for since rs->curr is a display surface line index)
+	 */
+
+	if (rs->curr > lws_fixed3232_roundup(&t2)) {
+		lws_display_dlo_destroy(&dlo);
+		return;
+	}
+
+	if (rs->curr >= co.y.whole) {
+		lws_dlo_ensure_err_diff(dlo);
+
+		/* clear down next line's error states */
+		memset(dlo->nle[rs->curr & 1] - 16, 0,
+		       sizeof(dlo->nle[0][0]) *
+				(unsigned int)(dlo->box.w.whole + 16 + 4));
+
+		dlo->render(rs->ic, dlo, origin, rs->curr, rs->line,
+			    &dlo->nle[0]);
+	}
+
+	if (!dlo->children.head)
+		return;
+
+	/*
+	 * Go through any children recursively, with their origin set to
+	 * ours, so they are "inside"
+	 */
+
+	lws_start_foreach_dll_safe(struct lws_dll2 *, p, p1,
+			      lws_dll2_get_head(&dlo->children)) {
+		lws_dlo_t *cdlo = lws_container_of(p, lws_dlo_t, list);
+
+		lws_display_list_render_dlo_recursive(rs, cdlo, &co);
+	} lws_end_foreach_dll_safe(p, p1);
+}
+
+int
+lws_display_list_render_line(lws_display_render_state_t *rs)
+{
+	lws_box_t origin;
+
+	if (!rs->displaylist)
+		return 0;
+
+	memset(&origin, 0, sizeof(origin));
+	lws_start_foreach_dll_safe(struct lws_dll2 *, p, p1,
+			      lws_dll2_get_head(&rs->displaylist->dl)) {
+		lws_dlo_t *dlo = lws_container_of(p, lws_dlo_t, list);
+
+		lws_display_list_render_dlo_recursive(rs, dlo, &origin);
+
+	} lws_end_foreach_dll_safe(p, p1);
+
+	return 0;
+}
+
+
+void
+lws_display_dlo_destroy(lws_dlo_t **r)
+{
+	if (!(*r))
+		return;
+
+	lws_dll2_remove(&(*r)->list);
+
+	while ((*r)->children.head) {
+		lws_dlo_t *d = lws_container_of((*r)->children.head, lws_dlo_t, list);
+
+		lws_display_dlo_destroy(&d);
+	}
+
+	if ((*r)->_destroy)
+		(*r)->_destroy(*r);
+
+	if ((*r)->nle[0]) {
+		(*r)->nle[0] -= 16;
+		lws_free_set_NULL((*r)->nle[0]);
+	}
+
+	lws_free_set_NULL(*r);
+	*r = NULL;
+}
+
+void
+lws_display_list_destroy(lws_displaylist_t **dl)
+{
+	if (!*dl)
+		return;
+
+	while ((*dl)->dl.head) {
+		lws_dlo_t *d = lws_container_of((*dl)->dl.head, lws_dlo_t, list);
+
+		lws_display_dlo_destroy(&d);
+	}
+	*dl = NULL;
+}
+
+lws_display_palette_idx_t
+lws_display_palettize(const lws_surface_info_t *ic, lws_display_colour_t c,
+		      lws_display_colour_t oc, lws_colour_error_t *ectx)
+{
+	unsigned int alpha = LWSDC_ALPHA(c), ialpha = 255 - alpha;
+	int best = 0x7fffffff, best_idx = 0, eialpha = 255;
+	lws_colour_error_t d;
+	size_t n;
+
+	d.rgb[0] = (int16_t)(((LWSDC_R(c) * alpha) / 255) +
+		   ((LWSDC_R(oc) * ialpha) / 255) +
+			   (unsigned int)((ectx->rgb[0] * eialpha) / 255));
+	d.rgb[1] = (int16_t)(((LWSDC_G(c) * alpha) / 255) +
+		   ((LWSDC_G(oc) * ialpha) / 255) +
+			   (unsigned int)((ectx->rgb[1] * eialpha) / 255));
+	d.rgb[2] = (int16_t)(((LWSDC_B(c) * alpha) / 255) +
+		   ((LWSDC_B(oc) * ialpha) / 255) +
+			   (unsigned int)((ectx->rgb[2] * eialpha) / 255));
+
+	if (d.rgb[0] > 255)
+		d.rgb[0] = 255;
+	if (d.rgb[1] > 255)
+		d.rgb[1] = 255;
+	if (d.rgb[2] > 255)
+		d.rgb[2] = 255;
+	if (d.rgb[0] < 0)
+		d.rgb[0] = 0;
+	if (d.rgb[1] < 0)
+		d.rgb[1] = 0;
+	if (d.rgb[2] < 0)
+		d.rgb[2] = 0;
+
+	/*
+	 * We know what we want, considering transparency and prior error...
+	 * let's pick the least bad choice from the palette
+	 */
+
+	for (n = 0; n < ic->palette_depth; n++) {
+		lws_colour_error_t e;
+		int sum;
+
+		e.rgb[0] = (int16_t)((int)d.rgb[0] - (int)(LWSDC_R(ic->palette[n])));
+		e.rgb[1] = (int16_t)(d.rgb[1] - (int)(LWSDC_G(ic->palette[n])));
+		e.rgb[2] = (int16_t)(d.rgb[2] - (int)(LWSDC_B(ic->palette[n])));
+
+		sum = (e.rgb[0] * e.rgb[0]) + (e.rgb[1] * e.rgb[1]) +
+					      (e.rgb[2] * e.rgb[2]);
+		if (sum < best) {
+			best_idx = (int)n;
+			best = sum;
+			*ectx = e;
+		}
+	}
+
+	return (lws_display_palette_idx_t)best_idx;
+}
+

--- a/lib/misc/dlo/private-lib-drivers-display-dlo.h
+++ b/lib/misc/dlo/private-lib-drivers-display-dlo.h
@@ -1,0 +1,17 @@
+#define set_nyb(_line, _x, _c) \
+	{ if ((_x) & 1) { _line[(_x) >> 1] &= 0xf0; _line[(_x) >> 1]  |= _c; } else \
+		    { _line[(_x) >> 1] &= 0x0f; _line[(_x) >> 1] |= (uint8_t)((_c) << 4); }}
+
+#define get_nyb(_line, _x)  ((_x) & 1) ? ((line[(_x) >> 1]) >> 4) : \
+					 ((line[(_x) >> 1]) & 0xf)
+
+void
+lws_display_raster(const struct lws_surface_info *ic, struct lws_dlo *dlo,
+			lws_display_scalar curr, int s, int e, uint8_t *line,
+			lws_colour_error_t **nle);
+
+void
+dist_err(const lws_colour_error_t *in, lws_colour_error_t *out, int sixteenths);
+
+unsigned int
+_isqrt(unsigned int n);

--- a/lib/misc/upng.c
+++ b/lib/misc/upng.c
@@ -1,0 +1,1529 @@
+/*
+ * LWS PNG -- derived from uPNG -- derived from LodePNG version 20100808
+ * Stateful, linewise PNG decode requiring ~36KB fixed heap
+ *
+ * Copyright (c) 2005-2010 Lode Vandevenne (LodePNG)
+ * Copyright (c) 2010 Sean Middleditch (uPNG)
+ * Copyright (c) 2021 Andy Green <andy@warmcat.com> (Stateful, incremental)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software
+ *      in a product, an acknowledgment in the product documentation would be
+ *	appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not be
+ *	misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any source
+ *	distribution.
+ *
+ *  AG: The above notice is the ZLIB license, libpng also uses it.
+ *
+ * This version was rewritten from the upng project's fork of lodepng and
+ * adapted to be a stateful stream parser.  This rewrite retains the ZLIB
+ * license of the source material for simplicity.
+ *
+ * That allows it to use a fixed 32KB ringbuffer to hold decodes, and
+ * incrementally decode chunks into it as we want output lines that are not yet
+ * present there.  The input png nor the output bitmap need to be all in one
+ * place at one time.
+ */
+
+#include <private-lib-core.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#define FIRST_LENGTH_CODE_INDEX		257
+#define LAST_LENGTH_CODE_INDEX		285
+
+/*256 literals, the end code, some length codes, and 2 unused codes */
+#define NUM_DEFLATE_CODE_SYMBOLS	288
+/*the distance codes have their own symbols, 30 used, 2 unused */
+#define NUM_DISTANCE_SYMBOLS		32
+/* The code length codes. 0-15: code lengths, 16: copy previous 3-6 times,
+ * 17: 3-10 zeros, 18: 11-138 zeros */
+#define NUM_CODE_LENGTH_CODES		19
+/* largest number of symbols used by any tree type */
+#define MAX_SYMBOLS			288
+
+#define DEFLATE_CODE_BITLEN		15
+#define DISTANCE_BITLEN			15
+#define CODE_LENGTH_BITLEN		7
+/* largest bitlen used by any tree type */
+#define MAX_BIT_LENGTH			15
+
+#define DEFLATE_CODE_BUFFER_SIZE	(NUM_DEFLATE_CODE_SYMBOLS * 2)
+#define DISTANCE_BUFFER_SIZE		(NUM_DISTANCE_SYMBOLS * 2)
+#define CODE_LENGTH_BUFFER_SIZE		(NUM_DISTANCE_SYMBOLS * 2)
+
+typedef uint16_t huff_t;
+
+typedef enum upng_color {
+	LWS_UPNG_LUM		= 0,
+	LWS_UPNG_RGB		= 2,
+	LWS_UPNG_LUMA		= 4,
+	LWS_UPNG_RGBA		= 6
+} upng_color;
+
+struct upng_unfline {
+	uint8_t			*recon;
+	const uint8_t		*scanline;
+	const uint8_t		*precon;
+	uint8_t			filterType;
+	unsigned int		bypp;
+	unsigned int		bypl;
+
+	const uint8_t		*in;
+	uint8_t			*lines;
+	unsigned int		bpp;
+
+	unsigned int		y;
+	unsigned long		diff;
+	unsigned long		ibp;
+	unsigned long		sp;
+
+	char			padded;
+	char			alt;
+};
+
+typedef struct htree {
+	huff_t			*tree2d;
+	/*maximum number of bits a single code can get */
+	uint16_t		maxbitlen;
+	/*number of symbols in the alphabet = number of codes */
+	uint16_t		numcodes;
+} htree_t;
+
+typedef enum {
+	UPNS_ID_BL_GB_DONE,
+	UPNS_ID_BL_GB_BTYPEb0,
+	UPNS_ID_BL_GB_BTYPEb1,
+
+	UPNS_ID_BL_GB_BTYPE_0,
+	UPNS_ID_BL_GB_BTYPE_1,
+	UPNS_ID_BL_GB_BTYPE_2,
+
+	UPNS_ID_BL_GB_BTYPE_0a,
+	UPNS_ID_BL_GB_BTYPE_0b,
+	UPNS_ID_BL_GB_BTYPE_0c,
+	UPNS_ID_BL_GB_BTYPE_0d,
+
+	UPNS_ID_BL_GB_BTYPE_2a,
+	UPNS_ID_BL_GB_BTYPE_2b,
+	UPNS_ID_BL_GB_BTYPE_2c,
+	UPNS_ID_BL_GB_BTYPE_2d,
+	UPNS_ID_BL_GB_BTYPE_2e,
+
+	UPNS_ID_BL_GB_BTYPE_2_16,
+	UPNS_ID_BL_GB_BTYPE_2_17,
+	UPNS_ID_BL_GB_BTYPE_2_18,
+
+	UPNS_ID_BL_GB_SPIN,
+
+	UPNS_ID_BL_GB_SPINa,
+	UPNS_ID_BL_GB_SPINb,
+	UPNS_ID_BL_GB_SPINc,
+	UPNS_ID_BL_GB_SPINd,
+	UPNS_ID_BL_GB_SPINe,
+
+} upng_inflate_states_t;
+
+typedef enum {
+	UOF_MAGIC,
+	UOF_SKIP,
+	UOF_TYPE4,
+	UOF_WIDTH4,
+	UOF_HEIGHT4,
+	UOF_CDEPTH,
+	UOF_CTYPE,
+	UOF_ONLY_ZERO3,
+	UOF_SKIP4,
+
+	UOF_CHUNK_LEN,
+	UOF_CHUNK_TYPE,
+	UOF_INSIDE,
+
+	UOF_SKIP_CHUNK_LEN,
+} upng_outer_framing_t;
+
+typedef struct inflator_ctx {
+	unsigned int		clenc[NUM_CODE_LENGTH_CODES];
+	unsigned int		bitlen[NUM_DEFLATE_CODE_SYMBOLS];
+	unsigned int		bitlenD[NUM_DISTANCE_SYMBOLS];
+	huff_t			clct_buffer[CODE_LENGTH_BUFFER_SIZE];
+	huff_t			ct_buffer[DEFLATE_CODE_BUFFER_SIZE];
+	huff_t			ctD_buffer[DISTANCE_BUFFER_SIZE];
+
+	lws_upng_t		*upng;
+
+	const uint8_t		*in;
+	uint8_t			*out;
+
+	htree_t			clct;
+	htree_t			ct;
+	htree_t			ctD;
+
+	size_t			bp;
+	size_t			inpos;
+	size_t			inlen;
+	size_t			outpos;
+	size_t			outpos_linear;
+	size_t			consumed_linear;
+	size_t			outlen;
+	size_t			length;
+	size_t			start;
+	size_t			forward;
+	size_t			backward;
+	size_t			exbits;
+	size_t			bypl;
+
+	upng_inflate_states_t	state;
+
+	unsigned int		len;
+	unsigned int		nlen;
+	unsigned int		n;
+	unsigned int		hlit;
+	unsigned int		hdist;
+	unsigned int		hclen;
+	unsigned int		i;
+	unsigned int		t;
+	unsigned int		codeD;
+	unsigned int		distance;
+	unsigned int		exbitsD;
+	unsigned int		code;
+	unsigned int		treepos;
+
+	unsigned int		read_bits_shifter;
+	unsigned int		read_bits_limit;
+	unsigned int 		read_bits_i;
+
+	unsigned int		info_size;
+
+	uint8_t			subsequent;
+	uint8_t			btype;
+	uint8_t			done;
+
+	char			read_bits_ongoing;
+} inflator_ctx_t;
+
+struct lws_upng_t {
+	struct upng_unfline	u;
+	inflator_ctx_t		inf;
+
+	unsigned int		width;
+	unsigned int		height;
+
+	upng_color		color_type;
+	unsigned int		color_depth;
+	lws_upng_format_t	format;
+
+	const uint8_t		*chunk;
+
+	int			sctr;
+	uint32_t		acc;
+
+	uint32_t		chunklen;
+	uint32_t		ctype;
+
+	upng_outer_framing_t	of;
+
+	uint8_t			no_more_input;
+};
+
+static lws_upng_ret_t
+lws_upng_decode(lws_upng_t *upng, const uint8_t **buf, size_t *size);
+
+static const huff_t huff_length_base[] = {
+	/*the base lengths represented by codes 257-285 */
+	3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59,
+	67, 83, 99, 115, 131, 163, 195, 227, 258
+};
+
+static const huff_t huff_length_extra[] = {
+	/*the extra bits used by codes 257-285 (added to base length) */
+	0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4,
+	5, 5, 5, 5, 0
+};
+
+static const huff_t huff_distance_base[] = {
+	/*
+	 * The base backwards distances (the bits of distance codes appear
+	 * after length codes and use their own huffman tree)
+	 */
+	1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385,
+	513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577
+};
+
+static const huff_t huff_distance_extra[] = {
+	/* the extra bits of backwards distances (added to base) */
+	0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10,
+	10, 11, 11, 12, 12, 13, 13
+};
+
+static const huff_t huff_cl_cl[] = {
+	/*
+	 * The order in which "code length alphabet code lengths" are stored,
+	 * out of this the huffman tree of the dynamic huffman tree lengths
+	 * is generated
+	 */
+	16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15
+};
+
+static const huff_t FIXED_DEFLATE_CODE_TREE[NUM_DEFLATE_CODE_SYMBOLS * 2] = {
+	289, 370, 290, 307, 546, 291, 561, 292, 293, 300, 294, 297, 295, 296,
+	0, 1, 2, 3, 298, 299, 4, 5, 6, 7, 301, 304, 302, 303, 8, 9, 10, 11, 305,
+	306, 12, 13, 14, 15, 308, 339, 309, 324, 310, 317, 311, 314, 312, 313,
+	16, 17, 18, 19, 315, 316, 20, 21, 22, 23, 318, 321, 319, 320, 24, 25,
+	26, 27, 322, 323, 28, 29, 30, 31, 325, 332, 326, 329, 327, 328, 32, 33,
+	34, 35, 330, 331, 36, 37, 38, 39, 333, 336, 334, 335, 40, 41, 42, 43,
+	337, 338, 44, 45, 46, 47, 340, 355, 341, 348, 342, 345, 343, 344, 48,
+	49, 50, 51, 346, 347, 52, 53, 54, 55, 349, 352, 350, 351, 56, 57, 58,
+	59, 353, 354, 60, 61, 62, 63, 356, 363, 357, 360, 358, 359, 64, 65, 66,
+	67, 361, 362, 68, 69, 70, 71, 364, 367, 365, 366, 72, 73, 74, 75, 368,
+	369, 76, 77, 78, 79, 371, 434, 372, 403, 373, 388, 374, 381, 375, 378,
+	376, 377, 80, 81, 82, 83, 379, 380, 84, 85, 86, 87, 382, 385, 383, 384,
+	88, 89, 90, 91, 386, 387, 92, 93, 94, 95, 389, 396, 390, 393, 391, 392,
+	96, 97, 98, 99, 394, 395, 100, 101, 102, 103, 397, 400, 398, 399, 104,
+	105, 106, 107, 401, 402, 108, 109, 110, 111, 404, 419, 405, 412, 406,
+	409, 407, 408, 112, 113, 114, 115, 410, 411, 116, 117, 118, 119, 413,
+	416, 414, 415, 120, 121, 122, 123, 417, 418, 124, 125, 126, 127, 420,
+	427, 421, 424, 422, 423, 128, 129, 130, 131, 425, 426, 132, 133, 134,
+	135, 428, 431, 429, 430, 136, 137, 138, 139, 432, 433, 140, 141, 142,
+	143, 435, 483, 436, 452, 568, 437, 438, 445, 439, 442, 440, 441, 144,
+	145, 146, 147, 443, 444, 148, 149, 150, 151, 446, 449, 447, 448, 152,
+	153, 154, 155, 450, 451, 156, 157, 158, 159, 453, 468, 454, 461, 455,
+	458, 456, 457, 160, 161, 162, 163, 459, 460, 164, 165, 166, 167, 462,
+	465, 463, 464, 168, 169, 170, 171, 466, 467, 172, 173, 174, 175, 469,
+	476, 470, 473, 471, 472, 176, 177, 178, 179, 474, 475, 180, 181, 182,
+	183, 477, 480, 478, 479, 184, 185, 186, 187, 481, 482, 188, 189, 190,
+	191, 484, 515, 485, 500, 486, 493, 487, 490, 488, 489, 192, 193, 194,
+	195, 491, 492, 196, 197, 198, 199, 494, 497, 495, 496, 200, 201, 202,
+	203, 498, 499, 204, 205, 206, 207, 501, 508, 502, 505, 503, 504, 208,
+	209, 210, 211, 506, 507, 212, 213, 214, 215, 509, 512, 510, 511, 216,
+	217, 218, 219, 513, 514, 220, 221, 222, 223, 516, 531, 517, 524, 518,
+	521, 519, 520, 224, 225, 226, 227, 522, 523, 228, 229, 230, 231, 525,
+	528, 526, 527, 232, 233, 234, 235, 529, 530, 236, 237, 238, 239, 532,
+	539, 533, 536, 534, 535, 240, 241, 242, 243, 537, 538, 244, 245, 246,
+	247, 540, 543, 541, 542, 248, 249, 250, 251, 544, 545, 252, 253, 254,
+	255, 547, 554, 548, 551, 549, 550, 256, 257, 258, 259, 552, 553, 260,
+	261, 262, 263, 555, 558, 556, 557, 264, 265, 266, 267, 559, 560, 268,
+	269, 270, 271, 562, 565, 563, 564, 272, 273, 274, 275, 566, 567, 276,
+	277, 278, 279, 569, 572, 570, 571, 280, 281, 282, 283, 573, 574, 284,
+	285, 286, 287, 0, 0
+};
+
+static const huff_t FIXED_DISTANCE_TREE[] = {
+	33, 48, 34, 41, 35, 38, 36, 37,
+	0, 1, 2, 3, 39, 40, 4, 5,
+	6, 7, 42, 45, 43, 44, 8, 9,
+	10, 11, 46, 47, 12, 13, 14, 15,
+	49, 56, 50, 53, 51, 52, 16, 17,
+	18, 19, 54, 55, 20, 21, 22, 23,
+	57, 60, 58, 59, 24, 25, 26, 27,
+	61, 62, 28, 29, 30, 31, 0, 0
+};
+
+static lws_upng_ret_t
+read_bit(inflator_ctx_t *inf, uint8_t *bits)
+{
+	size_t bo = inf->bp >> 3;
+
+	if (bo + inf->inpos >= inf->inlen)
+		return LWS_UPNG_WANT_INPUT;
+
+	*bits = (uint8_t)((*(inf->in + inf->inpos + bo) >> (inf->bp & 7)) & 1);
+
+	inf->bp++;
+
+	return LWS_UPNG_OK;
+}
+
+/* Stateful, so it can pick up after running out of input partway thru */
+
+static lws_upng_ret_t
+read_bits(inflator_ctx_t *inf, unsigned int nbits, unsigned int *bits)
+{
+	lws_upng_ret_t r;
+	uint8_t b;
+
+	if (!inf->read_bits_ongoing) {
+		inf->read_bits_ongoing	= 1;
+		inf->read_bits_shifter	= 0;
+		inf->read_bits_limit	= nbits;
+		inf->read_bits_i	= 0;
+	}
+
+	while (inf->read_bits_i < inf->read_bits_limit) {
+		 r =read_bit(inf, &b);
+		 if (r)
+			 return r;
+
+		 inf->read_bits_shifter = inf->read_bits_shifter | (unsigned int)(b << inf->read_bits_i);
+
+		 inf->read_bits_i++;
+	}
+
+	inf->read_bits_ongoing = 0;
+	*bits = inf->read_bits_shifter;
+
+	return LWS_UPNG_OK;
+}
+
+static lws_upng_ret_t
+read_byte(inflator_ctx_t *inf, uint8_t *byte)
+{
+	size_t bo;
+
+	while (inf->bp & 7)
+		inf->bp++;
+
+	bo = inf->bp >> 3;
+
+	if (bo + inf->inpos >= inf->inlen)
+		return LWS_UPNG_WANT_INPUT;
+
+	*byte = *(inf->in + inf->inpos + bo);
+
+	inf->bp += 8;
+
+	return LWS_UPNG_OK;
+}
+
+/* buffer must be numcodes*2 in size! */
+static void
+huffman_tree_init(htree_t *tree, huff_t *buffer, uint16_t numcodes,
+		  uint16_t maxbitlen)
+{
+	tree->tree2d = buffer;
+
+	tree->numcodes = numcodes;
+	tree->maxbitlen = maxbitlen;
+}
+
+#define EMPTY 32767
+
+/*
+ * Given the code lengths (as stored in the PNG file), generate the tree as
+ * defined by Deflate. maxbitlen is the maximum bits that a code in the tree
+ * can have.
+ */
+static lws_upng_ret_t
+huffman_tree_create_lengths(lws_upng_t *upng, htree_t *tree,
+			    const unsigned *bitlen)
+{
+	unsigned int tree1d[MAX_SYMBOLS], blcount[MAX_BIT_LENGTH],
+		     nextcode[MAX_BIT_LENGTH + 1];
+	unsigned int bits, n, i, nodefilled = 0, treepos = 0;
+
+	memset(blcount, 0, sizeof(blcount));
+	memset(nextcode, 0, sizeof(nextcode));
+
+	for (bits = 0; bits < tree->numcodes; bits++)
+		blcount[bitlen[bits]]++;
+
+	for (bits = 1; bits <= (unsigned int)tree->maxbitlen; bits++)
+		nextcode[bits] = (nextcode[bits - 1] + blcount[bits - 1]) << 1;
+
+	for (n = 0; n < tree->numcodes; n++)
+		if (bitlen[n])
+			tree1d[n] = nextcode[bitlen[n]]++;
+
+	for (n = 0; n < tree->numcodes * 2; n++)
+		tree->tree2d[n] = EMPTY;
+
+	for (n = 0; n < tree->numcodes; n++) {	/* the codes */
+		for (i = 0; i < bitlen[n]; i++) { /* the bits for this code */
+			uint8_t bit = (uint8_t)((tree1d[n] >>
+						(bitlen[n] - i - 1)) & 1);
+
+			/* check if oversubscribed */
+			if (treepos > tree->numcodes - 2u)
+				return LWS_UPNG_FATAL + 1;
+
+			if (tree->tree2d[2 * treepos + bit] == EMPTY) {
+				if (i + 1 == bitlen[n]) { /* ... last bit */
+					tree->tree2d[2 * treepos + bit] = (huff_t)n;
+					treepos = 0;
+				} else {
+					nodefilled++;
+					tree->tree2d[2 * treepos + bit] =
+					  (huff_t)(nodefilled + tree->numcodes);
+					treepos = nodefilled;
+				}
+			} else
+				treepos = (unsigned int)(tree->tree2d[2 * treepos + bit] -
+						tree->numcodes);
+		}
+	}
+
+	for (n = 0; n < tree->numcodes * 2u; n++)
+		if (tree->tree2d[n] == EMPTY)
+			tree->tree2d[n] = 0;
+
+	return LWS_UPNG_OK;
+}
+
+static lws_upng_ret_t
+huffman_decode_symbol(inflator_ctx_t *inf, const htree_t *ct, unsigned int *uct)
+{
+	lws_upng_ret_t r;
+	uint8_t bit;
+
+	do {
+		r = read_bit(inf, &bit);
+		if (r)
+			return r;
+
+		*uct = ct->tree2d[(inf->treepos << 1) | bit];
+		if (*uct < ct->numcodes)
+			return LWS_UPNG_OK;
+
+		inf->treepos = *uct - ct->numcodes;
+		if (inf->treepos >= ct->numcodes)
+			return LWS_UPNG_FATAL + 2;
+	} while (1);
+}
+
+static lws_upng_ret_t
+uz_inflate_data(inflator_ctx_t *inf)
+{
+	unsigned int count, val, tu;
+	uint8_t t, done = 0;
+	lws_upng_ret_t r;
+	size_t virt;
+
+	while (!done) {
+		switch (inf->state) {
+		case UPNS_ID_BL_GB_DONE:
+			r = read_bit(inf, &inf->done);
+			if (r)
+				return r;
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPEb0:
+			r = read_bit(inf, &inf->btype);
+			if (r)
+				return r;
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPEb1:
+			r = read_bit(inf, &t);
+			if (r)
+				return r;
+
+			inf->btype |= (uint8_t)(t << 1);
+
+			if (inf->btype == 3)
+				return LWS_UPNG_FATAL + 3;
+
+			inf->i = 0;
+
+			inf->state = UPNS_ID_BL_GB_BTYPE_0 + inf->btype;
+			continue;
+
+		case UPNS_ID_BL_GB_BTYPE_0: /* no compression */
+			r = read_byte(inf, &t);
+			if (r)
+				return r;
+
+			inf->len = t;
+			inf->state = UPNS_ID_BL_GB_BTYPE_0a;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_0a:
+			r = read_byte(inf, &t);
+			if (r)
+				return r;
+
+			inf->len = inf->len | (unsigned int)(t << 8);
+			inf->state++;
+			/* fallthru */
+
+		case UPNS_ID_BL_GB_BTYPE_0b:
+			r = read_byte(inf, &t);
+			if (r)
+				return r;
+
+			inf->nlen = t;
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_0c:
+			r = read_byte(inf, &t);
+			if (r)
+				return r;
+
+			inf->nlen = inf->nlen | (unsigned int)(t << 8);
+
+			if (inf->len + inf->nlen != 65535)
+				return LWS_UPNG_FATAL + 4;
+
+			inf->state++;
+			inf->n = 0;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_0d:
+
+			if (inf->n < inf->len) {
+
+				r = read_byte(inf, &t);
+				if (r)
+					return r;
+
+				inf->out[inf->outpos++] = t;
+				if (inf->outpos >= inf->outlen)
+					inf->outpos = 0;
+				inf->outpos_linear++;
+
+				if (inf->outpos_linear - inf->consumed_linear >=
+						inf->bypl + 1)
+					return LWS_UPNG_WANT_OUTPUT;
+
+				inf->n++;
+				continue;
+			}
+
+			inf->treepos = 0;
+			inf->state = UPNS_ID_BL_GB_SPIN;
+			continue;
+
+		case UPNS_ID_BL_GB_BTYPE_1: /* fixed trees */
+			huffman_tree_init(&inf->ct,
+					  (huff_t *)FIXED_DEFLATE_CODE_TREE,
+					  NUM_DEFLATE_CODE_SYMBOLS,
+					  DEFLATE_CODE_BITLEN);
+			huffman_tree_init(&inf->ctD,
+					  (huff_t *)FIXED_DISTANCE_TREE,
+					  NUM_DISTANCE_SYMBOLS,
+					  DISTANCE_BITLEN);
+
+			lwsl_notice("%s: fixed tree init\n", __func__);
+			inf->treepos = 0;
+			inf->state = UPNS_ID_BL_GB_SPIN;
+			continue;
+
+		case UPNS_ID_BL_GB_BTYPE_2: /* dynamic trees */
+			huffman_tree_init(&inf->ct, inf->ct_buffer,
+					  NUM_DEFLATE_CODE_SYMBOLS,
+					  DEFLATE_CODE_BITLEN);
+			huffman_tree_init(&inf->ctD, inf->ctD_buffer,
+					  NUM_DISTANCE_SYMBOLS,
+					  DISTANCE_BITLEN);
+			huffman_tree_init(&inf->clct, inf->clct_buffer,
+					  NUM_CODE_LENGTH_CODES,
+					  CODE_LENGTH_BITLEN);
+
+			/* clear bitlen arrays */
+			memset(inf->bitlen, 0, sizeof(inf->bitlen));
+			memset(inf->bitlenD, 0, sizeof(inf->bitlenD));
+
+			inf->state = UPNS_ID_BL_GB_BTYPE_2a;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_2a:
+			r = read_bits(inf, 5, &inf->hlit);
+			if (r)
+				return r;
+			inf->hlit += 257;
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_2b:
+			r = read_bits(inf, 5, &inf->hdist);
+			if (r)
+				return r;
+			inf->hdist++;
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_2c:
+			r = read_bits(inf, 4, &inf->hclen);
+			if (r)
+				return r;
+			inf->hclen += 4;
+			inf->state = UPNS_ID_BL_GB_BTYPE_2d;
+			inf->i = 0;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_2d:
+			if (inf->i < NUM_CODE_LENGTH_CODES) {
+				if (inf->i < inf->hclen) {
+					r = read_bits(inf, 3,
+						&inf->clenc[huff_cl_cl[inf->i]]);
+					if (r)
+						return r;
+				} else
+					/*if not, it must stay 0 */
+					inf->clenc[huff_cl_cl[inf->i]] = 0;
+
+				inf->i++;
+				continue;
+			}
+
+			r = huffman_tree_create_lengths(inf->upng, &inf->clct,
+							inf->clenc);
+			if (r)
+				return r;
+
+			inf->i = 0;
+			inf->state = UPNS_ID_BL_GB_BTYPE_2e;
+			inf->treepos = 0;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_BTYPE_2e:
+
+			if (inf->i >= inf->hlit + inf->hdist) {
+				if (inf->bitlen[256] == 0)
+					return LWS_UPNG_FATAL + 6;
+
+				if (huffman_tree_create_lengths(inf->upng,
+								&inf->ct,
+								inf->bitlen))
+					return LWS_UPNG_FATAL + 7;
+
+				if (huffman_tree_create_lengths(inf->upng,
+								&inf->ctD,
+								inf->bitlenD))
+					return LWS_UPNG_FATAL + 8;
+
+				inf->treepos = 0;
+				inf->state = UPNS_ID_BL_GB_SPIN;
+				continue;
+			}
+
+			r = huffman_decode_symbol(inf, &inf->clct, &inf->code);
+			if (r)
+				return r;
+
+			switch (inf->code) {
+			case 16:
+				inf->state = UPNS_ID_BL_GB_BTYPE_2_16;
+				continue;
+			case 17:
+				inf->state = UPNS_ID_BL_GB_BTYPE_2_17;
+				continue;
+			case 18:
+				inf->state = UPNS_ID_BL_GB_BTYPE_2_18;
+				continue;
+			default:
+				if (inf->code > 15)
+					return LWS_UPNG_FATAL + 9;
+
+				if (inf->i < inf->hlit)
+					inf->bitlen[inf->i] = inf->code;
+				else
+					inf->bitlenD[inf->i - inf->hlit] =
+								inf->code;
+
+				inf->i++;
+				inf->treepos = 0;
+
+				/* stay in 2e */
+				continue;
+			}
+
+		case UPNS_ID_BL_GB_BTYPE_2_16: /* repeat previous */
+			r = read_bits(inf, 2, &tu);
+			if (r)
+				return r;
+			count = tu + 3;
+
+			if ((inf->i - 1) < inf->hlit)
+				val = inf->bitlen[inf->i - 1];
+			else
+				val = inf->bitlenD[inf->i - inf->hlit - 1];
+
+			goto fill;
+
+		case UPNS_ID_BL_GB_BTYPE_2_17: /*repeat "0" 3-10 times */
+			r = read_bits(inf, 3, &tu);
+			if (r)
+				return r;
+			count = tu + 3;
+
+			val = 0;
+			goto fill;
+
+		case UPNS_ID_BL_GB_BTYPE_2_18: /*repeat "0" 11-138 times */
+			r = read_bits(inf, 7, &tu);
+			if (r)
+				return r;
+			count = tu + 11;
+			val = 0;
+fill:
+			if (inf->i + count > inf->hlit + inf->hdist)
+				return LWS_UPNG_FATAL + 10;
+
+			{
+				unsigned int n;
+
+				for (n = 0; n < count; n++) {
+
+					if (inf->i < inf->hlit)
+						inf->bitlen[inf->i] = val;
+					else
+						inf->bitlenD[inf->i - inf->hlit] = val;
+
+					inf->i++;
+				}
+			}
+			inf->state = UPNS_ID_BL_GB_BTYPE_2e;
+			inf->treepos = 0;
+			continue;
+
+
+		case UPNS_ID_BL_GB_SPIN:
+
+			r = huffman_decode_symbol(inf, &inf->ct, &inf->code);
+			if (r)
+				return r;
+
+			if (inf->code >= FIRST_LENGTH_CODE_INDEX &&
+			    inf->code - FIRST_LENGTH_CODE_INDEX <
+					    LWS_ARRAY_SIZE(huff_length_base))
+				inf->length = huff_length_base[inf->code -
+			                               FIRST_LENGTH_CODE_INDEX];
+			else
+				inf->length = 0;
+
+			if (inf->code == 256) {
+				/*
+				 * We're finished with this huffman block, we
+				 * need to go back up a level
+				 */
+				done = inf->done;
+				inf->state = UPNS_ID_BL_GB_DONE;
+				continue;
+			}
+
+			if (inf->code <= 255) {
+				inf->state = UPNS_ID_BL_GB_SPINa;
+				continue;
+			}
+
+			if (inf->code < FIRST_LENGTH_CODE_INDEX ||
+			    inf->code > LAST_LENGTH_CODE_INDEX) {
+				inf->treepos = 0;
+				continue;
+			}
+
+			inf->exbits = huff_length_extra[inf->code -
+			                                FIRST_LENGTH_CODE_INDEX];
+			inf->state = UPNS_ID_BL_GB_SPINb;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_SPINb:
+			r = read_bits(inf, (unsigned int)inf->exbits, &tu);
+			if (r)
+				return r;
+
+			inf->length += tu;
+			inf->state++;
+			inf->treepos = 0;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_SPINc:
+
+			/* part 3: get distance code */
+
+			r = huffman_decode_symbol(inf, &inf->ctD, &inf->codeD);
+			if (r)
+				return r;
+
+			/* invalid distance code (30-31 are never used) */
+			if (inf->codeD > 29)
+				return LWS_UPNG_FATAL + 11;
+
+			inf->distance = huff_distance_base[inf->codeD];
+
+			/* part 4: get extra bits from distance */
+
+			inf->exbitsD = huff_distance_extra[inf->codeD];
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_SPINd:
+
+			r = read_bits(inf, inf->exbitsD, &tu);
+			if (r)
+				return r;
+
+			inf->distance += tu;
+
+			if (inf->distance > inf->info_size) {
+				lwsl_err("%s: distance %lu\n", __func__,
+						(unsigned long)inf->distance);
+				assert(0);
+			}
+
+			/*
+			 * Part 5: fill in all the out[n] values based
+			 * on the length and dist
+			 */
+			inf->start = inf->outpos;
+			inf->forward = 0;
+			inf->backward = inf->distance; /* from inf->start */
+
+			inf->state++;
+
+			/* fallthru */
+		case UPNS_ID_BL_GB_SPINe:
+
+			if (inf->forward >= inf->length) {
+				inf->treepos = 0;
+				inf->state = UPNS_ID_BL_GB_SPIN;
+				continue;
+			}
+
+			if (inf->backward <= inf->start)
+				virt = inf->start - inf->backward;
+			else /* wrapped... backward >= start */
+				virt = inf->info_size -
+					(inf->backward - inf->start);
+
+			if (virt >= inf->info_size)
+				lwsl_err("virt %d\n", (int)virt);
+
+			inf->out[inf->outpos++] = inf->out[virt];
+			if (inf->outpos >= inf->outlen)
+				inf->outpos = 0;
+
+			inf->outpos_linear++;
+			inf->backward--;
+
+			if (!inf->backward)
+				inf->backward = inf->distance;
+
+			inf->forward++;
+
+			if (inf->outpos_linear - inf->consumed_linear >=
+								inf->bypl + 1)
+				return LWS_UPNG_WANT_OUTPUT;
+
+			continue;
+
+		case UPNS_ID_BL_GB_SPINa:
+
+			inf->out[inf->outpos++] = (uint8_t)inf->code;
+			if (inf->outpos >= inf->outlen)
+				inf->outpos = 0;
+
+			inf->outpos_linear++;
+			inf->treepos = 0;
+			inf->state = UPNS_ID_BL_GB_SPIN;
+
+			if (inf->outpos_linear - inf->consumed_linear >=
+								inf->bypl + 1)
+				return LWS_UPNG_WANT_OUTPUT;
+
+			continue;
+		}
+	}
+
+	return LWS_UPNG_OK;
+}
+
+static int
+paeth(int a, int b, int c)
+{
+	int p = a + b - c;
+	int pa = p > a ? p - a : a - p;
+	int pb = p > b ? p - b : b - p;
+	int pc = p > c ? p - c : c - p;
+
+	if (pa <= pb && pa <= pc)
+		return a;
+
+	if (pb <= pc)
+		return b;
+
+	return c;
+}
+
+static lws_upng_ret_t
+unfilter_scanline(lws_upng_t *u)
+{
+	struct upng_unfline *uf = &u->u;
+	unsigned long i;
+
+	switch (uf->filterType) {
+	case 0: /* None */
+		for (i = 0; i < uf->bypl; i++)
+			uf->recon[i] = u->inf.out[(uf->sp + i) %
+			                            u->inf.info_size];
+		break;
+	case 1: /* Sub */
+		for (i = 0; i <  uf->bypp; i++)
+			uf->recon[i] = u->inf.out[(uf->sp + i) %
+			                            u->inf.info_size];
+
+		for (i = uf->bypp; i < uf->bypl; i++)
+			uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+			                            u->inf.info_size] +
+				uf->recon[i - uf->bypp]);
+		break;
+	case 2: /* Up */
+		if (uf->y)
+			for (i = 0; i < uf->bypl; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				            u->inf.info_size] + uf->precon[i]);
+		else
+			for (i = 0; i < uf->bypl; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				                          u->inf.info_size]);
+		break;
+	case 3: /* Average */
+		if (uf->y) {
+			for (i = 0; i < uf->bypp; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				        u->inf.info_size] + uf->precon[i] / 2);
+			for (i = uf->bypp; i < uf->bypl; i++)
+				uf->recon[i] = (uint8_t)
+					(u->inf.out[(uf->sp + i) %
+					            u->inf.info_size] +
+					((uf->recon[i - uf->bypp] +
+							uf->precon[i]) / 2));
+		} else {
+			for (i = 0; i < uf->bypp; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				                         u->inf.info_size]);
+			for (i = uf->bypp; i < uf->bypl; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				                         u->inf.info_size] +
+					uf->recon[i - uf->bypp] / 2);
+		}
+		break;
+	case 4: /* Paeth */
+		if (uf->y) {
+			for (i = 0; i < uf->bypp; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				                          u->inf.info_size] +
+					paeth(0, uf->precon[i], 0));
+			for (i = uf->bypp; i < uf->bypl; i++)
+				uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+				                          u->inf.info_size] +
+					paeth(uf->recon[i - uf->bypp],
+							uf->precon[i],
+							uf->precon[i - uf->bypp]));
+			break;
+		}
+
+		for (i = 0; i < uf->bypp; i++)
+			uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+			                            u->inf.info_size]);
+		for (i = uf->bypp; i < uf->bypl; i++)
+			uf->recon[i] = (uint8_t)(u->inf.out[(uf->sp + i) %
+			                                u->inf.info_size] +
+				paeth(uf->recon[i - uf->bypp], 0, 0));
+		break;
+	default:
+		lwsl_err("%s: line start is broken %d\n", __func__,
+				uf->filterType);
+		return LWS_UPNG_FATAL + 12;
+	}
+
+	u->inf.consumed_linear += uf->bypl;
+
+	return LWS_UPNG_OK;
+}
+
+lws_upng_ret_t
+lws_upng_emit_next_line(lws_upng_t *u, const uint8_t **ppix,
+		    const uint8_t **pos, size_t *size)
+{
+	struct upng_unfline	*uf = &u->u;
+	unsigned long		obp;
+	lws_upng_ret_t		ret = LWS_UPNG_OK;
+
+	*ppix = NULL;
+
+	if (u->height && uf->y >= u->height)
+		goto out;
+
+	/*
+	 * The decoder emits into the 32KB window ringbuffer, if we don't
+	 * already have at least one line's worth of output in there, we'll
+	 * have to do more inflation
+	 */
+
+	if (u->inf.outpos_linear - u->inf.consumed_linear < uf->bypl + 1) {
+		ret = lws_upng_decode(u, pos, size);
+		if ((!*size && ret == LWS_UPNG_WANT_INPUT) ||
+		    ret >= LWS_UPNG_FATAL || !u->inf.outpos_linear)
+			return ret;
+
+		assert(u->inf.info_size);
+		assert(uf->bypl + 1);
+	}
+
+	if (u->inf.outpos_linear - u->inf.consumed_linear < uf->bypl + 1)
+		return ret;
+
+	obp		= uf->alt ? uf->bypl : 0;
+	uf->precon	= uf->alt ? uf->lines : uf->lines + uf->bypl;
+	uf->recon	= &uf->lines[obp];
+	*ppix		= uf->recon;
+	uf->filterType	= uf->in[(u->inf.consumed_linear++) % u->inf.info_size];
+	uf->sp		= u->inf.consumed_linear % u->inf.info_size;
+
+	if (unfilter_scanline(u) != LWS_UPNG_OK) {
+		ret = LWS_UPNG_FATAL + 13;
+
+		goto out;
+	}
+
+	if (uf->padded) {
+		unsigned long x;
+
+		for (x = 0; x < u->width * uf->bpp; x++) {
+			uint8_t bit = (uint8_t)((uf->in[(uf->ibp) >> 3] >>
+						(7 - ((uf->ibp) & 7))) & 1);
+			uf->ibp++;
+
+			if (!bit)
+				uf->lines[obp >> 3] &=
+					(uint8_t)(~(1 << (7 - (obp & 7))));
+			else
+				uf->lines[obp >> 3] = (uint8_t)(uf->lines[obp >> 3] |
+						(uint8_t)(1 << (7 - (obp & 7))));
+
+			obp++;
+		}
+
+		uf->ibp += uf->diff;
+	}
+
+out:
+	uf->alt ^= 1;
+	uf->y++;
+
+	return ret;
+}
+
+static lws_upng_format_t
+determine_format(lws_upng_t* upng) {
+	switch (upng->color_type) {
+	case LWS_UPNG_LUM:
+		switch (upng->color_depth) {
+		case 1:
+			return LWS_UPNG_LUMINANCE1;
+		case 2:
+			return LWS_UPNG_LUMINANCE2;
+		case 4:
+			return LWS_UPNG_LUMINANCE4;
+		case 8:
+			return LWS_UPNG_LUMINANCE8;
+		default:
+			return LWS_UPNG_BADFORMAT;
+		}
+	case LWS_UPNG_RGB:
+		switch (upng->color_depth) {
+		case 8:
+			return LWS_UPNG_RGB8;
+		case 16:
+			return LWS_UPNG_RGB16;
+		default:
+			return LWS_UPNG_BADFORMAT;
+		}
+	case LWS_UPNG_LUMA:
+		switch (upng->color_depth) {
+		case 1:
+			return LWS_UPNG_LUMINANCE_ALPHA1;
+		case 2:
+			return LWS_UPNG_LUMINANCE_ALPHA2;
+		case 4:
+			return LWS_UPNG_LUMINANCE_ALPHA4;
+		case 8:
+			return LWS_UPNG_LUMINANCE_ALPHA8;
+		default:
+			return LWS_UPNG_BADFORMAT;
+		}
+	case LWS_UPNG_RGBA:
+		switch (upng->color_depth) {
+		case 8:
+			return LWS_UPNG_RGBA8;
+		case 16:
+			return LWS_UPNG_RGBA16;
+		default:
+			return LWS_UPNG_BADFORMAT;
+		}
+	default:
+		return LWS_UPNG_BADFORMAT;
+	}
+}
+
+static const uint8_t magic[] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+static lws_upng_ret_t
+lws_upng_decode(lws_upng_t* u, const uint8_t **_pos, size_t *_size)
+{
+	const uint8_t *pos = *_pos, *end = pos + *_size;
+	lws_upng_ret_t r = LWS_UPNG_FATAL + 60;
+	size_t m;
+
+	if (u->of == UOF_INSIDE && !u->inf.in) {
+		u->inf.inpos = 0;
+		u->inf.in = pos;
+		u->inf.bp = 0;
+		m = lws_ptr_diff_size_t(end, pos);
+		if (m > u->chunklen)
+			m = u->chunklen;
+		u->inf.inlen = m;
+	}
+
+	while (!u->no_more_input &&
+	       ((u->of == UOF_INSIDE && _pos == NULL) || pos < end)) {
+		switch (u->of) {
+		case UOF_MAGIC:
+			if (*pos++ != magic[u->sctr++])
+				return LWS_UPNG_FATAL + 17;
+			if (u->sctr == sizeof(magic)) {
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_SKIP:
+			pos++;
+			if (++u->sctr == 4) {
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_TYPE4:
+			u->acc = (u->acc << 8) | *pos++;
+			if (++u->sctr == 4) {
+				lwsl_notice("%s: hdr %08X\n", __func__, (unsigned int)u->acc);
+				if (u->acc != LWS_FOURCC('I','H','D','R'))
+					return LWS_UPNG_FATAL + 18;
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_WIDTH4:
+			u->acc = (u->acc << 8) | *pos++;
+			if (++u->sctr == 4) {
+				u->width = u->acc;
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_HEIGHT4:
+			u->acc = (u->acc << 8) | *pos++;
+			if (++u->sctr == 4) {
+				u->height = u->acc;
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_CDEPTH:
+			u->color_depth =*pos++;
+			u->of++;
+			break;
+
+		case UOF_CTYPE:
+			u->color_type = *pos++;
+			lwsl_notice("w %d, h %d, depth %d, type %d\n",
+					u->width, u->height,
+					u->color_depth, u->color_type);
+			u->format = determine_format(u);
+			if (u->format == LWS_UPNG_BADFORMAT)
+				return LWS_UPNG_FATAL + 19;
+			u->of++;
+			break;
+
+		case UOF_ONLY_ZERO3:
+			if (*pos++)
+				return LWS_UPNG_FATAL + 20;
+			if (++u->sctr == 3) {
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_SKIP4:
+			pos++;
+			if (++u->sctr != 4)
+				break;
+
+			/* takes us to +33 */
+
+			memset(&u->inf, 0, sizeof(u->inf));
+
+			/* 32KB gz sliding window */
+			u->inf.info_size = 32768 + 512;
+			u->u.bpp	 = lws_upng_get_bpp(u);
+			if (!u->u.bpp)
+				return LWS_UPNG_FATAL + 14;
+
+			u->u.y		= 0;
+			u->u.ibp	= 0;
+			u->u.bypp	= (u->u.bpp + 7) / 8;
+			u->inf.bypl = u->u.bypl	= u->width * u->u.bypp;
+
+			if (!u->inf.out) {
+				u->inf.out = (uint8_t *)lws_malloc(
+						(u->u.bypl * 2) +
+						u->inf.info_size, __func__);
+				if (!u->inf.out) {
+					lwsl_notice("%s: inf malloc OOM\n",
+								__func__);
+					return LWS_UPNG_FATAL + 28;
+				}
+				u->u.lines = u->inf.out + u->inf.info_size;
+			}
+
+			u->inf.outlen	= u->inf.info_size;
+			u->inf.outpos	= 0;
+			u->inf.state	= UPNS_ID_BL_GB_DONE;
+			u->inf.upng	= u;
+			u->u.in		= u->inf.out;
+
+			u->u.alt	= 0; /* which of the two lines to write to */
+			u->u.padded	= u->u.bpp < 8 &&
+					  u->width * u->u.bpp !=
+					  ((u->width * u->u.bpp + 7) / 8) * 8;
+			u->u.diff	= (((u->width * u->u.bpp + 7) / 8) * 8) -
+						(u->width * u->u.bpp);
+
+			u->of++;
+			u->sctr = 0;
+			break;
+
+		case UOF_CHUNK_LEN:
+			u->chunklen = (u->chunklen << 8) | *pos++;
+			if (++u->sctr == 4) {
+				u->of++;
+				u->sctr = 0;
+			}
+			break;
+
+		case UOF_CHUNK_TYPE:
+			u->ctype = (u->ctype << 8) | *pos++;
+			if (++u->sctr != 4)
+				break;
+			u->sctr = 0;
+			if (u->ctype == LWS_FOURCC('I','E','N','D')) {
+				u->no_more_input = 1;
+				break;
+			}
+			if (u->ctype != LWS_FOURCC('I','D','A','T')) {
+				if (!(u->ctype & (32 << 24)))
+					/* says it is critical... */
+					 return LWS_UPNG_FATAL + 27;
+
+				u->chunklen += 4; /* chunk-end CRC */
+
+				/* noncritical, skip */
+				u->of = UOF_SKIP_CHUNK_LEN;
+				break;
+			}
+
+			if (u->chunklen < 2)
+				return LWS_UPNG_FATAL + 31;
+
+			/* it's a usable IDAT */
+
+			if (!u->inf.subsequent)
+				u->inf.inpos = 2;
+			else
+				u->inf.inpos = 0;
+
+			m = lws_ptr_diff_size_t(end, pos);
+			if (m > u->chunklen)
+				m = u->chunklen;
+
+			u->inf.in = pos;
+			u->inf.inlen = m;
+			u->inf.bp = 0;
+			u->of++;
+			break;
+
+		case UOF_INSIDE:
+			if (!u->inf.subsequent) {
+
+				switch (u->sctr) {
+				case 0:
+					u->acc = (uint32_t)((*pos++) << 8);
+					u->sctr++;
+					continue;
+
+				case 1:
+					u->acc |= *pos++;
+
+					if (u->acc % 31)
+						return LWS_UPNG_FATAL + 31;
+
+					if (((u->acc >> 8) & 15) != 8 ||
+					    ((u->acc >> 12) & 15) > 7)
+						return LWS_UPNG_FATAL + 31;
+
+					if ((u->acc >> 5) & 1)
+						return LWS_UPNG_FATAL + 31;
+
+					u->inf.subsequent = 1;
+					break;
+				}
+			}
+
+			r = uz_inflate_data(&u->inf);
+			switch (r) {
+
+			case LWS_UPNG_WANT_INPUT:
+
+				/* indicate no existing to drain */
+				u->inf.in = NULL;
+
+				pos += u->inf.inlen - u->inf.inpos;
+				u->chunklen = u->chunklen -
+						(unsigned int)(u->inf.inlen);
+
+				if (!u->chunklen) {
+					u->chunklen = 4; /* skip the 32-bit CRC */
+
+					u->of = UOF_SKIP_CHUNK_LEN;
+					break;
+				}
+				if (pos != end) {
+					u->inf.inpos = 0;
+					u->inf.in = pos;
+					m = lws_ptr_diff_size_t(end, pos);
+					if (m > u->chunklen)
+						m = u->chunklen;
+					u->inf.inlen = m;
+					continue;
+				}
+				goto bail;
+			default:
+				goto bail;
+			}
+			break;
+
+		case UOF_SKIP_CHUNK_LEN:
+			pos++;
+			if (!--u->chunklen) {
+				u->of = UOF_CHUNK_LEN;
+				u->sctr = 0;
+				break;
+			}
+			break;
+		}
+	}
+
+	r = LWS_UPNG_OK;
+	if (!u->no_more_input)
+		r = LWS_UPNG_WANT_INPUT;
+
+bail:
+	*_pos = pos;
+	*_size = lws_ptr_diff_size_t(end, pos);
+
+	return r;
+}
+
+lws_upng_t *
+lws_upng_new(void)
+{
+	lws_upng_t* upng;
+
+	upng = (lws_upng_t*)lws_zalloc(sizeof(lws_upng_t), __func__);
+	if (upng == NULL)
+		return NULL;
+
+	upng->color_type = LWS_UPNG_RGBA;
+	upng->color_depth = 8;
+	upng->format = LWS_UPNG_RGBA8;
+
+	upng->of = UOF_MAGIC;
+	upng->sctr = 0;
+
+	upng->inf.upng = upng;
+
+	return upng;
+}
+
+void
+lws_upng_free(lws_upng_t** upng)
+{
+	if ((*upng)->inf.out)
+		lws_free_set_NULL((*upng)->inf.out);
+
+	lws_free_set_NULL(*upng);
+}
+
+
+unsigned int
+lws_upng_get_width(const lws_upng_t* upng)
+{
+	return upng->width;
+}
+
+unsigned int
+lws_upng_get_height(const lws_upng_t* upng)
+{
+	return upng->height;
+}
+
+unsigned int
+lws_upng_get_bpp(const lws_upng_t* upng)
+{
+	return lws_upng_get_bitdepth(upng) *
+			lws_upng_get_components(upng);
+}
+
+unsigned int
+lws_upng_get_components(const lws_upng_t* upng)
+{
+	switch (upng->color_type) {
+	case LWS_UPNG_LUM:
+		return 1;
+	case LWS_UPNG_RGB:
+		return 3;
+	case LWS_UPNG_LUMA:
+		return 2;
+	case LWS_UPNG_RGBA:
+		return 4;
+	default:
+		return 0;
+	}
+}
+
+unsigned int
+lws_upng_get_bitdepth(const lws_upng_t* upng)
+{
+	return upng->color_depth;
+}
+
+unsigned int
+lws_upng_get_pixelsize(const lws_upng_t* upng)
+{
+	unsigned bits = lws_upng_get_bitdepth(upng) *
+				lws_upng_get_components(upng);
+
+	bits += bits % 8;
+
+	return bits;
+}
+
+lws_upng_format_t
+lws_upng_get_format(const lws_upng_t *upng)
+{
+	return upng->format;
+}

--- a/lib/secure-streams/policy-json.c
+++ b/lib/secure-streams/policy-json.c
@@ -105,6 +105,7 @@ static const char * const lejp_tokens_policy[] = {
 	"s[].*.ws_subprotocol",
 	"s[].*.ws_binary",
 	"s[].*.local_sink",
+	"s[].*.options[].*",
 	"s[].*.server",
 	"s[].*.server_cert",
 	"s[].*.server_key",
@@ -212,6 +213,7 @@ typedef enum {
 	LSSPPT_WS_SUBPROTOCOL,
 	LSSPPT_WS_BINARY,
 	LSSPPT_LOCAL_SINK,
+	LSSPPT_OPTIONS,
 	LSSPPT_SERVER,
 	LSSPPT_SERVER_CERT,
 	LSSPPT_SERVER_KEY,
@@ -309,6 +311,10 @@ lws_ss_policy_parser_cb(struct lejp_ctx *ctx, char reason)
 	lws_ss_trust_store_t *ts;
 	lws_ss_metadata_t *pmd;
 	lws_ss_x509_t *x, **py;
+#if defined(LWS_WITH_SERVER)
+	struct lws_protocol_vhost_options *pvo;
+	const char *pvo_name;
+#endif
 	lws_ss_policy_t *p2;
 	lws_retry_bo_t *b;
 	size_t inl, outl;
@@ -316,8 +322,8 @@ lws_ss_policy_parser_cb(struct lejp_ctx *ctx, char reason)
 	backoff_t *bot;
 	int n = -1;
 
-//	lwsl_debug("%s: %d %d %s\n", __func__, reason, ctx->path_match - 1,
-//		   ctx->path);
+	// lwsl_notice("%s: %d %d %s %s\n", __func__, reason, ctx->path_match - 1,
+	//	   ctx->path, ctx->buf);
 
 	switch (ctx->path_match - 1) {
 	case LSSPPT_RETRY:
@@ -382,6 +388,11 @@ lws_ss_policy_parser_cb(struct lejp_ctx *ctx, char reason)
 
 		return 0;
 	}
+
+	if (reason == LEJPCB_ARRAY_END &&
+	    ctx->path_match - 1 == LSSPPT_OPTIONS &&
+	    a->pvosp)
+		a->pvosp--;
 
 	if (reason == LEJPCB_OBJECT_END && a->p) {
 		/*
@@ -593,6 +604,36 @@ lws_ss_policy_parser_cb(struct lejp_ctx *ctx, char reason)
 		pp = (char **)&a->curr[LTY_METRICS].m->report;
 		goto string2;
 #endif
+
+	case LSSPPT_OPTIONS:
+#if defined(LWS_WITH_SERVER)
+		pvo_name = ctx->path + ctx->st[ctx->sp - 2].p + 1;
+		pvo = lwsac_use(&a->ac, sizeof(*pvo) + strlen(pvo_name) + 1 +
+				 ctx->npos + 1, POL_AC_GRAIN);
+		if (!pvo)
+			goto oom;
+
+		pvo->name = (const char *)&pvo[1];
+		pvo->value = pvo->name + strlen(pvo_name) + 1;
+		memcpy((char *)pvo->name, pvo_name, strlen(pvo_name) + 1);
+		memcpy((char *)pvo->value, ctx->buf, ctx->npos);
+		*((char *)&pvo->value[ctx->npos]) = '\0';
+		pvo->next = NULL;
+		pvo->options = NULL;
+
+		if (!a->curr[LTY_POLICY].p->pvo)
+			a->curr[LTY_POLICY].p->pvo = pvo;
+
+		/* for now we just support one level of options */
+
+		// lwsl_notice("%s: lv %d, %s=%s\n", __func__, a->pvosp,
+		//		pvo->name, pvo->value);
+
+		if (a->pvostack[a->pvosp])
+			a->pvostack[a->pvosp]->next = pvo;
+		a->pvostack[a->pvosp] = pvo;
+#endif
+		break;
 
 	case LSSPPT_SERVER_CERT:
 	case LSSPPT_SERVER_KEY:

--- a/lib/secure-streams/private-lib-secure-streams.h
+++ b/lib/secure-streams/private-lib-secure-streams.h
@@ -71,7 +71,7 @@ typedef struct lws_ss_handle {
 	lws_fi_ctx_t		fic;	/**< Fault Injection context */
 #endif
 
-	struct lws_dll2_owner	src_list; /**< sink's list of bound sources */
+	struct lws_dll2_owner   src_list; /**< server's list of bound sources */
 
 	struct lws_context      *context; /**< lws context we are created on */
 	const lws_ss_policy_t	*policy;  /**< system policy for stream */
@@ -91,9 +91,11 @@ typedef struct lws_ss_handle {
 #if defined(LWS_WITH_CONMON)
 	char			*conmon_json;
 #endif
-
-	//struct lws_ss_handle	*h_sink;  /**< sink we are bound to, or NULL */
-	//void 			*sink_obj;/**< sink's private object representing us */
+#if defined(LWS_WITH_SERVER)
+	lws_dll2_t		sink_bind; /* if bound to / owned by a sink */
+	lws_sorted_usec_list_t	sul_txreq; /* pending tx req to peer */
+	struct lws_ss_handle	*sink_local_bind; /* nonproxy sink peer */
+#endif
 
 	lws_sorted_usec_list_t	sul_timeout;
 	lws_sorted_usec_list_t	sul;
@@ -464,12 +466,15 @@ struct policy_cb_args {
 
 	lws_ss_http_respmap_t respmap[16];
 
+	struct lws_protocol_vhost_options *pvostack[4];
+
 	union u heads[_LTY_COUNT];
 	union u curr[_LTY_COUNT];
 
 	uint8_t *p;
 
 	int count;
+	int pvosp;
 	char pending_respmap;
 
 	uint8_t parse_data:1;

--- a/lib/secure-streams/secure-streams.c
+++ b/lib/secure-streams/secure-streams.c
@@ -675,12 +675,14 @@ _lws_ss_client_connect(lws_ss_handle_t *h, int is_retry, void *conn_if_sspc_onw)
 		return LWSSSSRET_OK;
 	}
 
+#if defined(LWS_WITH_SERVER)
 	/*
 	 * We are already bound to a sink?
 	 */
 
-//	if (h->h_sink)
-//		return 0;
+	if (h->sink_local_bind)
+		return 0;
+#endif
 
 	if (!is_retry)
 		h->retry = 0;
@@ -929,6 +931,9 @@ lws_ss_create(struct lws_context *context, int tsi, const lws_ss_info_t *ssi,
 	const lws_ss_policy_t *pol;
 	lws_ss_state_return_t r;
 	lws_ss_metadata_t *smd;
+#if defined(LWS_WITH_SERVER)
+	lws_ss_sinks_t *sn;
+#endif
 	lws_ss_handle_t *h;
 	size_t size;
 	void **v;
@@ -973,8 +978,9 @@ lws_ss_create(struct lws_context *context, int tsi, const lws_ss_info_t *ssi,
 	}
 #endif
 
-#if 0
+#if defined(LWS_WITH_SERVER)
 	if (ssi->flags & LWSSSINFLAGS_REGISTER_SINK) {
+
 		/*
 		 * This can register a secure streams sink as well as normal
 		 * secure streams connections.  If that's what's happening,
@@ -992,12 +998,20 @@ lws_ss_create(struct lws_context *context, int tsi, const lws_ss_info_t *ssi,
 
 			return 1;
 		}
-	} else {
 
-		if (!(pol->flags & LWSSSPOLF_LOCAL_SINK)) {
+		sn = lws_zalloc(sizeof(*sn), __func__);
+		if (!sn)
+			return 1;
 
-		}
-//		lws_dll2_foreach_safe(&pt->ss_owner, NULL, lws_ss_destroy_dll);
+		sn->info = *ssi;
+		sn->info.flags = (uint8_t)((sn->info.flags &
+						~(LWSSSINFLAGS_REGISTER_SINK)) |
+				LWSSSINFLAGS_ACCEPTED_SINK);
+		lws_dll2_add_tail(&sn->list, &context->sinks);
+
+		lwsl_cx_notice(context, "registered sink %s", ssi->streamtype);
+
+		return 0;
 	}
 #endif
 
@@ -1021,15 +1035,23 @@ lws_ss_create(struct lws_context *context, int tsi, const lws_ss_info_t *ssi,
 
 	h->lc.log_cx = context->log_cx;
 
+	n = LWSLCG_WSI_SS_CLIENT;
+#if defined(LWS_WITH_SERVER)
+	if (pol->flags & LWSSSPOLF_LOCAL_SINK) {
+		if (ssi->flags & LWSSSINFLAGS_ACCEPTED_SINK)
+			n = LWSLCG_WSI_SSP_SINK;
+		else
+			n = LWSLCG_WSI_SSP_SOURCE;
+	}
+#endif
+
 	if (ssi->sss_protocol_version)
-		__lws_lc_tag(context, &context->lcg[LWSLCG_WSI_SS_CLIENT],
-			     &h->lc, "%s|v%u|%u",
+		__lws_lc_tag(context, &context->lcg[n], &h->lc, "%s|v%u|%u",
 			     ssi->streamtype ? ssi->streamtype : "nostreamtype",
 			     (unsigned int)ssi->sss_protocol_version,
 			     (unsigned int)ssi->client_pid);
 	else
-		__lws_lc_tag(context, &context->lcg[LWSLCG_WSI_SS_CLIENT],
-			     &h->lc, "%s",
+		__lws_lc_tag(context, &context->lcg[n], &h->lc, "%s",
 			     ssi->streamtype ? ssi->streamtype : "nostreamtype");
 
 #if defined(LWS_WITH_SYS_FAULT_INJECTION)
@@ -1039,6 +1061,67 @@ lws_ss_create(struct lws_context *context, int tsi, const lws_ss_info_t *ssi,
 		lws_fi_import(&h->fic, &ssi->fic);
 
 	lws_fi_inherit_copy(&h->fic, &context->fic, "ss", ssi->streamtype);
+#endif
+
+#if defined(LWS_WITH_SERVER)
+	if (pol->flags & LWSSSPOLF_LOCAL_SINK) {
+
+		if (ssi->flags & LWSSSINFLAGS_ACCEPTED_SINK) {
+			/*
+			 * We are recursing to create the accepted sink, do
+			 * the binding while still in create so any downstream
+			 * actions understand our situation from the start
+			 */
+			h->sink_local_bind = (struct lws_ss_handle *)
+							opaque_user_data;
+			h->sink_local_bind->sink_local_bind = h;
+		} else {
+
+			/* we are creating an ss connected to a sink... find the sink */
+
+			lws_start_foreach_dll(struct lws_dll2 *, d,
+					      lws_dll2_get_head(&context->sinks)) {
+				sn = lws_container_of(d, lws_ss_sinks_t, list);
+
+				if (!strcmp(sn->info.streamtype, ssi->streamtype)) {
+					lws_ss_handle_t *has;
+
+					/*
+					 * How does the sink feel about us joining?
+					 */
+
+					if (sn->info.state(&h[1], h, LWSSSCS_SINK_JOIN,
+							    sn->accepts.count)) {
+						lwsl_ss_notice(h, "sink rejected");
+						goto fail_creation;
+					}
+
+					/*
+					 * Recurse to instantiate an accepted sink SS
+					 * for us to bind to... pass bind source handle
+					 * in as opaque data
+					 */
+
+					if (lws_ss_create(context, tsi, &sn->info,
+							  h, &has, NULL, NULL)) {
+						lwsl_ss_err(h, "sink accept failed");
+						goto fail_creation;
+					}
+
+					lws_dll2_add_tail(&has->sink_bind, &sn->accepts);
+
+					lwsl_ss_notice(h, "bound to sink");
+					break;
+				}
+
+			} lws_end_foreach_dll(d);
+
+			if (!h->sink_local_bind) {
+				lwsl_cx_err(context, "no sink %s", ssi->streamtype);
+				goto fail_creation;
+			}
+		}
+	}
 #endif
 
 	h->info = *ssi;
@@ -1266,9 +1349,18 @@ extant:
 	    lws_fi(&h->fic, "ss_create_destroy_me"))
 		goto fail_creation;
 
+	n = 0;
 #if defined(LWS_WITH_SYS_SMD)
 	if (!(ssi->flags & LWSSSINFLAGS_PROXIED) &&
-	    pol == &pol_smd) {
+	    pol == &pol_smd)
+		n = 1;
+#endif
+#if defined(LWS_WITH_SERVER)
+	if (h->sink_local_bind)
+		n = 1;
+#endif
+
+	if (n) {
 		r = lws_ss_event_helper(h, LWSSSCS_CONNECTING);
 		if (r || lws_fi(&h->fic, "ss_create_smd_1"))
 			goto fail_creation;
@@ -1276,9 +1368,11 @@ extant:
 		if (r || lws_fi(&h->fic, "ss_create_smd_2"))
 			goto fail_creation;
 	}
-#endif
 
-	if (!(ssi->flags & LWSSSINFLAGS_REGISTER_SINK) &&
+	if (
+#if defined(LWS_WITH_SERVER)
+			!h->sink_local_bind &&
+#endif
 	    ((h->policy->flags & LWSSSPOLF_NAILED_UP)
 #if defined(LWS_WITH_SYS_SMD)
 		|| ((h->policy == &pol_smd) //&&
@@ -1309,6 +1403,9 @@ fail_creation:
 	if (ppss)
 		*ppss = NULL;
 
+#if defined(LWS_WITH_SERVER)
+	lws_dll2_remove(&h->sink_bind);
+#endif
 	lws_ss_destroy(&h);
 
 	return 1;
@@ -1326,6 +1423,7 @@ lws_ss_destroy(lws_ss_handle_t **ppss)
 	struct lws_context_per_thread *pt;
 #if defined(LWS_WITH_SERVER)
 	struct lws_vhost *v = NULL;
+	lws_ss_handle_t *hlb;
 #endif
 	lws_ss_handle_t *h = *ppss;
 	lws_ss_metadata_t *pmd;
@@ -1373,6 +1471,10 @@ lws_ss_destroy(lws_ss_handle_t **ppss)
 		lws_set_timeout(h->wsi, 1, LWS_TO_KILL_SYNC);
 	}
 
+#if defined(LWS_WITH_SERVER)
+	lws_dll2_remove(&h->sink_bind);
+#endif
+
 	/*
 	 * if we bound an smd registration to the SS, unregister it
 	 */
@@ -1394,9 +1496,17 @@ lws_ss_destroy(lws_ss_handle_t **ppss)
 	*ppss = NULL;
 	lws_dll2_remove(&h->list);
 #if defined(LWS_WITH_SERVER)
-		lws_dll2_remove(&h->cli_list);
+	lws_dll2_remove(&h->cli_list);
+	lws_dll2_remove(&h->sink_bind);
+	lws_sul_cancel(&h->sul_txreq);
+	hlb = h->sink_local_bind;
+	if (hlb) {
+		h->sink_local_bind = NULL;
+		lws_ss_destroy(&hlb);
+	}
 #endif
 	lws_dll2_remove(&h->to_list);
+
 	lws_sul_cancel(&h->sul_timeout);
 
 	/*
@@ -1534,6 +1644,46 @@ lws_ss_server_foreach_client(struct lws_ss_handle *h, lws_sssfec_cb cb,
 
 	} lws_end_foreach_dll_safe(d, d1);
 }
+
+/*
+ * Deal with tx requests between source and accepted sink... h is the guy who
+ * requested the write
+ */
+
+static void
+lws_ss_sink_txreq_cb(lws_sorted_usec_list_t *sul)
+{
+	struct lws_ss_handle *h = lws_container_of(sul, struct lws_ss_handle,
+						   sul_txreq);
+	uint8_t buf[1380 + LWS_PRE];
+	size_t size = sizeof(buf) - LWS_PRE;
+	lws_ss_state_return_t r;
+	int flags = 0;
+
+	/* !!! just let writes happen for now */
+
+	assert(h->sink_local_bind);
+
+	/* collect the source tx */
+	r = h->info.tx(&h[1], 0, buf + LWS_PRE, &size, &flags);
+	switch (r) {
+	case LWSSSSRET_OK:
+		if (!h->sink_local_bind->info.rx) {
+			lwsl_ss_warn(h->sink_local_bind, "No RX cb");
+			break;
+		}
+		r = h->sink_local_bind->info.rx(&h->sink_local_bind[1],
+						 buf + LWS_PRE, size, flags);
+		_lws_ss_handle_state_ret_CAN_DESTROY_HANDLE(r, NULL,
+							    &h->sink_local_bind);
+		break;
+	case LWSSSSRET_TX_DONT_SEND:
+		break;
+	default:
+		_lws_ss_handle_state_ret_CAN_DESTROY_HANDLE(r, NULL, &h);
+		break;
+	}
+}
 #endif
 
 lws_ss_state_return_t
@@ -1569,6 +1719,21 @@ _lws_ss_request_tx(lws_ss_handle_t *h)
 
 	if (h->policy->flags & LWSSSPOLF_SERVER)
 		return LWSSSSRET_OK;
+
+#if defined(LWS_WITH_SERVER)
+	if (h->sink_local_bind) {
+		/*
+		 * We are bound to a local sink / source
+		 */
+
+		lwsl_ss_notice(h->sink_local_bind, "Req tx");
+
+		lws_sul_schedule(h->context, 0, &h->sink_local_bind->sul_txreq,
+				 lws_ss_sink_txreq_cb, 1);
+
+		return LWSSSSRET_OK;
+	}
+#endif
 
 	/*
 	 * there's currently no wsi / connection associated with the ss handle

--- a/lib/tls/CMakeLists.txt
+++ b/lib/tls/CMakeLists.txt
@@ -254,7 +254,7 @@ if (LWS_WITH_SSL)
 	endif()
 
 	if (NOT chose_ssl)
-		if (OPENSSL_FOUND)
+		if (OPENSSL_FOUND AND "${OPENSSL_INCLUDE_DIRS}" STREQUAL "")
 			set(OPENSSL_INCLUDE_DIRS "${OPENSSL_INCLUDE_DIR}")
 		endif()
 

--- a/lib/tls/CMakeLists.txt
+++ b/lib/tls/CMakeLists.txt
@@ -254,6 +254,10 @@ if (LWS_WITH_SSL)
 	endif()
 
 	if (NOT chose_ssl)
+		if (OPENSSL_FOUND)
+			set(OPENSSL_INCLUDE_DIRS "${OPENSSL_INCLUDE_DIR}")
+		endif()
+
 		if (NOT OPENSSL_FOUND AND NOT LWS_WITH_BORINGSSL)
 			# TODO: Add support for STATIC also.
 			if (NOT LWS_PLAT_FREERTOS)

--- a/minimal-examples-lowlevel/api-tests/api-test-lws_tokenize/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-lws_tokenize/main.c
@@ -379,6 +379,266 @@ int main(int argc, const char **argv)
 		memcert[info.client_ssl_ca_mem_len++] = '\0';
 	}
 #endif
+	{
+		/* lws_fixed3232_t */
+
+		lws_fixed3232_t r, a, b;
+
+		a.whole = 1;
+		a.frac = 0;
+
+		b.whole = 5;
+		b.frac = 50000000;
+
+		lws_fixed3232_add(&r, &a, &b);
+
+		if (r.whole != 6 || r.frac != 50000000) {
+			lwsl_err("%s: fixed3232: test1 fail\n", __func__);
+			return 1;
+		}
+
+
+		lws_fixed3232_sub(&r, &b, &a);
+
+		if (r.whole != 4 || r.frac != 50000000) {
+			lwsl_err("%s: fixed3232: test2 fail\n", __func__);
+			return 1;
+		}
+
+
+		a.whole = -1;
+		a.frac = 0;
+
+		b.whole = 5;
+		b.frac = 50000000;
+
+		lws_fixed3232_add(&r, &a, &b);
+
+		if (r.whole != 4 || r.frac != 50000000) {
+			lwsl_err("%s: fixed3232: test3 fail\n", __func__);
+			return 1;
+		}
+
+
+		a.whole = -1;
+		a.frac = 0;
+
+		b.whole = -1;
+		b.frac = 50000000;
+
+		lws_fixed3232_add(&r, &a, &b);
+
+		if (r.whole != -2 || r.frac != 50000000) {
+			lwsl_err("%s: fixed3232: test4 fail\n", __func__);
+			return 1;
+		}
+
+		a.whole = 3;
+		a.frac = 0;
+
+		b.whole = 5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != 15 || r.frac != 30000000) {
+			lwsl_err("%s: fixed3232: test5 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = -3;
+		a.frac = 0;
+
+		b.whole = 5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != -15 || r.frac != 30000000) {
+			lwsl_err("%s: fixed3232: test6 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 3;
+		a.frac = 0;
+
+		b.whole = -5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != -15 || r.frac != 30000000) {
+			lwsl_err("%s: fixed3232: test7 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+
+		a.whole = -3;
+		a.frac = 0;
+
+		b.whole = -5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != 15 || r.frac != 30000000) {
+			lwsl_err("%s: fixed3232: test8 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 3;
+		a.frac = 50000000;
+
+		b.whole = 5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != 17 || r.frac != 85000000) {
+			lwsl_err("%s: fixed3232: test9 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = -3;
+		a.frac = 50000000;
+
+		b.whole = 5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != -17 || r.frac != 85000000) {
+			lwsl_err("%s: fixed3232: test10 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 3;
+		a.frac = 50000000;
+
+		b.whole = -5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != -17 || r.frac != 85000000) {
+			lwsl_err("%s: fixed3232: test11 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = -3;
+		a.frac = 50000000;
+
+		b.whole = -5;
+		b.frac = 10000000;
+
+		lws_fixed3232_mul(&r, &a, &b);
+
+		if (r.whole != 17 || r.frac != 85000000) {
+			lwsl_err("%s: fixed3232: test12 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 27;
+		a.frac = 0;
+
+		b.whole = 9;
+		b.frac = 0;
+
+		lws_fixed3232_div(&r, &a, &b);
+
+		if (r.whole != 3 || r.frac != 0) {
+			lwsl_err("%s: fixed3232: test13 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 33;
+		a.frac = 33333333;
+
+		b.whole = 11;
+		b.frac = 0;
+
+		lws_fixed3232_div(&r, &a, &b);
+
+		if (r.whole != 3 || r.frac != 3030302) {
+			lwsl_err("%s: fixed3232: test14 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 33;
+		a.frac = 33333333;
+
+		b.whole = 1;
+		b.frac = 10000000;
+
+		lws_fixed3232_div(&r, &a, &b);
+
+		if (r.whole != 30 || r.frac != 30303030) {
+			lwsl_err("%s: fixed3232: test15 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = -33;
+		a.frac = 33333333;
+
+		b.whole = 1;
+		b.frac = 10000000;
+
+		lws_fixed3232_div(&r, &a, &b);
+
+		if (r.whole != -30 || r.frac != 30303030) {
+			lwsl_err("%s: fixed3232: test16 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 33;
+		a.frac = 33333333;
+
+		b.whole = -1;
+		b.frac = 10000000;
+
+		lws_fixed3232_div(&r, &a, &b);
+
+		if (r.whole != -30 || r.frac != 30303030) {
+			lwsl_err("%s: fixed3232: test17 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = -33;
+		a.frac = 33333333;
+
+		b.whole = -1;
+		b.frac = 10000000;
+
+		lws_fixed3232_div(&r, &a, &b);
+
+		if (r.whole != 30 || r.frac != 30303030) {
+			lwsl_err("%s: fixed3232: test18 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+
+		a.whole = 64;
+		a.frac = 0;
+
+		lws_fixed3232_sqrt(&r, &a);
+
+		if (r.whole != 8 || r.frac != 0) {
+			lwsl_err("%s: fixed3232: test19 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+
+		a.whole = 16512;
+		a.frac = 25000000;
+
+		lws_fixed3232_sqrt(&r, &a);
+
+		if (r.whole != 128 || r.frac != 50000000) {
+			lwsl_err("%s: fixed3232: test20 fail: %d.%08u\n", __func__, r.whole, r.frac);
+			return 1;
+		}
+	}
+
+
 	cx = lws_create_context(&info);
 
 	/* lws_strexp */

--- a/minimal-examples-lowlevel/api-tests/api-test-upng/CMakeLists.txt
+++ b/minimal-examples-lowlevel/api-tests/api-test-upng/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(lws-api-test-upng C)
+cmake_minimum_required(VERSION 2.8.12)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SAMP lws-api-test-upng)
+set(SRCS main.c )
+
+set(requirements 1)
+require_lws_config(LWS_WITH_UPNG 1 requirements)
+
+if (requirements)
+
+	add_executable(${SAMP} ${SRCS})
+
+	if (websockets_shared)
+		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${SAMP} websockets_shared)
+	else()
+		target_link_libraries(${SAMP} websockets ${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+endif()

--- a/minimal-examples-lowlevel/api-tests/api-test-upng/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-upng/main.c
@@ -1,0 +1,133 @@
+/*
+ * lws-api-test-upng
+ *
+ * Written in 2010-2022 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ */
+
+#include <libwebsockets.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+
+int fdin = 0, fdout = 1;
+
+int
+main(int argc, const char **argv)
+{
+	int result = 0, logs = LLL_USER | LLL_ERR | LLL_WARN | LLL_NOTICE;
+	lws_upng_ret_t r = LWS_UPNG_WANT_INPUT;
+	const char *p;
+	lws_upng_t *u;
+
+	if ((p = lws_cmdline_option(argc, argv, "-d")))
+		logs = atoi(p);
+
+	lws_set_log_level(logs, NULL);
+	lwsl_user("LWS UPNG test tool\n");
+
+	if ((p = lws_cmdline_option(argc, argv, "--stdin"))) {
+		fdin = open(p, LWS_O_RDONLY, 0);
+		if (fdin < 0) {
+			result = 1;
+			lwsl_err("%s: unable to open stdin file\n", __func__);
+			goto bail;
+		}
+	}
+
+	if ((p = lws_cmdline_option(argc, argv, "--stdout"))) {
+		fdout = open(p, LWS_O_WRONLY | LWS_O_CREAT | LWS_O_TRUNC, 0600);
+		if (fdout < 0) {
+			result = 1;
+			lwsl_err("%s: unable to open stdout file\n", __func__);
+			goto bail;
+		}
+	}
+
+	if (!fdin) {
+		struct timeval	timeout;
+		fd_set	fds;
+
+		FD_ZERO(&fds);
+		FD_SET(0, &fds);
+
+		timeout.tv_sec  = 0;
+		timeout.tv_usec = 1000;
+
+		if (select(fdin + 1, &fds, NULL, NULL, &timeout) < 0 ||
+		    !FD_ISSET(0, &fds)) {
+			result = 1;
+			lwsl_err("%s: pass PNG "
+				 "on stdin or use --stdin\n", __func__);
+			goto bail;
+		}
+	}
+
+
+	u = lws_upng_new();
+	if (!u) {
+		lwsl_err("%s: failed to allocate\n", __func__);
+		goto bail;
+	}
+
+	do {
+		const uint8_t *pix;
+		uint8_t ib[256];
+		const uint8_t *pib = (const uint8_t *)ib;
+		ssize_t s, os;
+		size_t ps;
+
+		if (r == LWS_UPNG_WANT_INPUT) {
+			s = read(fdin, ib, sizeof(ib));
+
+			if (s <= 0) {
+				lwsl_err("%s: failed to read: %d\n", __func__, errno);
+				goto bail1;
+			}
+
+			ps = (size_t)s;
+
+			// lwsl_notice("%s: fetched %d\n", __func__, (int)s);
+		}
+
+		do {
+			r = lws_upng_emit_next_line(u, &pix, &pib, &ps);
+			if (r == LWS_UPNG_WANT_INPUT)
+				break;
+
+			if (r > LWS_UPNG_FATAL) {
+				result = 1;
+				goto bail1;
+			}
+
+			if (!pix)
+				goto bail1;
+
+			os = (ssize_t)(lws_upng_get_width(u) * (lws_upng_get_pixelsize(u) / 8));
+
+			if (write(fdout, pix, (size_t)os) < os) {
+				lwsl_err("%s: write %d failed %d\n", __func__, (int)os, errno);
+				goto bail1;
+			}
+
+//			lwsl_notice("%s: wrote %d\n", __func__, (int)os);
+		} while (ps);
+
+	} while (1);
+
+bail1:
+	if (fdin)
+		close(fdin);
+	if (fdout != 1)
+		close(fdout);
+
+	lws_upng_free(&u);
+
+bail:
+	lwsl_user("Completed: %s\n", result ? "FAIL" : "PASS");
+
+	return result;
+}

--- a/minimal-examples/embedded/esp32/esp-c3dev/main/devices.c
+++ b/minimal-examples/embedded/esp32/esp-c3dev/main/devices.c
@@ -1,7 +1,7 @@
 /*
  * devices for ESP32 C3 dev board
  *
- * Written in 2010-2021 by Andy Green <andy@warmcat.com>
+ * Written in 2010-2022 by Andy Green <andy@warmcat.com>
  *
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
@@ -61,8 +61,10 @@ static const lws_pwm_ops_t pwm_ops = {
 static const lws_display_ssd1306_t disp = {
 	.disp = {
 		lws_display_ssd1306_ops,
-		.w			= 128,
-		.h			= 64
+			.ic = {
+			.wh_px = { { 128,0 },      { 64,0 } },
+			.wh_mm = { { 22,00000000 },  { 10,00000000 } },
+               },
 	},
 	.i2c				= (lws_i2c_ops_t *)&li2c,
 	.gpio				= &lws_gpio_plat,

--- a/minimal-examples/embedded/esp32/esp-heltec-wb32/main/devices.c
+++ b/minimal-examples/embedded/esp32/esp-heltec-wb32/main/devices.c
@@ -1,7 +1,7 @@
 /*
  * devices for ESP32 Heltec WB32
  *
- * Written in 2010-2020 by Andy Green <andy@warmcat.com>
+ * Written in 2010-2022 by Andy Green <andy@warmcat.com>
  *
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
@@ -78,8 +78,10 @@ static const lws_pwm_ops_t pwm_ops = {
 static const lws_display_ssd1306_t disp = {
 	.disp = {
 		lws_display_ssd1306_ops,
-		.w			= 128,
-		.h			= 64
+		.ic = {
+			.wh_px = { { 128,0 },      { 64,0 } },
+			.wh_mm = { { 22,00000000 },  { 10,00000000 } },
+               },
 	},
 	.i2c				= (lws_i2c_ops_t *)&li2c,
 	.gpio				= &lws_gpio_plat,

--- a/minimal-examples/embedded/esp32/esp-heltec-wb32/main/lws-minimal-esp32.c
+++ b/minimal-examples/embedded/esp32/esp-heltec-wb32/main/lws-minimal-esp32.c
@@ -1,7 +1,7 @@
 /*
  * lws-minimal-esp32
  *
- * Written in 2010-2020 by Andy Green <andy@warmcat.com>
+ * Written in 2010-2022 by Andy Green <andy@warmcat.com>
  *
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
@@ -153,6 +153,7 @@ void
 app_main(void)
 {
 	struct lws_context_creation_info *info;
+	lws_box_t box = { {0,0}, {0,0}, {128,0}, {64,0} };
 
 	lws_set_log_level(1024 | 15, NULL);
 
@@ -196,7 +197,7 @@ app_main(void)
 
 	/* put the logo on the OLED display */
 
-	lds.disp->blit(lds.disp, img, 0, 0, 128, 64);
+	lds.disp->blit(&lds, img, &box);
 	lws_display_state_active(&lds);
 
 	/* the lws event loop */

--- a/minimal-examples/embedded/esp32/esp-wrover-kit/main/devices.c
+++ b/minimal-examples/embedded/esp32/esp-wrover-kit/main/devices.c
@@ -1,7 +1,7 @@
 /*
  * devices for ESP WROVER KIT
  *
- * Written in 2010-2020 by Andy Green <andy@warmcat.com>
+ * Written in 2010-2022 by Andy Green <andy@warmcat.com>
  *
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
@@ -143,8 +143,10 @@ static const lws_display_ili9341_t disp = {
 		.bl_dim			= &lws_pwmseq_static_half,
 		.bl_transition		= &lws_pwmseq_linear_wipe,
 		.bl_index		= 3,
-		.w			= 320,
-		.h			= 240,
+		.ic = {
+			.wh_px = { { 320,0 },      { 240,0 } },
+			.wh_mm = { { 64,00000000 },  { 48,00000000 } },
+		},
 		.latency_wake_ms	= 150,
 	},
 	.spi				= (lws_spi_ops_t *)&lbspi,

--- a/minimal-examples/embedded/esp32/esp-wrover-kit/main/lws-minimal-esp32.c
+++ b/minimal-examples/embedded/esp32/esp-wrover-kit/main/lws-minimal-esp32.c
@@ -1,7 +1,7 @@
 /*
  * lws-minimal-esp32
  *
- * Written in 2010-2020 by Andy Green <andy@warmcat.com>
+ * Written in 2010-2022 by Andy Green <andy@warmcat.com>
  *
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
@@ -116,7 +116,7 @@ myss_state(void *userobj, void *sh, lws_ss_constate_t state,
 
 	switch (state) {
 	case LWSSSCS_CREATING:
-		lws_ss_client_connect(m->ss);
+		return lws_ss_client_connect(m->ss);
 		break;
 	default:
 		break;
@@ -183,6 +183,7 @@ void
 app_main(void)
 {
 	struct lws_context_creation_info *info;
+	lws_box_t box = { {0,0}, {0,0}, {320,0}, {240,0} };
 
 	lws_set_log_level(1024 | 15, NULL);
 
@@ -231,7 +232,7 @@ app_main(void)
 
 	/* put the cat picture up there and enable the backlight */
 
-	lds.disp->blit(lds.disp, logo, 0, 0, 320, 240);
+	lds.disp->blit(&lds, logo, &box);
 	lws_display_state_active(&lds);
 
 	/* the lws event loop */

--- a/minimal-examples/sink/hello_world/CMakeLists.txt
+++ b/minimal-examples/sink/hello_world/CMakeLists.txt
@@ -1,0 +1,52 @@
+project(lws-minimal-ss-sink-hello_world C)
+cmake_minimum_required(VERSION 2.8.12)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SRCS main.c ss-sink.c ss-source.c)
+
+set(requirements 1)
+require_lws_config(LWS_ROLE_H1 1 requirements)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
+require_lws_config(LWS_WITH_SYS_SMD 1 requirements)
+require_lws_config(LWS_WITH_SECURE_STREAMS 1 requirements)
+require_lws_config(LWS_WITH_SECURE_STREAMS_STATIC_POLICY_ONLY 0 requirements)
+
+require_lws_config(LWS_WITH_SECURE_STREAMS_PROXY_API 1 has_ss_proxy)
+
+if (requirements)
+	add_executable(${PROJECT_NAME} ${SRCS})
+
+	if (websockets_shared)
+		target_link_libraries(${PROJECT_NAME}
+					websockets_shared
+					${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${PROJECT_NAME}
+					websockets_shared)
+	else()
+		target_link_libraries(${PROJECT_NAME}
+					websockets
+					${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+
+	if (HAS_LWS_WITH_SECURE_STREAMS_PROXY_API OR has_ss_proxy OR
+	    LWS_WITH_SECURE_STREAMS_PROXY_API)
+
+		add_compile_options(-DLWS_SS_USE_SSPC)
+		add_executable(${PROJECT_NAME}-client ${SRCS})
+
+		if (websockets_shared)
+			target_link_libraries(${PROJECT_NAME}-client
+						websockets_shared
+						${LIBWEBSOCKETS_DEP_LIBS})
+			add_dependencies(${PROJECT_NAME}-client
+						websockets_shared)
+		else()
+			target_link_libraries(${PROJECT_NAME}-client
+						websockets
+						${LIBWEBSOCKETS_DEP_LIBS})
+		endif()
+	endif()
+endif()

--- a/minimal-examples/sink/hello_world/README.md
+++ b/minimal-examples/sink/hello_world/README.md
@@ -1,0 +1,87 @@
+# lws minimal secure streams sink hello_world
+
+This example shows how to register your own SS as a "sink", that is a "server"
+that handles a given streamtype locally.
+
+User code just creates its own SS of that streamtype as usual, if it is marked
+in the policy as a local_sink
+
+```
+	"local_sink": true,
+```
+
+and the sink was registered, then the SS is fulfilled by the sink rather than
+directly making onward connections.  This lets you, eg handle streams completely
+locally, or intercept or store-and-forward their content to the cloud using
+another SS when convenient.
+
+Like any server, when you connect to it, at the server-side it creates an
+"accepted" sink SS specific to the connection, which is closed when the incoming
+connection closes.
+
+The example shows how to register the sink, and create a normal SS of the same
+streamtype name.  The source then sends a "hello_world" message to the sink
+instance, and the sink instance responds with a message back to the source.
+
+In this example, the source getting the ack message makes us exit with a
+success return.
+
+Sinks can be registered where the policy is in your system, either directly if
+there is no proxying, or at the proxy process when there is.
+
+## build
+
+```
+ $ cmake . && make
+```
+
+## usage
+
+Commandline option|Meaning
+---|---
+-d <loglevel>|Debug verbosity in decimal, eg, -d15
+
+```
+[2021/10/11 06:25:54:8413] U: LWS Secure Streams Sink hello_world
+[2021/10/11 06:25:54:8757] N: LWS: 4.3.99-v4.3.0-19-g9da508e91b, NET CLI SRV H1 H2 WS MQTT SS-JSON-POL SSPROX ConMon IPv6-absent
+[2021/10/11 06:25:54:8876] N:  ++ [1819937|wsi|0|pipe] (1)
+[2021/10/11 06:25:54:8920] N:  ++ [1819937|vh|0|netlink] (1)
+[2021/10/11 06:25:55:0233] N:  ++ [1819937|vh|1|_ss_default||-1] (2)
+[2021/10/11 06:25:55:4867] N: lws_ss_create: registered sink sink_hello_world
+[2021/10/11 06:25:55:4881] N:  ++ [1819937|SSsrc|0|sink_hello_world] (1)
+[2021/10/11 06:25:55:4890] N:  ++ [1819937|SSsink|0|sink_hello_world] (1)
+[2021/10/11 06:25:55:4907] N: [1819937|SSsink|0|sink_hello_world]: lws_ss_check_next_state_ss: (unset) -> LWSSSCS_CREATING
+[2021/10/11 06:25:55:4929] N: [1819937|SSsink|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_CREATING -> LWSSSCS_CONNECTING
+[2021/10/11 06:25:55:4930] N: [1819937|SSsink|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_CONNECTING -> LWSSSCS_CONNECTED
+[2021/10/11 06:25:55:4935] N: [1819937|SSsrc|0|sink_hello_world]: lws_ss_create: bound to sink
+[2021/10/11 06:25:55:4940] N: [1819937|SSsrc|0|sink_hello_world]: lws_ss_check_next_state_ss: (unset) -> LWSSSCS_CREATING
+[2021/10/11 06:25:55:4942] N: myss_src_state: CREATING
+[2021/10/11 06:25:55:4945] N: [1819937|SSsrc|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_CREATING -> LWSSSCS_CONNECTING
+[2021/10/11 06:25:55:4946] N: [1819937|SSsrc|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_CONNECTING -> LWSSSCS_CONNECTED
+[2021/10/11 06:25:55:4950] N: [1819937|SSsink|0|sink_hello_world]: _lws_ss_request_tx: Req tx
+[2021/10/11 06:25:55:4962] U: [1819937|SSsrc|0|sink_hello_world]: myss_src_tx: TX 39, flags 0x3, r 0
+[2021/10/11 06:25:55:4969] N: [1819937|SSsink|0|sink_hello_world]: myss_sink_rx: len 39, flags 0x3
+[2021/10/11 06:25:55:4974] N:
+[2021/10/11 06:25:55:4987] N: 0000: 46 72 6F 6D 20 53 6F 75 72 63 65 3A 20 48 65 6C    From Source: Hel
+[2021/10/11 06:25:55:4989] N: 0010: 6C 6F 20 57 6F 72 6C 64 3A 20 31 38 35 35 37 30    lo World: 185570
+[2021/10/11 06:25:55:4993] N: 0020: 37 36 35 36 33 31 38                               7656318
+[2021/10/11 06:25:55:4995] N:
+[2021/10/11 06:25:55:4999] N: [1819937|SSsrc|0|sink_hello_world]: _lws_ss_request_tx: Req tx
+[2021/10/11 06:25:55:5009] U: [1819937|SSsink|0|sink_hello_world]: myss_sink_tx: TX 37, flags 0x3, r 0
+[2021/10/11 06:25:55:5012] N: [1819937|SSsrc|0|sink_hello_world]: myss_src_rx: len 37, flags 0x3
+[2021/10/11 06:25:55:5014] N:
+[2021/10/11 06:25:55:5015] N: 0000: 46 72 6F 6D 20 53 69 6E 6B 3A 20 48 65 6C 6C 6F    From Sink: Hello
+[2021/10/11 06:25:55:5015] N: 0010: 20 57 6F 72 6C 64 3A 20 31 38 35 35 37 30 37 36     World: 18557076
+[2021/10/11 06:25:55:5016] N: 0020: 36 31 33 32 34                                     61324
+[2021/10/11 06:25:55:5016] N:
+[2021/10/11 06:25:55:5166] N:  -- [1819937|wsi|0|pipe] (0) 628.987ms
+[2021/10/11 06:25:55:5177] N:  -- [1819937|vh|0|netlink] (1) 625.669ms
+[2021/10/11 06:25:55:5205] N: [1819937|SSsink|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_CONNECTED -> LWSSSCS_DISCONNECTED
+[2021/10/11 06:25:55:5207] N: [1819937|SSsink|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_DISCONNECTED -> LWSSSCS_DESTROYING
+[2021/10/11 06:25:55:5211] N:  -- [1819937|SSsink|0|sink_hello_world] (0) 32.090ms
+[2021/10/11 06:25:55:5215] N: [1819937|SSsrc|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_CONNECTED -> LWSSSCS_DISCONNECTED
+[2021/10/11 06:25:55:5215] N: [1819937|SSsrc|0|sink_hello_world]: lws_ss_check_next_state_ss: LWSSSCS_DISCONNECTED -> LWSSSCS_DESTROYING
+[2021/10/11 06:25:55:5216] N:  -- [1819937|SSsrc|0|sink_hello_world] (0) 33.434ms
+[2021/10/11 06:25:55:5431] N:  -- [1819937|vh|1|_ss_default||-1] (0) 519.819ms
+[2021/10/11 06:25:55:5487] U: Completed: OK (seen expected 0)
+```

--- a/minimal-examples/sink/hello_world/example-policy.json
+++ b/minimal-examples/sink/hello_world/example-policy.json
@@ -1,0 +1,21 @@
+{
+	"release":"01234567",
+	"product":"myproduct",
+	"schema-version":1,
+	"retry": [{"default": {"backoff": [1000,2000,3000,5000,10000],"conceal":5,"jitterpc":20,"svalidping":300,"svalidhup":310}}],
+	"certs": [{
+		"isrg_root_x1": "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAwTzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2VhcmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygch77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6UA5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sWT8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyHB5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UCB5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUvKBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWnOlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTnjh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbwqHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CIrU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkqhkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZLubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KKNFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7UrTkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdCjNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVcoyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPAmRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57demyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc="
+	}
+],
+	"trust_stores": [{
+		"name": "le_via_isrg",
+		"stack": [ "isrg_root_x1" ]
+	}],
+	"s": [
+		{ "sink_hello_world": {
+			"local_sink": true
+			}
+		}
+	]
+}
+

--- a/minimal-examples/sink/hello_world/main.c
+++ b/minimal-examples/sink/hello_world/main.c
@@ -1,0 +1,99 @@
+/*
+ * lws-minimal-ss-sink-hello_world
+ *
+ * Written in 2010-2021 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ *
+ * Simple example registers an SS "sink", it's a streamtype with server-type
+ * semantics you can subsequently bind to by creating SS with the same
+ * streamtype name.
+ *
+ * The user code doesn't know if it is being fulfilled by a sink locally, via a
+ * SS proxy, or talking to a remote peer, the policy decides it.
+ *
+ * In the example, we register the sink, then create a source SS.  This also
+ * instantiates an accepted sink SS bound to the source.
+ *
+ * The source sends a message to the accepted sink instance, and that returns
+ * a message acknowledging it.
+ */
+
+#include <libwebsockets.h>
+#include <signal.h>
+
+extern const lws_ss_info_t ssi_myss_sink_t, ssi_myss_src_t;
+
+static struct lws_context *cx;
+int test_result = 1, multipart;
+
+static int
+smd_cb(void *opaque, lws_smd_class_t c, lws_usec_t ts, void *buf, size_t len)
+{
+	if (!(c & LWSSMDCL_SYSTEM_STATE))
+		return 0;
+
+	if (lws_json_simple_strcmp(buf, len, "\"state\":", "OPERATIONAL"))
+		return 0;
+
+	/*
+	 * Register our example sink
+	 */
+
+	if (lws_ss_create(cx, 0, &ssi_myss_sink_t, NULL, NULL, NULL, NULL)) {
+		lwsl_err("%s: unable to register sink\n", __func__);
+
+		return -1;
+	}
+
+	/*
+	 * Create our example source (which also instantiates an accepted
+	 * sink)
+	 */
+
+	if (lws_ss_create(cx, 0, &ssi_myss_src_t, NULL, NULL, NULL, NULL)) {
+		lwsl_err("%s: unable to register src\n", __func__);
+
+		return -1;
+	}
+
+	return 0;
+}
+
+static void
+sigint_handler(int sig)
+{
+	lws_default_loop_exit(cx);
+}
+
+int
+main(int argc, const char **argv)
+{
+	struct lws_context_creation_info *info = malloc(sizeof(*info));
+
+	if (!info)
+		return -1;
+
+	lws_context_info_defaults(info, "example-policy.json");
+	lws_cmdline_option_handle_builtin(argc, argv, info);
+	signal(SIGINT, sigint_handler);
+
+	lwsl_user("LWS Secure Streams Sink hello_world\n");
+
+	info->early_smd_cb		= smd_cb;
+	info->early_smd_class_filter	= LWSSMDCL_SYSTEM_STATE;
+
+	cx = lws_create_context(info);
+	free(info);
+	if (!cx) {
+		lwsl_err("lws init failed\n");
+		return 1;
+	}
+
+	lws_context_default_loop_run_destroy(cx);
+
+	/* process ret 0 if actual is as expected (0, or--expected-exit 123) */
+
+	return lws_cmdline_passfail(argc, argv, test_result);
+}

--- a/minimal-examples/sink/hello_world/ss-sink.c
+++ b/minimal-examples/sink/hello_world/ss-sink.c
@@ -1,0 +1,97 @@
+/*
+ * lws-minimal-ss-sink-hello_world
+ *
+ * Written in 2010-2021 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ *
+ * Simple SS sink
+ */
+
+#include <libwebsockets.h>
+
+LWS_SS_USER_TYPEDEF
+	char			payload[200];
+	size_t			size;
+	size_t			pos;
+} myss_sink_t;
+
+static lws_ss_state_return_t
+myss_sink_tx(void *userobj, lws_ss_tx_ordinal_t ord, uint8_t *buf, size_t *len,
+	    int *flags)
+{
+	myss_sink_t *g = (myss_sink_t *)userobj;
+	lws_ss_state_return_t r = LWSSSSRET_OK;
+
+	if (g->size == g->pos)
+		return LWSSSSRET_TX_DONT_SEND;
+
+	if (*len > g->size - g->pos)
+		*len = g->size - g->pos;
+
+	if (!g->pos)
+		*flags |= LWSSS_FLAG_SOM;
+
+	memcpy(buf, g->payload + g->pos, *len);
+	g->pos += *len;
+
+	if (g->pos != g->size) /* more to do */
+		r = lws_ss_request_tx(lws_ss_from_user(g));
+	else
+		*flags |= LWSSS_FLAG_EOM;
+
+	lwsl_ss_user(lws_ss_from_user(g), "TX %zu, flags 0x%x, r %d", *len,
+					  (unsigned int)*flags, (int)r);
+
+	return r;
+}
+
+static lws_ss_state_return_t
+myss_sink_rx(void *userobj, const uint8_t *buf, size_t len, int flags)
+{
+	myss_sink_t *g = (myss_sink_t *)userobj;
+
+	lwsl_ss_notice(lws_ss_from_user(g), "len %u, flags 0x%x",
+					    (unsigned int)len,
+					    (unsigned int)flags);
+	lwsl_hexdump_notice(buf, len);
+
+	if (flags & LWSSS_FLAG_EOM) {
+		/* we're going to respond to it */
+
+		g->size	= (size_t)lws_snprintf(g->payload, sizeof(g->payload),
+					       "From Sink: Hello World: %lu",
+					       (unsigned long)lws_now_usecs());
+		g->pos = 0;
+
+		return lws_ss_request_tx_len(lws_ss_from_user(g),
+					     (unsigned long)g->size);
+	}
+
+	return LWSSSSRET_OK;
+}
+
+static lws_ss_state_return_t
+myss_sink_state(void *userobj, void *sh, lws_ss_constate_t state,
+	       lws_ss_tx_ordinal_t ack)
+{
+	myss_sink_t *g = (myss_sink_t *)userobj;
+
+	switch ((int)state) {
+	case LWSSSCS_CREATING:
+		return lws_ss_request_tx(lws_ss_from_user(g));
+
+	case LWSSSCS_SERVER_TXN:
+		break;
+	}
+
+	return LWSSSSRET_OK;
+}
+
+LWS_SS_INFO("sink_hello_world", myss_sink_t)
+	.tx				= myss_sink_tx,
+	.rx				= myss_sink_rx,
+	.state				= myss_sink_state,
+	.flags				= LWSSSINFLAGS_REGISTER_SINK
+};

--- a/minimal-examples/sink/hello_world/ss-source.c
+++ b/minimal-examples/sink/hello_world/ss-source.c
@@ -1,0 +1,103 @@
+/*
+ * lws-minimal-ss-sink-hello_world
+ *
+ * Written in 2010-2021 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ *
+ * Simple SS source... it's just a normal SS user implementation, it does not
+ * have any dependency on the policy routing it to a sink instead of, eg,
+ * wss to a cloud endpoint.
+ */
+
+#include <libwebsockets.h>
+
+extern int test_result;
+
+LWS_SS_USER_TYPEDEF
+	char			payload[200];
+	size_t			size;
+	size_t			pos;
+} myss_src_t;
+
+static lws_ss_state_return_t
+myss_src_tx(void *userobj, lws_ss_tx_ordinal_t ord, uint8_t *buf, size_t *len,
+	    int *flags)
+{
+	myss_src_t *g = (myss_src_t *)userobj;
+	lws_ss_state_return_t r = LWSSSSRET_OK;
+
+	if (g->size == g->pos)
+		return LWSSSSRET_TX_DONT_SEND;
+
+	if (*len > g->size - g->pos)
+		*len = g->size - g->pos;
+
+	if (!g->pos)
+		*flags |= LWSSS_FLAG_SOM;
+
+	memcpy(buf, g->payload + g->pos, *len);
+	g->pos += *len;
+
+	if (g->pos != g->size) /* more to do */
+		r = lws_ss_request_tx(lws_ss_from_user(g));
+	else
+		*flags |= LWSSS_FLAG_EOM;
+
+	lwsl_ss_user(lws_ss_from_user(g), "TX %zu, flags 0x%x, r %d", *len,
+					  (unsigned int)*flags, (int)r);
+
+	return r;
+}
+
+static lws_ss_state_return_t
+myss_src_rx(void *userobj, const uint8_t *buf, size_t len, int flags)
+{
+	myss_src_t *g = (myss_src_t *)userobj;
+
+	lwsl_ss_notice(lws_ss_from_user(g), "len %u, flags 0x%x",
+					    (unsigned int)len,
+					    (unsigned int)flags);
+	lwsl_hexdump_notice(buf, len);
+
+	/*
+	 * In this example, we take getting the sink's ack of our message
+	 * as meaning "success".
+	 */
+
+	test_result = 0;
+	lws_default_loop_exit(lws_ss_cx_from_user(g));
+
+	return LWSSSSRET_OK;
+}
+
+static lws_ss_state_return_t
+myss_src_state(void *userobj, void *sh, lws_ss_constate_t state,
+	       lws_ss_tx_ordinal_t ack)
+{
+	myss_src_t *g = (myss_src_t *)userobj;
+
+	switch ((int)state) {
+	case LWSSSCS_CREATING:
+		lwsl_notice("%s: CREATING\n", __func__);
+		return lws_ss_request_tx(lws_ss_from_user(g));
+
+	case LWSSSCS_CONNECTED:
+		g->size	= (size_t)lws_snprintf(g->payload, sizeof(g->payload),
+					       "From Source: Hello World: %lu",
+					       (unsigned long)lws_now_usecs());
+		g->pos = 0;
+
+		return lws_ss_request_tx_len(lws_ss_from_user(g),
+					     (unsigned long)g->size);
+	}
+
+	return LWSSSSRET_OK;
+}
+
+LWS_SS_INFO("sink_hello_world", myss_src_t)
+	.tx				= myss_src_tx,
+	.rx				= myss_src_rx,
+	.state				= myss_src_state,
+};


### PR DESCRIPTION
We (are going to) use libwebsockets in our project: https://github.com/apache/nifi-minifi-cpp.

We download and compile both OpenSSL(*) and libwebsockets during the build process.  This doesn't quite work out of the box, because CMake sets `OPENSSL_FOUND` to `TRUE` and OpenSSL sets `OPENSSL_INCLUDE_DIR` (and `OPENSSL_LIBRARIES`), but it does not set `OPENSSL_INCLUDE_DIRS`, which is read by libwebsockets.

This patch fixes the issue, so it will allow us, and others, to use libwebsockets in this way.



(*) we currently use the LibreSSL flavor of OpenSSL for licensing reasons, but according to [FindOpenSSL.cmake](https://github.com/Kitware/CMake/blob/master/Modules/FindOpenSSL.cmake), setting `OPENSSL_INCLUDE_DIR` but not `OPENSSL_INCLUDE_DIRS` is the correct behavior and other flavors probably do the same.