### PR TITLE
add Openssl client callback also for wolfssl

### DIFF
--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -44,7 +44,6 @@ int lws_openssl_describe_cipher(struct lws *wsi);
 extern int openssl_websocket_private_data_index,
     openssl_SSL_CTX_private_data_index;
 
-#if !defined(USE_WOLFSSL)
 
 #if 0
 #if defined(LWS_WITH_TLS_JIT_TRUST)
@@ -228,7 +227,6 @@ OpenSSL_client_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
 	 */
 	return !n;
 }
-#endif
 
 int
 lws_ssl_client_bio_create(struct lws *wsi)
@@ -368,6 +366,8 @@ lws_ssl_client_bio_create(struct lws *wsi)
 #else
 	if (wsi->tls.use_ssl & LCCSCF_ALLOW_SELFSIGNED)
 		wolfSSL_set_verify(wsi->tls.ssl, SSL_VERIFY_NONE, NULL);
+	else if (wsi->tls.use_ssl & LCCSCF_USE_SSL)
+		wolfSSL_set_verify(wsi->tls.ssl, SSL_VERIFY_PEER, OpenSSL_client_verify_callback);
 #endif
 #endif /* USE_WOLFSSL */
 


### PR DESCRIPTION
Please consider this WIP for now.

When using WolfSSL and connecting a client against a TLS server, the callback `LWS_CALLBACK_OPENSSL_PERFORM_SERVER_CERT_VERIFICATION` is not invoked - also not on `protocols[0]`.

Going through the code, I realized it is implemented to only do this for OpenSSL.

This change allows to re-use the existing OpenSSL callback `OpenSSL_client_verify_callback` also for WolfSSL.

What I tested as of now is loading the root certificate via `client_ssl_ca_filepath`, set `LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK` (because it is not implemented for WolfSSL) and then do the hostname check inside the verify callback. Also an OCSP check etc. could be done in this callback.

I am not yet sure about the already existing logic insde `OpenSSL_client_verify_callback` and whether this fits to WolfSSL.
An option would be to introduce `WolfSSL_client_verify_callback`, that only does
```
	n = lws_get_context_protocol(wsi->a.context, 0).callback(wsi,
			LWS_CALLBACK_OPENSSL_PERFORM_SERVER_CERT_VERIFICATION,
			x509_ctx, ssl, (unsigned int)preverify_ok);
```
and leaves the rest to the user.

Happy about any thoughts.