### PR TITLE
fix segmentation fault when generate client ws handshake failed

### DIFF
--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -1641,6 +1641,8 @@ lws_generate_client_handshake(struct lws *wsi, char *pkt)
 	//	if (!wsi->client_pipeline)
 	//		conn1 = "close, ";
 		p = lws_generate_client_ws_handshake(wsi, p, conn1);
+                if (!p)
+                    return NULL;
 	} else
 #endif
 	{


### PR DESCRIPTION
I am working with libwebsockets as a **ws-client** to connect to servers. I encountered a **segmentation fault** randomly while attempting to append handshake headers.

The stack trace is as follows:
```
#0 lws_add_http_header_by_name (...)
#1 service_callback( wsi=0xfffff212790, reason=LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER, user=0x0, in=0xffff4878ec20, len=756637908)
```

Typically, the value of `len` should be smaller than `wsi->a.context->pt_serv_buf_size`. 
Additionally, an error log message states: "E: Unable to read from random device /dev/urandom."

The cause of this issue is that a null pointer is returned when `lws_get_random` fails within the function `lws_generate_client_ws_handshake`.