### PR TITLE
Fixing digest auth challenge parsing

### DIFF
--- a/include/libwebsockets/lws-tokenize.h
+++ b/include/libwebsockets/lws-tokenize.h
@@ -99,7 +99,7 @@ typedef enum {
 } lws_tokenize_state;
 
 typedef struct lws_tokenize {
-	char collect[128]; /* token length limit */
+	char collect[256]; /* token length limit */
 	const char *start; /**< set to the start of the string to tokenize */
 	const char *token; /**< the start of an identified token or delimiter */
 	size_t len;	/**< set to the length of the string to tokenize */

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -846,9 +846,15 @@ lws_http_digest_auth(struct lws* wsi)
 					lws_genhash_size(LWS_GENHASH_TYPE_MD5),
 					a1, sizeof(a1));
 		lwsl_debug("A1: %s:%s:%s = %s\n", username, realm, password, a1);
-
-		n = lws_snprintf(tmp_digest, l, "%s:%s",
-				wsi->stash->cis[CIS_METHOD], uri);
+		/**
+		 * In case of Websocket upgrade, method is NULL
+		 * we assume it is a GET
+		*/
+		if(wsi->stash->cis[CIS_METHOD] == NULL)
+			n = lws_snprintf(tmp_digest, l, "GET:%s", uri);
+		else
+			n = lws_snprintf(tmp_digest, l, "%s:%s",
+					wsi->stash->cis[CIS_METHOD], uri);
 
 		if (lws_genhash_init(&hc, LWS_GENHASH_TYPE_MD5) ||
 				     lws_genhash_update(&hc,

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -611,6 +611,7 @@ lws_http_digest_auth(struct lws* wsi)
 	char realm[64];
 	char b64[512];
 	int m, ml, fi;
+	char *tmp_digest = NULL;
 
 	/* Did he send auth? */
 	ml = lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_WWW_AUTHENTICATE);
@@ -818,7 +819,6 @@ lws_http_digest_auth(struct lws* wsi)
 		struct lws *nwsi;
 		char cnonce[128];
 		size_t l;
-		char *tmp_digest = NULL;
 
 		l = sizeof(a1) + sizeof(a2) + sizeof(nonce) +
 			(sizeof(ncount) *2) + sizeof(response) +
@@ -932,8 +932,7 @@ lws_http_digest_auth(struct lws* wsi)
 	return 0;
 
 bail:
-	lws_free(wsi->http.digest_auth_hdr);
-	wsi->http.digest_auth_hdr = NULL;
+	lws_free(tmp_digest);
 
 	return -1;
 }

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -603,7 +603,7 @@ static const char *digest_toks[] = {
 enum lws_check_basic_auth_results
 lws_http_digest_auth(struct lws* wsi)
 {
-	uint8_t nonce[128], response[LWS_GENHASH_LARGEST], qop[32];
+	uint8_t nonce[256], response[LWS_GENHASH_LARGEST], qop[32];
 	int seen = 0, n, pend = -1, skipping = 0;
 	struct lws_tokenize ts;
 	char resp_username[32];
@@ -804,7 +804,7 @@ lws_http_digest_auth(struct lws* wsi)
 
 	lwsl_wsi_info(wsi, "HTTP digest auth realm %s nonce %s\n", realm, nonce);
 
-	if (wsi->stash && wsi->stash->cis[CIS_METHOD] &&
+	if (wsi->stash &&
 	    wsi->stash->cis[CIS_PATH]) {
 		char *username =  wsi->stash->cis[CIS_USERNAME];
 		char *password = wsi->stash->cis[CIS_PASSWORD];
@@ -817,7 +817,7 @@ lws_http_digest_auth(struct lws* wsi)
 		int ncount = 1, ssl;
 		const char *a, *p;
 		struct lws *nwsi;
-		char cnonce[128];
+		char cnonce[256];
 		size_t l;
 
 		l = sizeof(a1) + sizeof(a2) + sizeof(nonce) +


### PR DESCRIPTION
Fix Digest auth challenge parsing.

Tested with Nginx and [nginx-http-auth-digest](https://github.com/atomx/nginx-http-auth-digest )

Digest auth parsing is working, but the new connection attempt with challenge response still not working.

I will look toward this issue.