### PR TITLE
Fix compilation errors when compiling with MSVC 2022 (cl.exe 19.34.31944.0)

### DIFF
--- a/lib/core-net/wol.c
+++ b/lib/core-net/wol.c
@@ -31,7 +31,7 @@ lws_wol(struct lws_context *ctx, const char *ip_or_NULL, uint8_t *mac_6_bytes)
         uint8_t pkt[17 * ETHER_ADDR_LEN];
         struct sockaddr_in addr;
 
-        fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+        fd = (int) socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         if (fd < 0) {
                 lwsl_cx_err(ctx, "failed to open UDP, errno %d\n", errno);
                 goto bail;


### PR DESCRIPTION
Hi.
When using said compiler, I've got the following error:

```
libwebsockets\lib\core-net\wol.c(34,23): error C2220: the following warning is treated as an error [libwebsockets\lib\websockets.vcxproj]
libwebsockets\lib\core-net\wol.c(34,23): warning C4244: '=': conversion from 'SOCKET' to 'int', possible loss of data [libwebsockets\lib\websockets.vcxproj]
```
