### PR TITLE
dbus: prevent double free timeout event

### DIFF
--- a/lib/roles/dbus/dbus.c
+++ b/lib/roles/dbus/dbus.c
@@ -293,8 +293,6 @@ lws_dbus_sul_cb(lws_sorted_usec_list_t *sul)
 		if (time(NULL) > r->fire) {
 			lwsl_notice("%s: firing timer\n", __func__);
 			dbus_timeout_handle(r->data);
-			lws_dll2_remove(rdt);
-			lws_free(rdt);
 		}
 	} lws_end_foreach_dll_safe(rdt, nx);
 


### PR DESCRIPTION
SUL callback triggers a dbus timeout handle, handle removes the linked list entry and free's the memory attached to the entry. Remove the code where the the entry was removed by the timer callback, which triggered a double free of the same linked list entry.

See issue: https://github.com/warmcat/libwebsockets/issues/2864