### PR TITLE
Fix lws_callback_all_protocol and some others

### DIFF
--- a/lib/core-net/pollfd.c
+++ b/lib/core-net/pollfd.c
@@ -621,7 +621,9 @@ lws_callback_on_writable_all_protocol_vhost(const struct lws_vhost *vhost,
 			lws_dll2_get_head(&vhost->same_vh_protocol_owner[n])) {
 		wsi = lws_container_of(d, struct lws, same_vh_protocol);
 
-		assert(wsi->a.protocol == protocol);
+		assert(wsi->a.protocol &&
+		 wsi->a.protocol->callback ==protocol->callback &&
+		 !strcmp(protocol->name, wsi->a.protocol->name));
 		lws_callback_on_writable(wsi);
 
 	} lws_end_foreach_dll_safe(d, d1);

--- a/lib/core-net/wsi.c
+++ b/lib/core-net/wsi.c
@@ -218,8 +218,8 @@ lws_callback_all_protocol_vhost_args(struct lws_vhost *vh,
 			if (!wsi || !wsi->a.protocol)
 				continue;
 			if (wsi->a.vhost == vh && (
-				 wsi->a.protocol->callback == protocol->callback &&
-			     !strcmp(protocol->name, wsi->a.protocol->name) ||
+				 (wsi->a.protocol->callback == protocol->callback &&
+			     !strcmp(protocol->name, wsi->a.protocol->name)) ||
 				 !protocol))
 				wsi->a.protocol->callback(wsi, (enum lws_callback_reasons)reason,
 						wsi->user_space, argp, len);

--- a/lib/core-net/wsi.c
+++ b/lib/core-net/wsi.c
@@ -172,9 +172,10 @@ lws_callback_all_protocol(struct lws_context *context,
 	while (m--) {
 		for (n = 0; n < pt->fds_count; n++) {
 			wsi = wsi_from_fd(context, pt->fds[n].fd);
-			if (!wsi)
+			if (!wsi || !wsi->a.protocol)
 				continue;
-			if (wsi->a.protocol == protocol)
+			if (wsi->a.protocol->callback == protocol->callback &&
+			     !strcmp(protocol->name, wsi->a.protocol->name))
 				protocol->callback(wsi,
 					(enum lws_callback_reasons)reason,
 					wsi->user_space, NULL, 0);

--- a/lib/core-net/wsi.c
+++ b/lib/core-net/wsi.c
@@ -215,10 +215,12 @@ lws_callback_all_protocol_vhost_args(struct lws_vhost *vh,
 	while (m--) {
 		for (n = 0; n < pt->fds_count; n++) {
 			wsi = wsi_from_fd(context, pt->fds[n].fd);
-			if (!wsi)
+			if (!wsi || !wsi->a.protocol)
 				continue;
-			if (wsi->a.vhost == vh && (wsi->a.protocol == protocol ||
-						 !protocol))
+			if (wsi->a.vhost == vh && (
+				 wsi->a.protocol->callback == protocol->callback &&
+			     !strcmp(protocol->name, wsi->a.protocol->name) ||
+				 !protocol))
 				wsi->a.protocol->callback(wsi, (enum lws_callback_reasons)reason,
 						wsi->user_space, argp, len);
 		}
@@ -479,9 +481,10 @@ lws_rx_flow_allow_all_protocol(const struct lws_context *context,
 	while (m--) {
 		for (n = 0; n < pt->fds_count; n++) {
 			wsi = wsi_from_fd(context, pt->fds[n].fd);
-			if (!wsi)
+			if (!wsi || !wsi->a.protocol)
 				continue;
-			if (wsi->a.protocol == protocol)
+			if (wsi->a.protocol->callback == protocol->callback &&
+			     !strcmp(protocol->name, wsi->a.protocol->name))
 				lws_rx_flow_control(wsi, LWS_RXFLOW_ALLOW);
 		}
 		pt++;


### PR DESCRIPTION
Hello maintainers,
In `lws_callback_all_protocol`, you were checking if the current protocol is the targeted one by comparing its pointer to the pointer of the targeted protocol. However, this approach doesn't work as `wsi->a.protocol` is a copy of the protocols (see [lws_create_context() (context.c#L675)](https://github.com/warmcat/libwebsockets/blob/main/lib/core/context.c#L675)).
Instead, it is better to compare callback functions and names as you did there [pollfd.c#L646](https://github.com/warmcat/libwebsockets/blob/main/lib/core-net/pollfd.c#L646).
I noticed that some functions were using the same method to compare protocols, so I have fixed some of them in the meantime.