### PR TITLE
openssl: Properly report OpenSSL error in lws_tls_client_connect

### DIFF
--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -517,6 +517,7 @@ lws_tls_client_connect(struct lws *wsi, char *errbuf, size_t elen)
 	unsigned int len;
 #endif
 	int m, n, en;
+	unsigned long l;
 #if defined(LWS_WITH_TLS_SESSIONS) && defined(LWS_HAVE_SSL_SESSION_set_time)
 	SSL_SESSION *sess;
 #endif
@@ -541,9 +542,10 @@ lws_tls_client_connect(struct lws *wsi, char *errbuf, size_t elen)
 	}
 
 	if (m == SSL_ERROR_SSL) {
+		l = ERR_get_error();
 		n = lws_snprintf(errbuf, elen, "tls: %s", wsi->tls.err_helper);
 		if (!wsi->tls.err_helper[0])
-			ERR_error_string_n((unsigned int)m, errbuf + n, (elen - (unsigned int)n));
+			ERR_error_string_n((unsigned int)l, errbuf + n, (elen - (unsigned int)n));
 		return LWS_SSL_CAPABLE_ERROR;
 	}
 

--- a/lib/tls/openssl/openssl-ssl.c
+++ b/lib/tls/openssl/openssl-ssl.c
@@ -57,8 +57,6 @@ int lws_ssl_get_error(struct lws *wsi, int n)
 
 	m = SSL_get_error(wsi->tls.ssl, n);
        lwsl_debug("%s: %p %d -> %d (errno %d)\n", __func__, wsi->tls.ssl, n, m, LWS_ERRNO);
-	if (m == SSL_ERROR_SSL)
-		lws_tls_err_describe_clear();
 
        // assert (LWS_ERRNO != 9);
 
@@ -250,6 +248,9 @@ lws_ssl_capable_read(struct lws *wsi, unsigned char *buf, size_t len)
 		if (m == SSL_ERROR_ZERO_RETURN) /* cleanly shut down */
 			goto do_err;
 
+		if (m == SSL_ERROR_SSL) {
+		    lws_tls_err_describe_clear();
+		}
 		/* hm not retryable.. could be 0 size pkt or error  */
 
 		if (m == SSL_ERROR_SSL || m == SSL_ERROR_SYSCALL ||


### PR DESCRIPTION
In case of an SSL_ERROR_SSL in lws_tls_client_connect, the lws_ssl_get_error call was calling lws_tls_err_describe_clear which cleared the OpenSSL error from the stack. Thus, the tls.err_helper attribute was set to the default value from ERR_error_string_n, masking the actual OpenSSL error message from client code.