### PR TITLE
Restore erroneous modified assertion

### DIFF
--- a/lib/core-net/pollfd.c
+++ b/lib/core-net/pollfd.c
@@ -623,7 +623,10 @@ lws_callback_on_writable_all_protocol_vhost(const struct lws_vhost *vhost,
 			lws_dll2_get_head(&vhost->same_vh_protocol_owner[n])) {
 		wsi = lws_container_of(d, struct lws, same_vh_protocol);
 
-		assert(wsi->a.protocol == protocol);
+		assert(wsi->a.protocol &&
+		       wsi->a.protocol->callback == protocol->callback &&
+		       !strcmp(protocol->name, wsi->a.protocol->name));
+
 		lws_callback_on_writable(wsi);
 
 	} lws_end_foreach_dll_safe(d, d1);


### PR DESCRIPTION
Incorrect modifications on assert: https://github.com/warmcat/libwebsockets/commit/e82028320345fd1942096b35a7015f9ab5ac4931
I fix the incorrect modification on assert by "push -f" at Sat Apr 13, but may not work. So I create a new pull request.