### PR TITLE
docs: set port to zero when using unix domain sockets

### DIFF
--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -334,7 +334,10 @@ struct lws_context_creation_info {
 	 *
 	 * You can also set port to 0, in which case the kernel will pick
 	 * a random port that is not already in use.  You can find out what
-	 * port the vhost is listening on using lws_get_vhost_listen_port() */
+	 * port the vhost is listening on using lws_get_vhost_listen_port()
+	 * 
+	 * If options specifies LWS_SERVER_OPTION_UNIX_SOCK, you should set
+	 * port to 0 */
 
 	unsigned int http_proxy_port;
 	/**< VHOST: If http_proxy_address was non-NULL, uses this port */


### PR DESCRIPTION
When a server is set to listen to a unix domain socket, i.e. options field of `struct lws_context_creation_info` has the
`LWS_SERVER_OPTION_UNIX_SOCK` flag set, the port must be set to zero, otherwise the unix socket is never created.