### PR TITLE
Always return result of _lws_vhost_init_server_af

### DIFF
--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -479,8 +479,9 @@ _lws_vhost_init_server(const struct lws_context_creation_info *info,
 	      (vhost->options & LWS_SERVER_OPTION_IPV6_V6ONLY_VALUE))) {
 #endif
 		a.af = AF_INET;
-		if (_lws_vhost_init_server_af(&a))
-			return 1;
+		int n = _lws_vhost_init_server_af(&a);
+		if (n)
+			return n;
 
 #if defined(LWS_WITH_IPV6)
 	}


### PR DESCRIPTION
Fixes https://github.com/warmcat/libwebsockets/issues/2702.

I don't understand the full implications of the return value here, but this is consistent with the return value further down in the function, as noted in #2702.