### PR TITLE
Remove usage of malloc_usable_size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,10 +604,6 @@ CHECK_C_SOURCE_COMPILES(
 	"#include <malloc.h>
 	int main(int argc, char **argv) { return malloc_trim(0); }
 	" LWS_HAVE_MALLOC_TRIM)
-CHECK_C_SOURCE_COMPILES(
-	"#include <malloc.h>
-	int main(int argc, char **argv) { return (int)malloc_usable_size((void *)0); }
-	" LWS_HAVE_MALLOC_USABLE_SIZE)
 
 if (PICO_SDK_PATH)
 	set(CMAKE_REQUIRED_DEFINITIONS "-Dxxexit=exit")

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -65,7 +65,6 @@
 #cmakedefine LWS_HAVE_HMAC_CTX_new
 #cmakedefine LWS_HAVE_MALLOC_H
 #cmakedefine LWS_HAVE_MALLOC_TRIM
-#cmakedefine LWS_HAVE_MALLOC_USABLE_SIZE
 #cmakedefine LWS_HAVE_mbedtls_md_setup
 #cmakedefine LWS_HAVE_mbedtls_net_init
 #cmakedefine LWS_HAVE_mbedtls_rsa_complete

--- a/include/libwebsockets/lws-misc.h
+++ b/include/libwebsockets/lws-misc.h
@@ -857,23 +857,6 @@ lws_dir_glob_cb(const char *dirpath, void *user, struct lws_dir_entry *lde);
 #endif
 
 /**
- * lws_get_allocated_heap() - if the platform supports it, returns amount of
- *				heap allocated by lws itself
- *
- * On glibc currently, this reports the total amount of current logical heap
- * allocation, found by tracking the amount allocated by lws_malloc() and
- * friends and accounting for freed allocations via lws_free().
- *
- * This is useful for confirming where processwide heap allocations actually
- * come from... this number represents all lws internal allocations, for
- * fd tables, wsi allocations, ah, etc combined.  It doesn't include allocations
- * from user code, since lws_malloc() etc are not exported from the library.
- *
- * On other platforms, it always returns 0.
- */
-size_t lws_get_allocated_heap(void);
-
-/**
  * lws_get_tsi() - Get thread service index wsi belong to
  * \param wsi:  websocket connection to check
  *

--- a/lib/core/alloc.c
+++ b/lib/core/alloc.c
@@ -201,9 +201,4 @@ void lws_set_allocator(void *(*cb)(void *ptr, size_t size, const char *reason))
 {
 	_lws_realloc = cb;
 }
-
-size_t lws_get_allocated_heap(void)
-{
-	return 0;
-}
 #endif

--- a/lib/core/alloc.c
+++ b/lib/core/alloc.c
@@ -24,14 +24,6 @@
 
 #include "private-lib-core.h"
 
-#if defined(LWS_HAVE_MALLOC_USABLE_SIZE)
-
-#include <malloc.h>
-
-/* the heap is processwide */
-static size_t allocated;
-#endif
-
 #if defined(LWS_WITH_ALLOC_METADATA_LWS)
 static lws_dll2_owner_t active;
 #endif
@@ -136,11 +128,6 @@ _realloc(void *ptr, size_t size, const char *reason)
 			   (unsigned long)size, reason);
 #endif
 
-#if defined(LWS_HAVE_MALLOC_USABLE_SIZE)
-		if (ptr)
-			allocated -= malloc_usable_size(ptr);
-#endif
-
 #if defined(LWS_WITH_ALLOC_METADATA_LWS)
 		size += adj;
 #endif
@@ -153,10 +140,6 @@ _realloc(void *ptr, size_t size, const char *reason)
 
 		if (!v)
 			return v;
-
-#if defined(LWS_HAVE_MALLOC_USABLE_SIZE)
-		allocated += malloc_usable_size(v);
-#endif
 
 #if defined(LWS_WITH_ALLOC_METADATA_LWS)
 		_lws_alloc_metadata_adjust(&active, &v, adj, comp, (unsigned int)complen);
@@ -174,9 +157,6 @@ _realloc(void *ptr, size_t size, const char *reason)
 		_lws_alloc_metadata_trim(&ptr, NULL, NULL);
 #endif
 
-#if defined(LWS_HAVE_MALLOC_USABLE_SIZE)
-		allocated -= malloc_usable_size(ptr);
-#endif
 		free(ptr);
 #if defined(LWS_PLAT_FREERTOS)
 		lwsl_debug("%s: free heap %d\n", __func__,
@@ -224,10 +204,6 @@ void lws_set_allocator(void *(*cb)(void *ptr, size_t size, const char *reason))
 
 size_t lws_get_allocated_heap(void)
 {
-#if defined(LWS_HAVE_MALLOC_USABLE_SIZE)
-	return allocated;
-#else
 	return 0;
-#endif
 }
 #endif


### PR DESCRIPTION
Arch Linux is [preparing](https://gitlab.archlinux.org/archlinux/rfcs/-/blob/master/rfcs/0017-increase-fortification-level.rst) switching to -D_FORTIFY_SOURCE=3, upon inspection of all packages I noticed libwebsockets uses a function called `malloc_usable_size`. This function is "for diagnostic purposes only" and should not be used in release builds, as it's going to be considered a fatal memory violation with -D_FORTIFY_SOURCE=3 ([source](https://developers.redhat.com/articles/2022/09/17/gccs-new-fortification-level)).

From the [glibc documentation](https://man7.org/linux/man-pages/man3/malloc_usable_size.3.html):

> The value returned by malloc_usable_size() may be greater than
> the requested size of the allocation because of alignment and
> minimum size constraints.  Although the excess bytes can be
> overwritten by the application without ill effects, this is not
> good programming practice: the number of excess bytes in an
> allocation depends on the underlying implementation.
>
> The main use of this function is for debugging and introspection.

This patch deletes all code paths that depend on `LWS_HAVE_MALLOC_USABLE_SIZE` to be true, and `LWS_HAVE_MALLOC_USABLE_SIZE` itself.

Unfortunately this feature was somewhat exposed through `lws_get_allocated_heap`, since the consuming developer of this library might not have taken into account for `LWS_HAVE_MALLOC_USABLE_SIZE` to be false, so there might not be proper error handling in place for `return 0`, so this patch also removes this function entirely.

It may be possible to unconditionally do `allocated += adj;` in `_realloc` and `allocated = 0` in case of a free. `lws_get_allocated_heap` could then continue to exist as simply `return alloc;`, but I didn't understand the libwebsocket allocator code well enough to say for sure this is accurate.

Thanks!