### PR TITLE
Fix pipe end socket fd left open leak on linux

### DIFF
--- a/lib/core-net/close.c
+++ b/lib/core-net/close.c
@@ -921,7 +921,10 @@ __lws_close_free_wsi_final(struct lws *wsi)
 		if (pt->pipe_wsi == wsi)
 			pt->pipe_wsi = NULL;
 		if (pt->dummy_pipe_fds[0] == wsi->desc.sockfd)
+		{
 			pt->dummy_pipe_fds[0] = LWS_SOCK_INVALID;
+			compatible_close(pt->dummy_pipe_fds[1]);
+		}
 	}
 
 	wsi->desc.sockfd = LWS_SOCK_INVALID;


### PR DESCRIPTION
lws_context_destroy() left pipe end fd open, causing fd leak visible in application open file desctiptions list.
When application was doing multiple context create/destroys cycles, it was finally causing "too many files open" error in application.