### PR TITLE
Fix -Werror=enum-int-mismatch in lws_tls_server_abort_connection()

### DIFF
--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -699,7 +699,7 @@ lws_tls_server_new_nonblocking(struct lws *wsi, lws_sockfd_type accept_fd)
 	return 0;
 }
 
-int
+enum lws_ssl_capable_status
 lws_tls_server_abort_connection(struct lws *wsi)
 {
 	if (wsi->tls.use_ssl)


### PR DESCRIPTION
GCC 13 is findinf this function signature mismatch.

../git/lib/tls/openssl/openssl-server.c:713:1: error: conflicting types for 'lws_tls_server_abort_connection' due to enum/integer mismatch; have 'int(struct lws *)' [-Werror=enum-int-mismatch]

Signed-off-by: Khem Raj <raj.khem@gmail.com>