### PR TITLE
sul scheduled callback for connection establishment

### DIFF
--- a/include/libwebsockets/lws-callbacks.h
+++ b/include/libwebsockets/lws-callbacks.h
@@ -160,15 +160,6 @@ enum lws_callback_reasons {
 	 * the default callback action of returning 0 allows the client
 	 * certificates. */
 
-	LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY	= 37,
-	/**< if configured for including OpenSSL support but no private key
-	 * file has been specified (ssl_private_key_filepath is NULL), this is
-	 * called to allow the user to set the private key directly via
-	 * libopenssl and perform further operations if required; this might be
-	 * useful in situations where the private key is not directly accessible
-	 * by the OS, for example if it is stored on a smartcard.
-	 * user is the server's OpenSSL SSL_CTX* */
-
 	LWS_CALLBACK_SSL_INFO					= 67,
 	/**< SSL connections only.  An event you registered an
 	 * interest in at the vhost has occurred on a connection

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -941,6 +941,14 @@ struct lws_context_creation_info {
 	 */
 #endif
 
+#if defined(WIN32)
+	unsigned int win32_connect_check_interval_usec;
+	/**< CONTEXT: win32 needs client connection status checking at intervals
+	 * to work reliably.  This sets the interval in us, up to 999999.  By
+	 * default, it's 500us.
+	 */
+#endif
+
 	/* Add new things just above here ---^
 	 * This is part of the ABI, don't needlessly break compatibility
 	 *

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -393,10 +393,15 @@ struct lws_context_creation_info {
 	 */
 	const char *ssl_private_key_filepath;
 	/**<  VHOST: filepath to private key if wanting SSL mode;
-	 * if this is set to NULL but ssl_cert_filepath is set, the
-	 * OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY callback is called
-	 * to allow setting of the private key directly via openSSL
-	 * library calls.   (For backwards compatibility, this can also be used
+	 * this should not be set to NULL when ssl_cert_filepath is set.
+	 *
+	 * Alteratively, the certificate and private key can both be set in
+	 * the OPENSSL_LOAD_EXTRA_SERVER_VERIFY_CERTS callback directly via
+	 * openSSL library calls.  This requires that
+	 * LWS_SERVER_OPTION_CREATE_VHOST_SSL_CTX is set in the vhost info options
+	 * to force initializtion of the SSL_CTX context.
+	 *
+	 * (For backwards compatibility, this can also be used
 	 * to pass the client cert private key filepath when setting up a
 	 * vhost client SSL context, but it is preferred to use
 	 * .client_ssl_private_key_filepath for that.)

--- a/lib/core-net/client/connect3.c
+++ b/lib/core-net/client/connect3.c
@@ -24,6 +24,30 @@
 
 #include "private-lib-core.h"
 
+#if defined(WIN32)
+
+/*
+ * Windows doesn't offer a Posix connect() event... we use a sul
+ * to check the connection status periodically while a connection
+ * is ongoing.
+ *
+ * Leaving this to POLLOUT to retry which is the way for Posix
+ * platforms instead on win32 causes event-loop busywaiting
+ * so for win32 we manage the retry interval directly with the sul.
+ */
+
+void
+lws_client_win32_conn_async_check(lws_sorted_usec_list_t *sul)
+{
+	struct lws *wsi = lws_container_of(sul, struct lws,
+					   win32_sul_connect_async_check);
+
+	lwsl_wsi_debug(wsi, "checking ongoing connection attempt");
+	lws_client_connect_3_connect(wsi, NULL, NULL, 0, NULL);
+}
+
+#endif
+
 void
 lws_client_conn_wait_timeout(lws_sorted_usec_list_t *sul)
 {
@@ -107,40 +131,41 @@ lws_client_connect_check(struct lws *wsi, int *real_errno)
 
 		return LCCCR_FAILED;
 	}
-
 #else
+	fd_set write_set, except_set;
+	struct timeval tv;
+	int ret;
 
-	if (!connect(wsi->desc.sockfd, (const struct sockaddr *)&wsi->sa46_peer.sa4,
-#if defined(WIN32)
-				sizeof(struct sockaddr)))
-#else
-				0))
-#endif
+	FD_ZERO(&write_set);
+	FD_ZERO(&except_set);
+	FD_SET(wsi->desc.sockfd, &write_set);
+	FD_SET(wsi->desc.sockfd, &except_set);
 
+	tv.tv_sec = 0;
+	tv.tv_usec = 1;
+
+	ret = select((int)wsi->desc.sockfd + 1, NULL, &write_set, &except_set, &tv);
+	if (FD_ISSET(wsi->desc.sockfd, &write_set)) {
+		/* actually connected */
+		lwsl_wsi_debug(wsi, "select write fd set, conn OK");
 		return LCCCR_CONNECTED;
-
-	en = LWS_ERRNO;
-
-	if (en == WSAEISCONN) /* already connected */
-		return LCCCR_CONNECTED;
-
-	if (en == WSAEALREADY) {
-		/* reset the POLLOUT wait */
-		if (lws_change_pollfd(wsi, 0, LWS_POLLOUT))
-			lwsl_wsi_notice(wsi, "pollfd failed");
 	}
 
-	if (!en || en == WSAEINVAL ||
-		   en == WSAEWOULDBLOCK ||
-		   en == WSAEALREADY) {
-		lwsl_wsi_debug(wsi, "%s",
-				lws_errno_describe(en, t16, sizeof(t16)));
+	if (FD_ISSET(wsi->desc.sockfd, &except_set)) {
+		/* Failed to connect */
+		lwsl_wsi_notice(wsi, "connect failed, select exception fd set");
+		return LCCCR_FAILED;
+	}
 
+	if (!ret) {
+		lwsl_wsi_debug(wsi, "select timeout");
 		return LCCCR_CONTINUE;
 	}
+
+	en = LWS_ERRNO;
 #endif
 
-	lwsl_wsi_notice(wsi, "connect check FAILED: %s",
+	lwsl_wsi_notice(wsi, "connection check FAILED: %s",
 			lws_errno_describe(*real_errno || en, t16, sizeof(t16)));
 
 	return LCCCR_FAILED;
@@ -261,7 +286,14 @@ lws_client_connect_3_connect(struct lws *wsi, const char *ads,
 			 */
 			goto conn_good;
 		case LCCCR_CONTINUE:
+#if defined(WIN32)
+			lws_sul_schedule(wsi->a.context, 0, &wsi->win32_sul_connect_async_check,
+				lws_client_win32_conn_async_check,
+				wsi->a.context->win32_connect_check_interval_usec);
+#endif
+
 			return NULL;
+
 		default:
 			if (!real_errno)
 				real_errno = LWS_ERRNO;
@@ -627,13 +659,25 @@ ads_known:
 				 lws_client_conn_wait_timeout,
 				 wsi->a.context->timeout_secs *
 						 LWS_USEC_PER_SEC);
-
+#if defined(WIN32)
 		/*
-		 * must do specifically a POLLOUT poll to hear
-		 * about the connect completion
+		 * Windows is not properly POSIX, we have to manually schedule a
+		 * callback to poll checking its status
 		 */
+
+		lws_sul_schedule(wsi->a.context, 0, &wsi->win32_sul_connect_async_check,
+				 lws_client_win32_conn_async_check,
+				 wsi->a.context->win32_connect_check_interval_usec
+		);
+#else
+		/*
+		 * POSIX platforms must do specifically a POLLOUT poll to hear
+		 * about the connect completion as a POLLOUT event
+		 */
+
 		if (lws_change_pollfd(wsi, 0, LWS_POLLOUT))
 			goto try_next_dns_result_fds;
+#endif
 
 		return wsi;
 	}
@@ -673,8 +717,10 @@ conn_good:
 #endif
 	}
 #endif
-
 	lws_sul_cancel(&wsi->sul_connect_timeout);
+#if defined(WIN32)
+	lws_sul_cancel(&wsi->win32_sul_connect_async_check);
+#endif
 	lws_metrics_caliper_report(wsi->cal_conn, METRES_GO);
 
 	lws_addrinfo_clean(wsi);
@@ -745,6 +791,9 @@ try_next_dns_result_closesock:
 
 try_next_dns_result:
 	lws_sul_cancel(&wsi->sul_connect_timeout);
+#if defined(WIN32)
+	lws_sul_cancel(&wsi->win32_sul_connect_async_check);
+#endif
 	if (lws_dll2_get_head(&wsi->dns_sorted_list))
 		goto next_dns_result;
 

--- a/lib/core-net/client/connect3.c
+++ b/lib/core-net/client/connect3.c
@@ -142,7 +142,7 @@ lws_client_connect_check(struct lws *wsi, int *real_errno)
 	FD_SET(wsi->desc.sockfd, &except_set);
 
 	tv.tv_sec = 0;
-	tv.tv_usec = 1;
+	tv.tv_usec = 0;
 
 	ret = select((int)wsi->desc.sockfd + 1, NULL, &write_set, &except_set, &tv);
 	if (FD_ISSET(wsi->desc.sockfd, &write_set)) {

--- a/lib/core-net/close.c
+++ b/lib/core-net/close.c
@@ -581,6 +581,9 @@ just_kill_connection:
 #endif
 
 	lws_sul_cancel(&wsi->sul_connect_timeout);
+#if defined(WIN32)
+	lws_sul_cancel(&wsi->win32_sul_connect_async_check);
+#endif
 #if defined(LWS_WITH_SYS_ASYNC_DNS)
 	lws_async_dns_cancel(wsi);
 #endif

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -665,6 +665,9 @@ struct lws {
 	lws_sorted_usec_list_t		sul_hrtimer;
 	lws_sorted_usec_list_t		sul_validity;
 	lws_sorted_usec_list_t		sul_connect_timeout;
+#if defined(WIN32)
+	lws_sorted_usec_list_t		win32_sul_connect_async_check;
+#endif
 
 	struct lws_dll2			dll_buflist; /* guys with pending rxflow */
 	struct lws_dll2			same_vh_protocol;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -1065,7 +1065,7 @@ lws_create_context(const struct lws_context_creation_info *info)
 #if defined(LWS_WITH_NETWORK)
 #if defined(WIN32)
 	if (!info->win32_connect_check_interval_usec)
-		context->win32_connect_check_interval_usec = 500;
+		context->win32_connect_check_interval_usec = 1000;
 	else
 		context->win32_connect_check_interval_usec =
 				info->win32_connect_check_interval_usec;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -1059,12 +1059,20 @@ lws_create_context(const struct lws_context_creation_info *info)
 	}
 
 #endif
+
+	context->timeout_secs = 15;
+
 #if defined(LWS_WITH_NETWORK)
+#if defined(WIN32)
+	if (!info->win32_connect_check_interval_usec)
+		context->win32_connect_check_interval_usec = 500;
+	else
+		context->win32_connect_check_interval_usec =
+				info->win32_connect_check_interval_usec;
+#endif
 	if (info->timeout_secs)
 		context->timeout_secs = info->timeout_secs;
-	else
-#endif
-		context->timeout_secs = 15;
+#endif /* WITH_NETWORK */
 
 #if defined(LWS_ROLE_H1) || defined(LWS_ROLE_H2)
 	if (info->max_http_header_data)

--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -737,6 +737,9 @@ struct lws_context {
 	int fd_random;
 	int count_cgi_spawned;
 #endif
+#if defined(WIN32)
+	unsigned int win32_connect_check_interval_usec;
+#endif
 
 	unsigned int fd_limit_per_thread;
 	unsigned int timeout_secs;

--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -228,7 +228,10 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 			return 1;
 		}
 
-		if (private_key) {
+		if (!private_key) {
+			lwsl_err("ssl private key not set\n");
+			return 1;
+		} else {
 			/* set the private key from KeyFile */
 			if (SSL_CTX_use_PrivateKey_file(vhost->tls.ssl_ctx, private_key,
 							SSL_FILETYPE_PEM) != 1) {
@@ -242,14 +245,6 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 					       (char *)vhost->context->pt[0].serv_buf);
 				lwsl_err("ssl problem getting key '%s' %lu: %s\n",
 					 private_key, error, s);
-				return 1;
-			}
-		} else {
-			if (vhost->protocols[0].callback(wsi,
-				      LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-							 vhost->tls.ssl_ctx, NULL, 0)) {
-				lwsl_err("ssl private key not set\n");
-
 				return 1;
 			}
 		}
@@ -389,7 +384,10 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 		return 1;
 	}
 
-	if (n != LWS_TLS_EXTANT_ALTERNATIVE && private_key) {
+	if (n == LWS_TLS_EXTANT_ALTERNATIVE || !private_key) {
+		lwsl_err("ssl private key not set\n");
+		return 1;
+	} else {
 		/* set the private key from KeyFile */
 		if (SSL_CTX_use_PrivateKey_file(vhost->tls.ssl_ctx, private_key,
 					        SSL_FILETYPE_PEM) != 1) {
@@ -398,14 +396,6 @@ lws_tls_server_certs_load(struct lws_vhost *vhost, struct lws *wsi,
 				 private_key, error,
 				 ERR_error_string(error,
 				      (char *)vhost->context->pt[0].serv_buf));
-			return 1;
-		}
-	} else {
-		if (vhost->protocols[0].callback(wsi,
-			      LWS_CALLBACK_OPENSSL_CONTEXT_REQUIRES_PRIVATE_KEY,
-						 vhost->tls.ssl_ctx, NULL, 0)) {
-			lwsl_err("ssl private key not set\n");
-
 			return 1;
 		}
 	}


### PR DESCRIPTION
this fixes the same issue as this pull request https://github.com/warmcat/libwebsockets/pull/2715 with fixes proposed here https://github.com/warmcat/libwebsockets/pull/2715#issuecomment-1232383955 by @Mitch-Martinez and maybe this issue too https://github.com/warmcat/libwebsockets/issues/2700

with the approach that avoids spinning or blocking described by @lws-team here https://github.com/warmcat/libwebsockets/pull/2715#issuecomment-1232445737 which removes setting pollout and adds a sul scheduled callback to check connection state.

i am again not very sure that i:
- cancel the sul callback in all appropriate places
- set the value for the check interval appropriately
- removed the correct pollout or did not miss anything

tested happy path - does establish connection, logs below
did not test the error case described here  https://github.com/warmcat/libwebsockets/issues/2700

```
 ./lws-minimal-ws-client.exe
...
[2022/09/03 22:54:33:6820] I: _lws_create_ah: created ah 00000244AA70DCA0 (size 4096): pool length 1
[2022/09/03 22:54:33:6820] I: lws_header_table_attach: did attach wsi [wsicli|0|WS/h1/default/libwebsockets.org]: ah 00000244AA70DCA0: count 1 (on exit)
[2022/09/03 22:54:33:6820] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_connect_2_dnsreq: lookup libwebsockets.org:443
[2022/09/03 22:54:33:6830] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_getaddrinfo46: getaddrinfo 'libwebsockets.org' says 0
[2022/09/03 22:54:33:6830] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_sort_dns: sort_dns: 00000244AA738570
[2022/09/03 22:54:33:6830] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_sort_dns: unsorted entry (af 2) 46.105.127.147
[2022/09/03 22:54:33:6830] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_sort_dns_dump: 1: (2)46.105.127.147, gw (0)(unset), idi: 0, lbl: 0, prec: 0
[2022/09/03 22:54:33:6830] W: lws_plat_set_socket_options_ip: priority and ip sockets options not implemented on windows platform
[2022/09/03 22:54:33:6830] N: lws_plat_set_socket_options_ip: set use exclusive addresses
[2022/09/03 22:54:33:6840] N: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_connect_3_connect: trying 46.105.127.147
[2022/09/03 22:54:33:6840] I: lws_state_transition_steps: CONTEXT_CREATED -> OPERATIONAL
[2022/09/03 22:54:33:6850] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_conn_async_check: checking ongoing connection attempt
[2022/09/03 22:54:33:6970] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_conn_async_check: checking ongoing connection attempt
[2022/09/03 22:54:33:7130] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_conn_async_check: checking ongoing connection attempt
[2022/09/03 22:54:33:7150] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_connect_3_connect: source ads 192.168.1.227
[2022/09/03 22:54:33:7150] I: [wsicli|0|WS/h1/default/libwebsockets.org]: lws_client_connect_4_established: h1 lws-minimal-client client created own conn (raw 0) vh default st 0x202
```