### PR TITLE
Fixes leaking fds created by 'pipe()' call

### DIFF
--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -1797,9 +1797,9 @@ lws_pt_destroy(struct lws_context_per_thread *pt)
 		pt->pipe_wsi = NULL;
 	}
 
-	if (pt->dummy_pipe_fds[0]
+	if ((pt->dummy_pipe_fds[0] || pt->dummy_pipe_fds[1])
 #if !defined(WIN32)
-	    && (int)pt->dummy_pipe_fds[0] != -1
+	    && ((int)pt->dummy_pipe_fds[0] != -1 || (int)pt->dummy_pipe_fds[1] != -1)
 #endif
 	) {
 		struct lws wsi;


### PR DESCRIPTION
Updates the `lws_pt_destroy()` logic to ensure the pipe fds are closed if either `pt->dummy_pipe_fds[0]` or `pt->dummy_pipe_fds[1]` are still valid (previously was only checking `pt->dummy_pipe_fds[0]` which was resulting in the write fd to leak whenever a context was destroyed).



Potential fix for issue: https://github.com/warmcat/libwebsockets/issues/2744