### PR TITLE
fix ws parser for non pmd packet with pmd ext enabled

### DIFF
--- a/lib/roles/ws/client-parser-ws.c
+++ b/lib/roles/ws/client-parser-ws.c
@@ -637,6 +637,7 @@ utf8_fail:
 
 			if (n == PMDR_DID_NOTHING
 #if !defined(LWS_WITHOUT_EXTENSIONS)
+			    || n == PMDR_NOTHING_WE_SHOULD_DO
 			    || n == PMDR_UNKNOWN
 #endif
 			)


### PR DESCRIPTION
PMDR_NOTHING_WE_SHOULD_DO handle logic is missing from lws_ws_client_rx_sm compared to lws_ws_rx_sm. If we change the binance example from url subscribed future stream to live subscribed spot stream, we will see a dead loop for spot live subscribe response. Quoting logic from lws_ws_rx_sm would fix it.