### PR TITLE
mbedtls-client: Enable the version is correct

### DIFF
--- a/lib/tls/mbedtls/mbedtls-client.c
+++ b/lib/tls/mbedtls/mbedtls-client.c
@@ -379,7 +379,7 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 					)
 {
 	X509 *d2i_X509(X509 **cert, const unsigned char **buffer, long len);
-	SSL_METHOD *method = (SSL_METHOD *)TLS_client_method();
+	SSL_METHOD *method;
 	unsigned long error;
 	int n;
 
@@ -387,6 +387,16 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 	vh->tls_session_cache_max = info->tls_session_cache_max ?
 				    info->tls_session_cache_max : 10;
 	lws_tls_session_cache(vh, info->tls_session_timeout);
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+	method = (SSL_METHOD *)TLSv1_2_client_method();
+#elif defined(MBEDTLS_SSL_PROTO_TLS1_1)
+	method = (SSL_METHOD *)TLSv1_1_client_method();
+#elif defined(MBEDTLS_SSL_PROTO_TLS1)
+	method = (SSL_METHOD *)TLSv1_client_method();
+#else
+	method = (SSL_METHOD *)TLS_client_method();
 #endif
 
 	if (!method) {


### PR DESCRIPTION
After mbedtls version 3.0, support for TLS 1.0 and 1.1 has been removed.
For details, please see https://github.com/Mbed-TLS/mbedtls/issues/4286. 
If use a new version of mbedtls, connection errors may occur due to version reasons.
So we hope it can be configured according to the supported version.