### PR TITLE
lws-map: Do not assume include order

### DIFF
--- a/include/libwebsockets/lws-map.h
+++ b/include/libwebsockets/lws-map.h
@@ -42,6 +42,8 @@
  */
 //@{
 
+#include "../libwebsockets.h"
+
 typedef struct lws_map lws_map_t;
 struct lws_map_item;
 


### PR DESCRIPTION
This header uses types that are defined in other headers, so include libwebsockets.h explicitly.