### PR TITLE
mbedtls_wrapper_openssl: Modify 'd2i_X509' with standard declaration in openssl

### DIFF
--- a/lib/tls/mbedtls/mbedtls-client.c
+++ b/lib/tls/mbedtls/mbedtls-client.c
@@ -378,7 +378,7 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 					unsigned int key_mem_len
 					)
 {
-	X509 *d2i_X509(X509 **cert, const unsigned char *buffer, long len);
+	X509 *d2i_X509(X509 **cert, const unsigned char **buffer, long len);
 	SSL_METHOD *method = (SSL_METHOD *)TLS_client_method();
 	unsigned long error;
 	int n;
@@ -418,13 +418,13 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 			lwsl_err("Load CA cert file %s failed\n", ca_filepath);
 			return 1;
 		}
-		vh->tls.x509_client_CA = d2i_X509(NULL, buf, (long)len);
+		vh->tls.x509_client_CA = d2i_X509(NULL, &buf, (long)len);
 		free(buf);
 
 		lwsl_info("Loading vh %s client CA for verification %s\n", vh->name, ca_filepath);
 #endif
 	} else {
-		vh->tls.x509_client_CA = d2i_X509(NULL, (uint8_t*)ca_mem, (long)ca_mem_len);
+		vh->tls.x509_client_CA = d2i_X509(NULL, (uint8_t**)&ca_mem, (long)ca_mem_len);
 		lwsl_info("%s: using mem client CA cert %d\n",
 			    __func__, ca_mem_len);
 	}

--- a/lib/tls/mbedtls/wrapper/include/internal/ssl_x509.h
+++ b/lib/tls/mbedtls/wrapper/include/internal/ssl_x509.h
@@ -52,7 +52,7 @@ X509* X509_new(void);
  *
  * @return X509 certification object point
  */
-X509* d2i_X509(X509 **cert, const unsigned char *buffer, long len);
+X509* d2i_X509(X509 **cert, const unsigned char **buffer, long len);
 
 /**
  * @brief free a X509 certification object

--- a/lib/tls/mbedtls/wrapper/library/ssl_x509.c
+++ b/lib/tls/mbedtls/wrapper/library/ssl_x509.c
@@ -86,7 +86,7 @@ void X509_free(X509 *x)
  * @brief load a character certification context into system context. If '*cert' is pointed to the
  *        certification, then load certification into it. Or create a new X509 certification object
  */
-X509* d2i_X509(X509 **cert, const unsigned char *buffer, long len)
+X509* d2i_X509(X509 **cert, const unsigned char **buffer, long len)
 {
     int m = 0;
     int ret;
@@ -106,7 +106,7 @@ X509* d2i_X509(X509 **cert, const unsigned char *buffer, long len)
         m = 1;
     }
 
-    ret = X509_METHOD_CALL(load, x, buffer, (int)len);
+    ret = X509_METHOD_CALL(load, x, *buffer, (int)len);
     if (ret) {
         SSL_DEBUG(SSL_PKEY_ERROR_LEVEL, "X509_METHOD_CALL(load) return %d", ret);
         goto failed2;
@@ -178,7 +178,7 @@ int SSL_CTX_add_client_CA_ASN1(SSL_CTX *ctx, int len,
 {
 	SSL_ASSERT1(ctx);
 
-	if (!d2i_X509(&ctx->client_CA, d, len)) {
+	if (!d2i_X509(&ctx->client_CA, &d, len)) {
 		SSL_DEBUG(SSL_PKEY_ERROR_LEVEL, "d2i_X509() return NULL");
 		return 0;
 	}
@@ -259,7 +259,7 @@ int SSL_CTX_use_certificate_ASN1(SSL_CTX *ctx, int len,
     int ret;
     X509 *x;
 
-    x = d2i_X509(NULL, d, len);
+    x = d2i_X509(NULL, &d, len);
     if (!x) {
         SSL_DEBUG(SSL_PKEY_ERROR_LEVEL, "d2i_X509() return NULL");
         goto failed1;
@@ -287,7 +287,7 @@ int SSL_use_certificate_ASN1(SSL *ssl, const unsigned char *d, int len)
     int ret;
     X509 *x;
 
-    x = d2i_X509(NULL, d, len);
+    x = d2i_X509(NULL, &d, len);
     if (!x) {
         SSL_DEBUG(SSL_PKEY_ERROR_LEVEL, "d2i_X509() return NULL");
         goto failed1;


### PR DESCRIPTION
In the mbedtls wrapper openssl module of libwebsocket, we have noticed a deviation from the standard function declarations used by OpenSSL. While this modification might have been made for specific needs or considerations, we recommend adopting the official function declarations to ensure compatibility and minimize potential issues. This approach helps maintain the stability and consistency of the code, and facilitates integration with other open-source projects and libraries. We appreciate the efforts of all developers who have contributed to libwebsocket and hope that this suggestion will be taken into consideration and adopted.
Signed-off-by: makejian <[makejian@xiaomi.com](mailto:makejian@xiaomi.com)>