### PR TITLE
Fix prototype mismatch in private-network.h

### DIFF
--- a/lib/tls/private-network.h
+++ b/lib/tls/private-network.h
@@ -167,7 +167,11 @@ lws_tls_server_new_nonblocking(struct lws *wsi, lws_sockfd_type accept_fd);
 enum lws_ssl_capable_status
 lws_tls_server_accept(struct lws *wsi);
 
+#if defined(LWS_AMAZON_RTOS)
 enum lws_ssl_capable_status
+#else
+int
+#endif
 lws_tls_server_abort_connection(struct lws *wsi);
 
 enum lws_ssl_capable_status


### PR DESCRIPTION
The implementation of `lws_tls_server_abort_connection` is defined as below.

```c
#if defined(LWS_AMAZON_RTOS)
enum lws_ssl_capable_status
#else
int
#endif
lws_tls_server_abort_connection(struct lws *wsi)
{
...
}
```

But in the header file, it is defined as the following.

```c
enum lws_ssl_capable_status
lws_tls_server_abort_connection(struct lws *wsi);
```

Compiling with a aarch64-none-linux-gnu compiler, the following error is produced.

<img width="827" alt="image" src="https://github.com/warmcat/libwebsockets/assets/13937320/1692640f-89d0-4a9d-acf2-d4a0992d8483">

This error does not appear when compiling with arm-linux-gnueabihf compiler.

The proposed change simply updates the prototype in the header to match the body. This resolves the compilation issue.
