### PR TITLE
Allow all HTTP method to be pipelined

### DIFF
--- a/lib/core-net/client/connect2.c
+++ b/lib/core-net/client/connect2.c
@@ -196,10 +196,8 @@ lws_client_connect_2_dnsreq(struct lws *wsi)
 	}
 
 	/* only pipeline things we associate with being a stream */
-
-	if (meth && strcmp(meth, "RAW") && strcmp(meth, "GET") &&
-		    strcmp(meth, "POST") && strcmp(meth, "PUT") &&
-		    strcmp(meth, "UDP") && strcmp(meth, "MQTT"))
+	if(meth && !is_http_method(meth) && strcmp(meth, "RAW")  &&
+		strcmp(meth, "UDP") && strcmp(meth, "MQTT"))
 		goto solo;
 
 	if (!adsin)
@@ -252,8 +250,7 @@ solo:
 	 * piggyback on our transaction queue
 	 */
 
-	if (meth && (!strcmp(meth, "RAW") || !strcmp(meth, "GET") ||
-		     !strcmp(meth, "POST") || !strcmp(meth, "PUT") ||
+	if (meth && (!strcmp(meth, "RAW") || is_http_method(meth) ||
 		     !strcmp(meth, "MQTT")) &&
 	    lws_dll2_is_detached(&wsi->dll2_cli_txn_queue) &&
 	    lws_dll2_is_detached(&wsi->dll_cli_active_conns)) {

--- a/lib/roles/h1/ops-h1.c
+++ b/lib/roles/h1/ops-h1.c
@@ -971,11 +971,24 @@ static const char * const http_methods[] = {
 	"GET", "POST", "OPTIONS", "HEAD", "PUT", "PATCH", "DELETE", "CONNECT"
 };
 
+int
+is_http_method(const char *method)
+{
+	int n = 0;
+
+	if(NULL == method)
+		return 0;
+
+	for (n = 0; n < (int)LWS_ARRAY_SIZE(http_methods); n++)
+		if (!strcmp(method, http_methods[n]))
+			return 1;
+
+	return 0;
+}
+
 static int
 rops_client_bind_h1(struct lws *wsi, const struct lws_client_connect_info *i)
 {
-	int n;
-
 	if (!i) {
 		/* we are finalizing an already-selected role */
 
@@ -1046,10 +1059,8 @@ rops_client_bind_h1(struct lws *wsi, const struct lws_client_connect_info *i)
 	}
 
 	/* if a recognized http method, bind to it */
-
-	for (n = 0; n < (int)LWS_ARRAY_SIZE(http_methods); n++)
-		if (!strcmp(i->method, http_methods[n]))
-			goto bind_h1;
+	if(is_http_method(i->method))
+		goto bind_h1;
 
 	/* other roles may bind to it */
 

--- a/lib/roles/h1/private-lib-roles-h1.h
+++ b/lib/roles/h1/private-lib-roles-h1.h
@@ -25,6 +25,7 @@
  *
  *  Most of the h1 business is defined in the h1 / h2 common roles/http dir
  */
-
+int
+is_http_method(const char *method);
 extern const struct lws_role_ops role_ops_h1;
 #define lwsi_role_h1(wsi) (wsi->role_ops == &role_ops_h1)

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -1376,7 +1376,7 @@ lws_client_interpret_server_handshake(struct lws *wsi)
 		 */
 		if (!wsi->mux_substream && !wsi->client_mux_substream &&
 		    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH) &&
-		    !wsi->http.rx_content_length)
+		    (!wsi->http.rx_content_length || !strcmp(lws_hdr_simple_ptr(wsi, _WSI_TOKEN_CLIENT_METHOD),"HEAD")))
 		        return !!lws_http_transaction_completed_client(wsi);
 
 		/*

--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -1373,11 +1373,16 @@ lws_client_interpret_server_handshake(struct lws *wsi)
 		 * content-length of zero?  If so, and it's not H2 which will
 		 * notice it via END_STREAM, this transaction is already
 		 * completed at the end of the header processing...
+		 * We also completed it if the request method is HEAD which as
+		 * no content leftover.
 		 */
+		simp = lws_hdr_simple_ptr(wsi, _WSI_TOKEN_CLIENT_METHOD);
 		if (!wsi->mux_substream && !wsi->client_mux_substream &&
-		    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH) &&
-		    (!wsi->http.rx_content_length || !strcmp(lws_hdr_simple_ptr(wsi, _WSI_TOKEN_CLIENT_METHOD),"HEAD")))
+			lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH) &&
+			(!wsi->http.rx_content_length || (NULL != simp &&
+			!strcmp(simp,"HEAD"))))
 		        return !!lws_http_transaction_completed_client(wsi);
+
 
 		/*
 		 * We can also get a case where it's http/1 and there's no


### PR DESCRIPTION
Hello Andy,

I was trying to pipeline a HTTP Head request right after a GET and noticed on wireshark that the TCP connection  wasn't pipelined.

It seem that only GET, POST and PUT method are allowed to be pipelined, is there any reason ? Or just was not impleted so far ? 
I propose you the following patch to permit pipeline on all HTTP method.

I also noticed that the HTTP Head method as no LWS_CALLBACK_COMPLETED_CLIENT_HTTP callback, i propose a way to signal it, please let me known if somethings is wrong.

Thanks 

Simon
