### PR TITLE
remove LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY callback

### DIFF
--- a/include/libwebsockets/lws-callbacks.h
+++ b/include/libwebsockets/lws-callbacks.h
@@ -160,15 +160,6 @@ enum lws_callback_reasons {
 	 * the default callback action of returning 0 allows the client
 	 * certificates. */
 
-	LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY	= 37,
-	/**< if configured for including OpenSSL support but no private key
-	 * file has been specified (ssl_private_key_filepath is NULL), this is
-	 * called to allow the user to set the private key directly via
-	 * libopenssl and perform further operations if required; this might be
-	 * useful in situations where the private key is not directly accessible
-	 * by the OS, for example if it is stored on a smartcard.
-	 * user is the server's OpenSSL SSL_CTX* */
-
 	LWS_CALLBACK_SSL_INFO					= 67,
 	/**< SSL connections only.  An event you registered an
 	 * interest in at the vhost has occurred on a connection

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -393,10 +393,15 @@ struct lws_context_creation_info {
 	 */
 	const char *ssl_private_key_filepath;
 	/**<  VHOST: filepath to private key if wanting SSL mode;
-	 * if this is set to NULL but ssl_cert_filepath is set, the
-	 * OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY callback is called
-	 * to allow setting of the private key directly via openSSL
-	 * library calls.   (For backwards compatibility, this can also be used
+	 * this should not be set to NULL when ssl_cert_filepath is set.
+	 *
+	 * Alteratively, the certificate and private key can both be set in
+	 * the OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS callback directly via
+	 * openSSL library calls.  This requires that
+	 * LWS_SERVER_OPTION_CREATE_VHOST_SSL_CTX is set in the vhost info options
+	 * to force initializtion of the SSL_CTX context.
+	 *
+	 * (For backwards compatibility, this can also be used
 	 * to pass the client cert private key filepath when setting up a
 	 * vhost client SSL context, but it is preferred to use
 	 * .client_ssl_private_key_filepath for that.)

--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -228,7 +228,10 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 			return 1;
 		}
 
-		if (private_key) {
+		if (!private_key) {
+			lwsl_err("ssl private key not set\n");
+			return 1;
+		} else {
 			/* set the private key from KeyFile */
 			if (SSL_CTX_use_PrivateKey_file(vhost->tls.ssl_ctx, private_key,
 							SSL_FILETYPE_PEM) != 1) {
@@ -242,14 +245,6 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 					       (char *)vhost->context->pt[0].serv_buf);
 				lwsl_err("ssl problem getting key '%s' %lu: %s\n",
 					 private_key, error, s);
-				return 1;
-			}
-		} else {
-			if (vhost->protocols[0].callback(wsi,
-				      LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-							 vhost->tls.ssl_ctx, NULL, 0)) {
-				lwsl_err("ssl private key not set\n");
-
 				return 1;
 			}
 		}
@@ -389,7 +384,10 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 		return 1;
 	}
 
-	if (n != LWS_TLS_EXTANT_ALTERNATIVE && private_key) {
+	if (n == LWS_TLS_EXTANT_ALTERNATIVE || !private_key) {
+		lwsl_err("ssl private key not set\n");
+		return 1;
+	} else {
 		/* set the private key from KeyFile */
 		if (SSL_CTX_use_PrivateKey_file(vhost->tls.ssl_ctx, private_key,
 					        SSL_FILETYPE_PEM) != 1) {
@@ -398,14 +396,6 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 				 private_key, error,
 				 ERR_error_string(error,
 				      (char *)vhost->context->pt[0].serv_buf));
-			return 1;
-		}
-	} else {
-		if (vhost->protocols[0].callback(wsi,
-			      LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-						 vhost->tls.ssl_ctx, NULL, 0)) {
-			lwsl_err("ssl private key not set\n");
-
 			return 1;
 		}
 	}


### PR DESCRIPTION
When a certificate for a TLS connection is provided, but a private
key is not, the SSL_CTX initialization exits early, before the
CONTEXT_REQUIRES_PRIVATE_KEY callback can be issued.
Remove the now obsolete callback and update the vhost
field description to state that the LOAD_EXTRA_SERVER_VERIFY_CERTS
callback should be used instead.

Fixes #2495 