### PR TITLE
Add guard for setrlimit

### DIFF
--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -963,7 +963,7 @@ lws_create_context(const struct lws_context_creation_info *info)
 
 	context->options = info->options;
 
-#if !defined(LWS_PLAT_FREERTOS) && !defined(LWS_PLAT_OPTEE) && !defined(WIN32) && !defined(LWS_PLAT_BAREMETAL)
+#if defined(LWS_HAVE_SYS_RESOURCE_H) && !defined(LWS_PLAT_FREERTOS) && !defined(LWS_PLAT_OPTEE) && !defined(WIN32) && !defined(LWS_PLAT_BAREMETAL)
 	/*
 	 * If asked, try to set the rlimit / ulimit for process sockets / files.
 	 * We read the effective limit in a moment, so we will find out the


### PR DESCRIPTION
LWS_HAVE_SYS_RESOURCE_H is correctly set by lws to prevent including sys/resource.h. However there is no corresponding guard for setrlimit (a function from that header). This causes a build failure on platforms which don't have sys/resource.h available.