### PR TITLE
fix build on QNX 6.5.0

### DIFF
--- a/lib/misc/dir.c
+++ b/lib/misc/dir.c
@@ -131,7 +131,7 @@ lws_dir(const char *dirpath, void *user, lws_dir_callback_function cb)
 	}
 
 	for (i = 0; i < n; i++) {
-#if !defined(__sun)
+#if !defined(__sun) && !defined(__QNX__)
 		unsigned int type = namelist[i]->d_type;
 #endif
 		if (strchr(namelist[i]->d_name, '~'))
@@ -143,7 +143,7 @@ lws_dir(const char *dirpath, void *user, lws_dir_callback_function cb)
 		 * files are LDOT_UNKNOWN
 		 */
 
-#if defined(__sun)
+#if defined(__sun) || defined(__QNX__)
 		lws_dir_via_stat(combo, l, namelist[i]->d_name, &lde);
 #else
 		/*

--- a/lib/plat/unix/unix-sockets.c
+++ b/lib/plat/unix/unix-sockets.c
@@ -198,7 +198,7 @@ static const int ip_opt_lws_flags[] = {
 #endif
 }, ip_opt_val[] = {
 	IPTOS_LOWDELAY, IPTOS_THROUGHPUT, IPTOS_RELIABILITY
-#if !defined(__OpenBSD__) && !defined(__sun)
+#if !defined(__OpenBSD__) && !defined(__sun) && !defined(__QNX__)
 	, IPTOS_MINCOST
 #endif
 };


### PR DESCRIPTION
On QNX not found IPTOS_MINCOST in lib/plat/unix/unix-sockets.c

```log

/source_subfolder/lib/plat/unix/unix-sockets.c:202:4: error: 'IPTOS_MINCOST' undeclared here (not in a function)
  , IPTOS_MINCOST
    ^
```
and same problem with dir.c like __sun toolchain

``` log
/source_subfolder/lib/misc/dir.c: In function 'lws_dir':
/source_subfolder/lib/misc/dir.c:135:34: error: 'struct dirent' has no member named 'd_type'
   unsigned int type = namelist[i]->d_type;
                                  ^
/source_subfolder/lib/misc/dir.c:153:7: error: 'DT_BLK' undeclared (first use in this function)
   if (DT_BLK != DT_UNKNOWN && type == DT_BLK)
       ^
/source_subfolder/lib/misc/dir.c:153:7: note: each undeclared identifier is reported only once for each function it appears in
/source_subfolder/lib/misc/dir.c:153:17: error: 'DT_UNKNOWN' undeclared (first use in this function)
   if (DT_BLK != DT_UNKNOWN && type == DT_BLK)
                 ^
/source_subfolder/lib/misc/dir.c:155:12: error: 'DT_CHR' undeclared (first use in this function)
   else if (DT_CHR != DT_UNKNOWN && type == DT_CHR)
            ^
/source_subfolder/lib/misc/dir.c:157:12: error: 'DT_DIR' undeclared (first use in this function)
   else if (DT_DIR != DT_UNKNOWN && type == DT_DIR)
            ^
/source_subfolder/lib/misc/dir.c:159:12: error: 'DT_FIFO' undeclared (first use in this function)
   else if (DT_FIFO != DT_UNKNOWN && type == DT_FIFO)
            ^
/source_subfolder/lib/misc/dir.c:161:12: error: 'DT_LNK' undeclared (first use in this function)
   else if (DT_LNK != DT_UNKNOWN && type == DT_LNK)
            ^
/source_subfolder/lib/misc/dir.c:163:12: error: 'DT_REG' undeclared (first use in this function)
   else if (DT_REG != DT_UNKNOWN && type == DT_REG)
            ^
/source_subfolder/lib/misc/dir.c:165:12: error: 'DT_SOCK' undeclared (first use in this function)
   else if (DT_SOCK != DT_UNKNOWN && type == DT_SOCK)
            ^
make[2]: *** [source_subfolder/lib/CMakeFiles/websockets_shared.dir/build.make:538: source_subfolder/lib/CMakeFiles/websockets_shared.dir/misc/dir.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1273: source_subfolder/lib/CMakeFiles/websockets_shared.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
```
