### PR TITLE
Fix minor typo in MIT license text in fsmount.c

### DIFF
--- a/lib/misc/fsmount.c
+++ b/lib/misc/fsmount.c
@@ -6,12 +6,12 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
  * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicefsme, and/or
- * sell copies of the Software, and to permit persofsm to whom the Software is
- * furnished to do so, subject to the following conditiofsm:
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portiofsm of the Software.
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Somehow, an unruly string replacement of "ns" by "fsm" likely had damaged the license text and introduced small garbage.

FWIW, this was found while I was running a ScanCode scan in a codebase that includes libwebsockets and we had an approximate match to the MIT text.
```
matches:
    -   score: '93.22'
        start_line: 74
        end_line: 90
        matched_length: 157
        match_coverage: '98.12'
        matcher: 3-seq
        license_expression: mit
        rule_identifier: mit_832.RULE
        rule_relevance: 95
        rule_url: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_832.RULE
        matched_text: |
            Permission is hereby granted, free of charge, to any person obtaining a copy
            * of this software and associated documentation files (the "Software"), to
            * deal in the Software without restriction, including without limitation the
            * rights to use, copy, modify, merge, publish, distribute, [sublicefsme], and/or
            * sell copies of the Software, and to permit [persofsm] to whom the Software is
            * furnished to do so, subject to the following [conditiofsm]:
            *
            * The above copyright notice and this permission notice shall be included in
            * all copies or substantial [portiofsm] of the Software.
            *
            * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
            * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
            * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
            * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
            * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
            * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
            * IN THE SOFTWARE.
```

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>