### PR TITLE
bind to interface using SO_BINDTODEVICE socket option on Linux platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,8 +337,10 @@ endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	option(LWS_WITH_NETLINK "Monitor Netlink for Routing Table changes" ON)
+	option(LWS_WITH_BINDTODEVICE "Use bind to interface socket option" ON)
 else()
 	set(LWS_WITH_NETLINK 0)
+	set(LWS_WITH_BINDTODEVICE 0)
 endif()
 option(LWS_WITH_MCUFONT_ENCODER "Build the ttf to mcufont encoder" OFF)
 

--- a/cmake/lws_config.h.in
+++ b/cmake/lws_config.h.in
@@ -201,6 +201,7 @@
 #cmakedefine LWS_WITH_MBEDTLS
 #cmakedefine LWS_WITH_MINIZ
 #cmakedefine LWS_WITH_NETLINK
+#cmakedefine LWS_WITH_BINDTODEVICE
 #cmakedefine LWS_WITH_NETWORK
 #cmakedefine LWS_WITH_NO_LOGS
 #cmakedefine LWS_WITH_OTA

--- a/lib/core-net/network.c
+++ b/lib/core-net/network.c
@@ -381,6 +381,16 @@ lws_socket_bind(struct lws_vhost *vhost, struct lws *wsi,
 	/* just checking for the interface extant */
 	if (sockfd == LWS_SOCK_INVALID)
 		return LWS_ITOSA_USABLE;
+#if defined(LWS_WITH_BINDTODEVICE)
+	if (af != AF_UNIX && iface) {
+		if (setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE, iface, (socklen_t)strlen(iface)) < 0) {
+			int _lws_errno = LWS_ERRNO;
+			lwsl_wsi_warn(wsi, "setsockopt bind to device %s error fd %d (%d)",
+					  iface, sockfd, _lws_errno);
+			/* Root only, non-fatal, continue here. */
+		}
+	}
+#endif
 
 	n = bind(sockfd, v, (socklen_t)n);
 #ifdef LWS_WITH_UNIX_SOCK

--- a/minimal-examples-lowlevel/gtk/minimal-gtk/main.c
+++ b/minimal-examples-lowlevel/gtk/minimal-gtk/main.c
@@ -1,7 +1,7 @@
 #include <gtk/gtk.h>
 #include <libwebsockets.h>
 
-static int status = 0;
+static unsigned int status = 0;
 
 static void
 print_hello(GtkWidget *widget, gpointer data)
@@ -79,7 +79,7 @@ callback_http(struct lws *wsi, enum lws_callback_reasons reason,
 			lws_get_peer_simple(wsi, buf, sizeof(buf));
 			status = lws_http_client_http_response(wsi);
 
-			lwsl_user("Connected to %s, http response: %d\n",
+			lwsl_user("Connected to %s, http response: %u\n",
 					buf, status);
 		}
 		break;
@@ -124,7 +124,7 @@ static const struct lws_protocols protocols[] = {
 		0,
 		0,
 	},
-	{ NULL, NULL, 0, 0 }
+	LWS_PROTOCOL_LIST_TERM
 };
 
 static gpointer


### PR DESCRIPTION
Use the SO_BINDTODEVICE socket option on Linux platforms when binding lws sockets. Current behavior binds to an address on the interface when the interface is specified in `lws_socket_bind()`. This forces traffic over a certain interface, which can be useful for multi-homed systems.

This provides similar behavior to libcurl and c-ares libs. On Linux this requires elevated privileges, and failure to bind is non-fatal.

