### PR TITLE
openssl: Add lws ctx ref to client vhost's SSL_CTX

### DIFF
--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -922,6 +922,10 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 		return 1;
 	}
 
+	SSL_CTX_set_ex_data(vh->tls.ssl_client_ctx,
+				openssl_SSL_CTX_private_data_index,
+				(char *)vh->context);
+
 	lws_plat_vhost_tls_client_ctx_init(vh);
 
 	tcr = lws_zalloc(sizeof(*tcr), "client ctx tcr");


### PR DESCRIPTION
Adds a reference to the libwebsockets context to the OpenSSL context used by the client vhost. This allows SSL info callbacks to work correctly for clients, like it currently does for servers.