### PR TITLE
fix segmentation fault of lws_snprintf

### DIFF
--- a/lib/core/libwebsockets.c
+++ b/lib/core/libwebsockets.c
@@ -867,7 +867,7 @@ lws_snprintf(char *str, size_t size, const char *format, ...)
 	va_list ap;
 	int n;
 
-	if (!size)
+	if (!str || !size)
 		return 0;
 
 	va_start(ap, format);


### PR DESCRIPTION
I am working with libwebsockets v4.3.0 as a ws client.
It bears resemblance to #3171, differing in that I don't handle the callback LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER. so the null pointer `p` comes to `p += lws_snprintf(p,  lws_ptr_diff_size_t(end, p), "\x0d\x0a");`

The SIGSEGV stack trace on suse platform is as follows:
```
#0 vsnprintf (string=0x0, maxlen=93824992762488, ....) at ...
#1 lws_snprintf (str=0x0, size=93824992762488, ...) at libwebsockets.c:762
#2 lws_generate_client_handshake (...) at client-http.c:1296
```
I have observed numerous instances of the usage of `p += lws_snprintf(p, ...)`.
so I believe it would be prudent to verify the null pointer within the functions lws_snprintf and lws_strncpy.