### PR TITLE
openssl: support SSLKEYLOGFILE server secret logging

### DIFF
--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -1178,6 +1178,13 @@ lws_transport_mux_next_free(lws_transport_mux_t *tm, lws_mux_ch_idx_t *result);
 void
 sul_ping_cb(lws_sorted_usec_list_t *sul);
 
+/* Added Declaration of this function to make common for openssl-server */
+#if defined(LWS_HAVE_SSL_CTX_set_keylog_callback) && \
+	defined(LWS_WITH_TLS)
+void
+lws_klog_dump(const SSL *ssl, const char *line);
+#endif
+
 #if !defined(PRIu64)
 #define PRIu64 "llu"
 #endif

--- a/lib/tls/openssl/openssl-client.c
+++ b/lib/tls/openssl/openssl-client.c
@@ -707,7 +707,7 @@ lws_tls_client_vhost_extra_cert_mem(struct lws_vhost *vh,
 
 #if defined(LWS_HAVE_SSL_CTX_set_keylog_callback) && \
 	defined(LWS_WITH_TLS) && defined(LWS_WITH_CLIENT)
-static void
+void
 lws_klog_dump(const SSL *ssl, const char *line)
 {
 	struct lws *wsi = SSL_get_ex_data(ssl,

--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -539,6 +539,11 @@ lws_tls_server_vhost_backend_init(const struct lws_context_creation_info *info,
 				error, s);
 		return 1;
 	}
+	/* Added for sniffing packets on hub side */
+#if defined(LWS_HAVE_SSL_CTX_set_keylog_callback) && \
+		defined(LWS_WITH_TLS)
+			SSL_CTX_set_keylog_callback(vhost->tls.ssl_ctx, lws_klog_dump);
+#endif
 
 	SSL_CTX_set_ex_data(vhost->tls.ssl_ctx,
 			    openssl_SSL_CTX_private_data_index,


### PR DESCRIPTION
@lws-team  I have added **server** side  **support for SSLKEYLOGFILE server secret logging.**
as **you have already provide client side secret logging support** with below commit id , on top of this I have added support for server secret logging, so could you please review and merge thiese changes in **main** branch
: [openssl: support SSLKEYLOGFILE client secret logging](https://github.com/warmcat/libwebsockets/commit/b8c4820be477b5237378b04a4216fb274c6afbbd)

This patch checks for the env variable SSLKEYLOGFILE=path, if present, then
server connection tls secrets are appended into path.vhostname. This allows decryption of captured encrypted data for debugging purposes.
SSKEYLOGFILE=path env var method is the same as provided by Firefox and
Chrome for this.