### PR TITLE
lws_b64_decode_stateful truncates response

### DIFF
--- a/lib/misc/base64-decode.c
+++ b/lib/misc/base64-decode.c
@@ -114,7 +114,7 @@ lws_b64_decode_stateful(struct lws_b64state *s, const char *in, size_t *in_len,
 	uint8_t *orig_out = out, *end_out = out + *out_size;
 	int equals = 0;
 
-	while (in < end_in && *in && out + 4 < end_out) {
+	while (in < end_in && *in && out + 3 <= end_out) {
 
 		for (; s->i < 4 && in < end_in && *in; s->i++) {
 			uint8_t v;


### PR DESCRIPTION
Addresses issue #2855 by allowing the parsing of the final byte when there are at least 3 bytes remaining in the buffer.

For every 4 bytes of input, a maximum of 3 bytes of output are generated when decoding the base64 string. The buffer space, therefore, only requires an additional 3 bytes of space. The code checks for space in the buffer before adding null termination.