### PR TITLE
minimal-examples-lowlevel: fix misleading comment for the conceal value

### DIFF
--- a/include/libwebsockets/lws-callbacks.h
+++ b/include/libwebsockets/lws-callbacks.h
@@ -160,15 +160,6 @@ enum lws_callback_reasons {
 	 * the default callback action of returning 0 allows the client
 	 * certificates. */
 
-	LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY	= 37,
-	/**< if configured for including OpenSSL support but no private key
-	 * file has been specified (ssl_private_key_filepath is NULL), this is
-	 * called to allow the user to set the private key directly via
-	 * libopenssl and perform further operations if required; this might be
-	 * useful in situations where the private key is not directly accessible
-	 * by the OS, for example if it is stored on a smartcard.
-	 * user is the server's OpenSSL SSL_CTX* */
-
 	LWS_CALLBACK_SSL_INFO					= 67,
 	/**< SSL connections only.  An event you registered an
 	 * interest in at the vhost has occurred on a connection

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -393,10 +393,15 @@ struct lws_context_creation_info {
 	 */
 	const char *ssl_private_key_filepath;
 	/**<  VHOST: filepath to private key if wanting SSL mode;
-	 * if this is set to NULL but ssl_cert_filepath is set, the
-	 * OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY callback is called
-	 * to allow setting of the private key directly via openSSL
-	 * library calls.   (For backwards compatibility, this can also be used
+	 * this should not be set to NULL when ssl_cert_filepath is set.
+	 *
+	 * Alteratively, the certificate and private key can both be set in
+	 * the OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS callback directly via
+	 * openSSL library calls.  This requires that
+	 * LWS_SERVER_OPTION_CREATE_VHOST_SSL_CTX is set in the vhost info options
+	 * to force initializtion of the SSL_CTX context.
+	 *
+	 * (For backwards compatibility, this can also be used
 	 * to pass the client cert private key filepath when setting up a
 	 * vhost client SSL context, but it is preferred to use
 	 * .client_ssl_private_key_filepath for that.)

--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -228,7 +228,10 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 			return 1;
 		}
 
-		if (private_key) {
+		if (!private_key) {
+			lwsl_err("ssl private key not set\n");
+			return 1;
+		} else {
 			/* set the private key from KeyFile */
 			if (SSL_CTX_use_PrivateKey_file(vhost->tls.ssl_ctx, private_key,
 							SSL_FILETYPE_PEM) != 1) {
@@ -242,14 +245,6 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 					       (char *)vhost->context->pt[0].serv_buf);
 				lwsl_err("ssl problem getting key '%s' %lu: %s\n",
 					 private_key, error, s);
-				return 1;
-			}
-		} else {
-			if (vhost->protocols[0].callback(wsi,
-				      LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-							 vhost->tls.ssl_ctx, NULL, 0)) {
-				lwsl_err("ssl private key not set\n");
-
 				return 1;
 			}
 		}
@@ -389,7 +384,10 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 		return 1;
 	}
 
-	if (n != LWS_TLS_EXTANT_ALTERNATIVE && private_key) {
+	if (n == LWS_TLS_EXTANT_ALTERNATIVE || !private_key) {
+		lwsl_err("ssl private key not set\n");
+		return 1;
+	} else {
 		/* set the private key from KeyFile */
 		if (SSL_CTX_use_PrivateKey_file(vhost->tls.ssl_ctx, private_key,
 					        SSL_FILETYPE_PEM) != 1) {
@@ -398,14 +396,6 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 				 private_key, error,
 				 ERR_error_string(error,
 				      (char *)vhost->context->pt[0].serv_buf));
-			return 1;
-		}
-	} else {
-		if (vhost->protocols[0].callback(wsi,
-			      LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-						 vhost->tls.ssl_ctx, NULL, 0)) {
-			lwsl_err("ssl private key not set\n");
-
 			return 1;
 		}
 	}

--- a/minimal-examples-lowlevel/ws-client/minimal-ws-client-binance/main.c
+++ b/minimal-examples-lowlevel/ws-client/minimal-ws-client-binance/main.c
@@ -312,9 +312,9 @@ do_retry:
 	 * For this example, we try to conceal any problem for one set of
 	 * backoff retries and then exit the app.
 	 *
-	 * If you set retry.conceal_count to be larger than the number of
-	 * elements in the backoff table, it will never give up and keep
-	 * retrying at the last backoff delay plus the random jitter amount.
+	 * If you set retry.conceal_count to be LWS_RETRY_CONCEAL_ALWAYS,
+	 * it will never give up and keep retrying at the last backoff
+	 * delay plus the random jitter amount.
 	 */
 	if (lws_retry_sul_schedule_retry_wsi(wsi, &mco->sul, connect_client,
 					     &mco->retry_count)) {

--- a/minimal-examples-lowlevel/ws-client/minimal-ws-client/minimal-ws-client.c
+++ b/minimal-examples-lowlevel/ws-client/minimal-ws-client/minimal-ws-client.c
@@ -123,9 +123,9 @@ do_retry:
 	 * For this example, we try to conceal any problem for one set of
 	 * backoff retries and then exit the app.
 	 *
-	 * If you set retry.conceal_count to be larger than the number of
-	 * elements in the backoff table, it will never give up and keep
-	 * retrying at the last backoff delay plus the random jitter amount.
+	 * If you set retry.conceal_count to be LWS_RETRY_CONCEAL_ALWAYS,
+	 * it will never give up and keep retrying at the last backoff
+	 * delay plus the random jitter amount.
 	 */
 	if (lws_retry_sul_schedule_retry_wsi(wsi, &m->sul, connect_client,
 					     &m->retry_count)) {


### PR DESCRIPTION
Following the examples, I initially tried using `conceal_count` like:

```c
static const lws_retry_bo_t retry = {
    .retry_ms_table = backoff_ms,
    .retry_ms_table_count = LWS_ARRAY_SIZE(backoff_ms),

    .conceal_count = LWS_ARRAY_SIZE(backoff_ms) + 1,

    .secs_since_valid_ping = 3,
    .secs_since_valid_hangup = 10,

    .jitter_percent = 20,
};
```

expecting that the client would never give up. However it did after `LWS_ARRAY_SIZE(backoff_ms) + 1` attempts, as in the `lws_retry_get_delay_ms` method the conceal is calculated as 

```c
*conceal = (int)*ctry <= retry->conceal_count;
```

What is necessary instead is to set `conceal_count` to `0xffff` or `LWS_RETRY_CONCEAL_ALWAYS` if one wants the client to never give up.




