### PR TITLE
cmake: do not allow netlink support when external poll support is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ else()
 	option(LWS_WITH_CACHE_NSCOOKIEJAR "Build file-backed lws-cache-ttl that uses netscape cookie jar format (linux-only)" OFF)
 endif()
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT LWS_WITH_EXTERNAL_POLL)
 	option(LWS_WITH_NETLINK "Monitor Netlink for Routing Table changes" ON)
 else()
 	set(LWS_WITH_NETLINK 0)


### PR DESCRIPTION
Netlink fds are not passed to the user callback for external loop adoption, because vhost and its protocols are not yet in place when  `rops_pt_init_destroy_netlink() ` gets called during context creation. As a consequence, netlink fds are not polled, leading to outdated/missing routing table entries in the library, expecially when application starts at the same time of network itnerfaces. A complex rework would be required to support this, so for now disable netlink when external poll is needed.

This is the function calls sequence:

- `lws_create_context() `calls  `LWS_ROPS_pt_init_destroy() ` for every available role (so netlink too, on Linux)
-  `rops_pt_init_destroy_netlink() ` creates the netlink fd, and passes it to  `lws_wsi_inject_to_loop() `, which then passes it to  `__insert_wsi_socket_into_fds() `
- here, if  `LWS_WITH_EXTERNAL_POLL ` is defined, normally the fd is passed to  `LWS_CALLBACK_ADD_POLL_FD ` callback - but  `wsi->a.vhost ` is not yet inited at this point - so fd is not passed to the application, which gets no chance of adding it to its own poll loop

So, netlink socket ends up being not polled, thus all the library logic on routing table entries is disrupted.
For this reason, if application needs  `LWS_WITH_EXTERNAL_POLL ` support, unfortunately it is better to disable netlink on Linux, too.
