### PR TITLE
netlink: when binding the per-context socket, let the kernel choose the unicast address.

### DIFF
--- a/lib/roles/netlink/ops-netlink.c
+++ b/lib/roles/netlink/ops-netlink.c
@@ -602,7 +602,6 @@ rops_pt_init_destroy_netlink(struct lws_context *context,
 
 	memset(&sanl, 0, sizeof(sanl));
 	sanl.nl_family		= AF_NETLINK;
-	sanl.nl_pid		= (uint32_t)getpid();
 	sanl.nl_groups		= RTMGRP_LINK | RTMGRP_IPV4_ROUTE | RTMGRP_IPV4_IFADDR
 #if defined(LWS_WITH_IPV6)
 				  | RTMGRP_IPV6_ROUTE | RTMGRP_IPV6_IFADDR


### PR DESCRIPTION
When using multiple client contextes in a single application, rops_pt_init_destroy_netlink() fails binding the second socket and on - only the first one succeeds. The failure is made obvious by this log:
  W: rops_pt_init_destroy_netlink: netlink bind failed

This is due to the fact that nl_pid is set to pid value, which denies binding multiple sockets for a single application.

So, let's fix this by doing what netlink(7) man page suggests: 
  If the application sets nl_pid before calling bind(2), then it is up to the
  application to make sure that nl_pid is unique. If the application sets it
  to 0, the kernel takes care of assigning it. The kernel assigns the process
  ID to the first netlink socket the process opens and assigns a unique nl_pid
  to every netlink socket that the process subsequently creates.