### PR TITLE
Fix winsock recv() and send() buffer ptr type

### DIFF
--- a/lib/plat/windows/windows-sockets.c
+++ b/lib/plat/windows/windows-sockets.c
@@ -604,7 +604,7 @@ lws_plat_mbedtls_net_send(void *ctx, const uint8_t *buf, size_t len)
 	if (fd < 0)
 		return MBEDTLS_ERR_NET_INVALID_CONTEXT;
 
-	ret = send(fd, buf, (unsigned int)len, 0);
+	ret = send(fd, (const char *)buf, (unsigned int)len, 0);
 	if (ret >= 0)
 		return ret;
 
@@ -629,7 +629,7 @@ lws_plat_mbedtls_net_recv(void *ctx, unsigned char *buf, size_t len)
 	if (fd < 0)
 		return MBEDTLS_ERR_NET_INVALID_CONTEXT;
 
-	ret = (int)recv(fd, buf, (unsigned int)len, 0);
+	ret = (int)recv(fd, (char *)buf, (unsigned int)len, 0);
 	if (ret >= 0)
 		return ret;
 


### PR DESCRIPTION
This allows to build libwebsockets on MinGW. Winsock recv() and send()
expect non unsigned char* while lws uses uint_8*.

https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send
https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv


```
[  9%] Building C object lib/CMakeFiles/websockets.dir/plat/windows/windows-sockets.c.obj
Z:/src_win/libwebsockets/lib/plat/windows/windows-sockets.c: In function 'lws_plat_mbedtls_net_send':
Z:/src_win/libwebsockets/lib/plat/windows/windows-sockets.c:567:24: error: pointer targets in passing argument 2 of 'send' differ in signedness [-Werror=pointer-sign]
  567 |         ret = send(fd, buf, (unsigned int)len, 0);
      |                        ^~~
      |                        |
      |                        const uint8_t * {aka const unsigned char *}
In file included from Z:/src_win/libwebsockets/lib/plat/windows/private-lib-plat-windows.h:57,
                 from Z:/src_win/libwebsockets/lib/core/private-lib-core.h:124,
                 from Z:/src_win/libwebsockets/lib/plat/windows/windows-sockets.c:29:
C:/msys64/mingw64/x86_64-w64-mingw32/include/winsock2.h:1033:60: note: expected 'const char *' but argument is of type 'const uint8_t *' {aka 'const unsigned char *'}
 1033 |   WINSOCK_API_LINKAGE int WSAAPI send(SOCKET s,const char *buf,int len,int flags);
      |                                                ~~~~~~~~~~~~^~~
Z:/src_win/libwebsockets/lib/plat/windows/windows-sockets.c: In function 'lws_plat_mbedtls_net_recv':
Z:/src_win/libwebsockets/lib/plat/windows/windows-sockets.c:592:29: error: pointer targets in passing argument 2 of 'recv' differ in signedness [-Werror=pointer-sign]
  592 |         ret = (int)recv(fd, buf, (unsigned int)len, 0);
      |                             ^~~
      |                             |
      |                             unsigned char *
In file included from Z:/src_win/libwebsockets/lib/plat/windows/private-lib-plat-windows.h:57,
                 from Z:/src_win/libwebsockets/lib/core/private-lib-core.h:124,
                 from Z:/src_win/libwebsockets/lib/plat/windows/windows-sockets.c:29:
C:/msys64/mingw64/x86_64-w64-mingw32/include/winsock2.h:1028:54: note: expected 'char *' but argument is of type 'unsigned char *'
 1028 |   WINSOCK_API_LINKAGE int WSAAPI recv(SOCKET s,char *buf,int len,int flags);
      |                                                ~~~~~~^~~
cc1.exe: all warnings being treated as errors
make[2]: *** [lib/CMakeFiles/websockets.dir/build.make:174: lib/CMakeFiles/websockets.dir/plat/windows/windows-sockets.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:1255: lib/CMakeFiles/websockets.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```