### PR TITLE
Add support for RFC5014 for Linux

### DIFF
--- a/include/libwebsockets/lws-client.h
+++ b/include/libwebsockets/lws-client.h
@@ -56,6 +56,11 @@ enum lws_client_connect_ssl_connection_flags {
 	 * then it is not possible to bind to this port for any local address
 	 */
 
+	LCCSCF_IPV6_PREFER_PUBLIC_ADDR				= (1 << 15),
+	/**< RFC5014 - For IPv6 systems with SLAAC config, allow for preference
+	 * to bind a socket to public address vs temporary private address
+	 */
+
 	LCCSCF_PIPELINE				= (1 << 16),
 		/**< Serialize / pipeline multiple client connections
 		 * on a single connection where possible.

--- a/lib/plat/windows/windows-sockets.c
+++ b/lib/plat/windows/windows-sockets.c
@@ -193,6 +193,16 @@ lws_plat_set_socket_options_ip(lws_sockfd_type fd, uint8_t pri, int lws_flags)
 		} else
 			lwsl_notice("%s: set use exclusive addresses\n", __func__);
 	}
+
+
+#if defined(LWS_WITH_IPV6)
+	// I do not believe Microsoft supports RFC5014
+	// Instead, you must set lws_client_connect_info::iface
+	if (lws_flags & LCCSCF_IPV6_PREFER_PUBLIC_ADDR) {
+		lwsl_err("%s: UNIMPLEMENTED on this platform\n", __func__);
+	}
+#endif
+	
 	
 
 	return ret;


### PR DESCRIPTION
Issue #2979
Add support for a socket flag to prefer connecting with the IPv6 public IP vs temporary private for IPV6 SLAAC configured machines - Standard documented in RFC5014