### PR TITLE
[GIT PULL] Fix clang build error `-Wunused-but-set-variable`

### DIFF
--- a/lib/secure-streams/protocols/ss-h1.c
+++ b/lib/secure-streams/protocols/ss-h1.c
@@ -313,7 +313,7 @@ static int
 lws_extract_metadata(lws_ss_handle_t *h, struct lws *wsi)
 {
 	lws_ss_metadata_t *polmd = h->policy->metadata, *omd;
-	int n, m = 0;
+	int n;
 
 	while (polmd) {
 
@@ -410,7 +410,6 @@ lws_extract_metadata(lws_ss_handle_t *h, struct lws *wsi)
 			}
 #endif
 
-		m++;
 		polmd = polmd->next;
 	}
 


### PR DESCRIPTION
Hi,

When building with clang-15, I got the following error:
```
  error: variable 'm' set but not used [-Werror,-Wunused-but-set-variable]
          int n, m = 0;
                 ^
```
Let's just remove the `m` variable here, it's not used.

Signed-off-by: Ammar Faizi &lt;ammarfaizi2@gnuweeb.org&gt;

---

```
The following changes since commit a5612fbb9a63e38e2cce50880716745fadc8cb74:

  test-apps: use correct EXTERNAL_POLL flag (2022-06-17 04:52:17 +0100)

are available in the Git repository at:

  https://github.com/ammarfaizi2/libwebsockets.git tags/fix-clang-error

for you to fetch changes up to aa990b1451e87f2ad221b0a1a7ebfc0b1f369292:

  lib/secure-streams: Fix clang build error `-Wunused-but-set-variable` (2022-06-22 09:06:27 +0700)

----------------------------------------------------------------
fix-clang-error

----------------------------------------------------------------
Ammar Faizi (1):
      lib/secure-streams: Fix clang build error `-Wunused-but-set-variable`

 lib/secure-streams/protocols/ss-h1.c | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)
```