### PR TITLE
dlo: fix compiler complaints 'redefinition of typedef'

### DIFF
--- a/include/libwebsockets/lws-dlo.h
+++ b/include/libwebsockets/lws-dlo.h
@@ -267,8 +267,6 @@ typedef struct {
 	char				failed;
 } lws_dlo_image_t;
 
-typedef struct lws_display_state lws_display_state_t;
-
 typedef struct lws_displaylist {
 	lws_dll2_owner_t		dl;
 	struct lws_display_state 	*ds;
@@ -460,13 +458,11 @@ typedef struct {
 LWS_VISIBLE LWS_EXTERN int
 lws_dlo_ss_create(lws_dlo_ss_create_info_t *i, lws_dlo_t **pdlo);
 
-typedef struct lhp_ctx lhp_ctx_t;
-
 LWS_VISIBLE LWS_EXTERN int
 lws_dlo_ss_find(struct lws_context *cx, const char *url, lws_dlo_image_t *u);
 
 LWS_VISIBLE LWS_EXTERN lws_stateful_ret_t
-lhp_displaylist_layout(lhp_ctx_t *ctx, char reason);
+lhp_displaylist_layout(struct lhp_ctx *ctx, char reason);
 
 #define lws_dlo_image_width(_u) ((_u)->failed ? -1 : \
 		((_u)->type == LWSDLOSS_TYPE_JPEG ? \


### PR DESCRIPTION
Fix for #2739.
I get the same error when the pedantic flag is enabled.