### PR TITLE
Update for detailed SSL connection code

### DIFF
--- a/lib/tls/openssl/openssl-ssl.c
+++ b/lib/tls/openssl/openssl-ssl.c
@@ -51,12 +51,33 @@ int lws_openssl_describe_cipher(struct lws *wsi)
 int lws_ssl_get_error(struct lws *wsi, int n)
 {
 	int m;
+	unsigned long l;
+	char buf[160];
 
 	if (!wsi->tls.ssl)
 		return 99;
 
 	m = SSL_get_error(wsi->tls.ssl, n);
        lwsl_debug("%s: %p %d -> %d (errno %d)\n", __func__, wsi->tls.ssl, n, m, LWS_ERRNO);
+	if (m == SSL_ERROR_SSL) {		
+		if(!wsi->tls.err_helper[0]) {
+			// Append first error for clarity
+			l = ERR_get_error();
+			if (l) {				
+				ERR_error_string_n(
+				#if defined(LWS_WITH_BORINGSSL)
+					(uint32_t)
+				#endif
+					l, buf, sizeof(buf));
+
+				lws_strncpy(wsi->tls.err_helper, buf,
+				    sizeof(wsi->tls.err_helper));
+			}									
+		}
+	
+		// Describe other errors
+		lws_tls_err_describe_clear();
+	}
 
        // assert (LWS_ERRNO != 9);
 

--- a/lib/tls/private-network.h
+++ b/lib/tls/private-network.h
@@ -85,7 +85,7 @@ struct lws_lws_tls {
 	lws_tls_kid_chain_t	kid_chain;
 #endif
 	struct lws_dll2		dll_pending_tls;
-	char			err_helper[32];
+	char			err_helper[64];
 	unsigned int		use_ssl;
 	unsigned int		redirect_to_https:1;
 };


### PR DESCRIPTION
Updated code to spit out a relevant OpenSSL error when a connection fails. The return string should be pars-able to obtain the error described like: "tls: error:0A00010B:SSL routines::wrong version number"

Closes: https://github.com/warmcat/libwebsockets/issues/3216
