### PR TITLE
pmd: fix buffer being reused while draining extensions

### DIFF
--- a/lib/roles/ws/ops-ws.c
+++ b/lib/roles/ws/ops-ws.c
@@ -723,7 +723,7 @@ utf8_fail:
 			}
 
 #if !defined(LWS_WITHOUT_EXTENSIONS)
-			if (!lin)
+			if (!lin && !(already_processed & ALREADY_PROCESSED_FULL_DRAINING))
 				break;
 #endif
 

--- a/lib/roles/ws/private-lib-roles-ws.h
+++ b/lib/roles/ws/private-lib-roles-ws.h
@@ -75,6 +75,7 @@ enum lws_websocket_opcodes_07 {
 
 #define ALREADY_PROCESSED_IGNORE_CHAR 1
 #define ALREADY_PROCESSED_NO_CB 2
+#define ALREADY_PROCESSED_FULL_DRAINING 4
 
 #if !defined(LWS_WITHOUT_EXTENSIONS)
 struct lws_vhost_role_ws {

--- a/lib/roles/ws/server-ws.c
+++ b/lib/roles/ws/server-ws.c
@@ -1080,7 +1080,7 @@ lws_parse_ws(struct lws *wsi, unsigned char **buf, size_t len)
 				   wsi->ws->rx_draining_ext);
 #endif
 			m = lws_ws_rx_sm(wsi, ALREADY_PROCESSED_IGNORE_CHAR |
-					      ALREADY_PROCESSED_NO_CB, 0);
+					      ALREADY_PROCESSED_NO_CB | ALREADY_PROCESSED_FULL_DRAINING, 0);
 		}
 
 		if (m < 0) {


### PR DESCRIPTION
Closes #3011

The call stack is:
```
#0  0x000055a23aec9f30 in lws_ws_rx_sm (wsi=0x55a23c3348c0, already_processed=0x7, c=0x0) at lib/roles/ws/ops-ws.c:612
#1  0x000055a23aed2ad8 in lws_parse_ws (wsi=0x55a23c3348c0, buf=0x7ffed5639320, len=0x0) at lib/roles/ws/server-ws.c:1082
#2  0x000055a23aec790c in lws_read_h1 (wsi=0x55a23c3348c0, buf=0x55a23c309dc0 "@\356/<\242U", len=0x1000) at lib/roles/h1/ops-h1.c:270
#3  0x000055a23aecb033 in rops_handle_POLLIN_ws (pt=0x55a23c2ff118, wsi=0x55a23c3348c0, pollfd=0x7ffed5639470) at lib/roles/ws/ops-ws.c:1183
#4  0x00007f1f2d80f350 in lws_service_fd_tsi (context=0x55a23c2fee40, pollfd=0x7ffed5639470, tsi=0x0) at lib/core-net/service.c:766
#5  0x00007f1f2dbe3945 in lws_io_cb (watcher=0x55a23c315fb0, status=0x0, revents=0x1) at lib/event-libs/libuv/libuv.c:148
#6  0x00007f1f2dba011e in ?? () from /lib/x86_64-linux-gnu/libuv.so.1
#7  0x00007f1f2db89c88 in uv_run () from /lib/x86_64-linux-gnu/libuv.so.1
#8  0x00007f1f2dbe4f06 in elops_run_pt_uv (context=0x55a23c2fee40, tsi=0x0) at lib/event-libs/libuv/libuv.c:647
#9  0x000055a23aeb6d7d in lws_service (context=0x55a23c2fee40, timeout_ms=0x0) at lib/core-net/service.c:832
```

We are draining buffer in `lws_ws_rx_sm`, but there are pending data after it returned.

And after it return from `lib/roles/ws/ops-ws.c:1183`:
https://github.com/warmcat/libwebsockets/blob/a4a7e0a49b1e464e09caf78257df3be8ab92fc4a/lib/roles/ws/ops-ws.c#L1183

It will go to `lib/roles/ws/ops-ws.c:1227`:
https://github.com/warmcat/libwebsockets/blob/a4a7e0a49b1e464e09caf78257df3be8ab92fc4a/lib/roles/ws/ops-ws.c#L1227

Then go back to label `read`, and reuse the buffer `pt->serv_buf`:
https://github.com/warmcat/libwebsockets/blob/a4a7e0a49b1e464e09caf78257df3be8ab92fc4a/lib/roles/ws/ops-ws.c#L1121

Then `lws_ssl_capable_read` will write to the buffer `ebuf.token`:
https://github.com/warmcat/libwebsockets/blob/a4a7e0a49b1e464e09caf78257df3be8ab92fc4a/lib/roles/ws/ops-ws.c#L1133

And  the `ebuf.token` and `pt->serv_buf` are same as `priv->rx.avail_in` in:
https://github.com/warmcat/libwebsockets/blob/a4a7e0a49b1e464e09caf78257df3be8ab92fc4a/lib/roles/ws/ext/extension-permessage-deflate.c#L294

Then the next `inflate` will fail.