### PR TITLE
mbedtls-server: Fix broken client verification

### DIFF
--- a/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
+++ b/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
@@ -251,9 +251,9 @@ static int ssl_pm_reload_crt(SSL *ssl)
     struct x509_pm *crt_pm = (struct x509_pm *)ssl->cert->x509->x509_pm;
 
     if (ssl->verify_mode == SSL_VERIFY_PEER)
-        mode = MBEDTLS_SSL_VERIFY_REQUIRED;
-    else if (ssl->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
         mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
+    else if (ssl->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+        mode = MBEDTLS_SSL_VERIFY_REQUIRED;
     else if (ssl->verify_mode == SSL_VERIFY_CLIENT_ONCE)
         mode = MBEDTLS_SSL_VERIFY_UNSET;
     else


### PR DESCRIPTION
This fixes clients being able to connect with a certicate that was not signed by the configured CA when SSL_VERIFY_FAIL_IF_NO_PEER_CERT is set.

The issue only appeared when a client connects via IP address directly and not use a hostname.

When the hostname was used to connect, the SNI 'callback lws_mbedtls_sni_cb' overwrote the invalid verfiy mode of
MBEDTLS_SSL_VERIFY_OPTIONAL with MBEDTLS_SSL_VERIFY_REQUIRED by calling SSL_set_SSL_CTX.