### PR TITLE
allow reserved bits and opcode, should close #3076

### DIFF
--- a/include/libwebsockets/lws-client.h
+++ b/include/libwebsockets/lws-client.h
@@ -235,6 +235,18 @@ struct lws_client_connect_info {
 	 * wsi-specific logs into their own stream or file.
 	 */
 
+#if defined(LWS_ROLE_WS)
+	uint8_t		allow_reserved_bits;
+	/**< non-zero to allow reserved bits. You can get it by `lws_get_reserved_bits`.
+	 * Note: default zero means close the websocket connection for non-zero rsv.
+	 */
+
+	uint8_t		allow_unknown_opcode;
+	/**< non-zeo to allow unknown opcode. You can get it by `lws_get_opcode`.
+	 * None: default zero means close the websocket connection for unknown opcode.
+	 */
+#endif
+
 	/* Add new things just above here ---^
 	 * This is part of the ABI, don't needlessly break compatibility
 	 *

--- a/include/libwebsockets/lws-ws-state.h
+++ b/include/libwebsockets/lws-ws-state.h
@@ -61,6 +61,13 @@ LWS_VISIBLE LWS_EXTERN unsigned char
 lws_get_reserved_bits(struct lws *wsi);
 
 /**
+ * lws_get_opcode() - access opcode of ws frame
+ * \param wsi: lws connection
+ */
+LWS_VISIBLE LWS_EXTERN unsigned char
+lws_get_opcode(struct lws *wsi);
+
+/**
  * lws_partial_buffered() - find out if lws buffered the last write
  * \param wsi:	websocket connection to check
  *

--- a/lib/roles/ws/client-parser-ws.c
+++ b/lib/roles/ws/client-parser-ws.c
@@ -119,6 +119,8 @@ int lws_ws_client_rx_sm(struct lws *wsi, unsigned char c)
 			case 0xd:
 			case 0xe:
 			case 0xf:
+				if (wsi->ws->allow_unknown_opcode)
+					break;
 				lwsl_wsi_info(wsi, "illegal opcode");
 				return -1;
 			default:
@@ -131,7 +133,7 @@ int lws_ws_client_rx_sm(struct lws *wsi, unsigned char c)
 #if !defined(LWS_WITHOUT_EXTENSIONS)
 				!wsi->ws->count_act_ext &&
 #endif
-				wsi->ws->rsv) {
+				wsi->ws->rsv && !wsi->ws->allow_reserved_bits) {
 				lwsl_wsi_info(wsi, "illegal rsv bits set");
 				return -1;
 			}

--- a/lib/roles/ws/client-ws.c
+++ b/lib/roles/ws/client-ws.c
@@ -62,6 +62,12 @@ lws_create_client_ws_object(const struct lws_client_connect_info *i,
 
 	wsi->ws->ietf_spec_revision = (uint8_t)v;
 
+	if (i->allow_reserved_bits)
+		wsi->ws->allow_reserved_bits = 1;
+
+	if (i->allow_unknown_opcode)
+		wsi->ws->allow_unknown_opcode = 1;
+
 	return 0;
 }
 

--- a/lib/roles/ws/ops-ws.c
+++ b/lib/roles/ws/ops-ws.c
@@ -893,6 +893,12 @@ lws_get_reserved_bits(struct lws *wsi)
 	return wsi->ws->rsv;
 }
 
+unsigned char
+lws_get_opcode(struct lws *wsi)
+{
+	return wsi->ws->opcode;
+}
+
 int
 lws_get_close_length(struct lws *wsi)
 {

--- a/lib/roles/ws/private-lib-roles-ws.h
+++ b/lib/roles/ws/private-lib-roles-ws.h
@@ -148,6 +148,8 @@ struct _lws_websocket_related {
 	uint8_t stashed_write_type;
 	uint8_t tx_draining_stashed_wp;
 	uint8_t ietf_spec_revision;
+	uint8_t allow_reserved_bits;
+	uint8_t allow_unknown_opcode;
 #if !defined(LWS_WITHOUT_EXTENSIONS)
 	uint8_t count_act_ext;
 #endif


### PR DESCRIPTION
Provide a way for custom extensions to read and validate reserved bits and opcode.

For send reserved bits and opcode, extension can use `LWS_WRITE_RAW` directly.