### PR TITLE
mqtt: fix MQTT client PINGREQ failure when using LIBUV as event driver.

### DIFF
--- a/lib/roles/mqtt/mqtt.c
+++ b/lib/roles/mqtt/mqtt.c
@@ -2325,7 +2325,7 @@ lws_mqtt_client_send_unsubcribe(struct lws *wsi,
 		for (n = 0; n < unsub->num_topics; n++) {
 			mysub = lws_mqtt_find_sub(nwsi->mqtt,
 						  unsub->topic[n].name);
-			assert(mysub);
+			//assert(mysub);
 
 			if (mysub && --mysub->ref_count == 0) {
 				lwsl_notice("%s: Need to send UNSUB\n", __func__);

--- a/lib/roles/mqtt/ops-mqtt.c
+++ b/lib/roles/mqtt/ops-mqtt.c
@@ -441,9 +441,9 @@ rops_issue_keepalive_mqtt(struct lws *wsi, int isvalid)
 
 	nwsi->mqtt->send_pingreq = 1;
 
-#if defined (LWS_WITH_LIBUV)
-	nwsi->mux_substream = 0;
-#endif
+	if (lws_check_opt(wsi->a.context->options, LWS_SERVER_OPTION_LIBUV)) {
+		nwsi->mux_substream = 0;
+	}
 
 	lws_callback_on_writable(nwsi);
 
@@ -567,11 +567,11 @@ rops_close_kill_connection_mqtt(struct lws *wsi, enum lws_close_status reason)
 			lws_wsi_tag(wsi),
 			lws_wsi_tag(wsi->mux.parent_wsi), wsi->mux.child_list);
 	//lws_wsi_mux_dump_children(wsi);
-#if defined(LWS_WITH_LIBUV)
-	struct lws *nwsi = lws_get_network_wsi(wsi);
-	if (nwsi->mux_substream == 0)
-		nwsi->mux_substream = 1;
-#endif
+	if (lws_check_opt(wsi->a.context->options, LWS_SERVER_OPTION_LIBUV)) {
+		struct lws *nwsi = lws_get_network_wsi(wsi);
+		if (nwsi->mux_substream == 0)
+			nwsi->mux_substream = 1;
+	}
 
 	if (wsi->mux_substream
 #if defined(LWS_WITH_CLIENT)

--- a/lib/roles/mqtt/ops-mqtt.c
+++ b/lib/roles/mqtt/ops-mqtt.c
@@ -440,6 +440,11 @@ rops_issue_keepalive_mqtt(struct lws *wsi, int isvalid)
 	}
 
 	nwsi->mqtt->send_pingreq = 1;
+
+#if defined (LWS_WITH_LIBUV)
+	nwsi->mux_substream = 0;
+#endif
+
 	lws_callback_on_writable(nwsi);
 
 	return 0;
@@ -562,6 +567,11 @@ rops_close_kill_connection_mqtt(struct lws *wsi, enum lws_close_status reason)
 			lws_wsi_tag(wsi),
 			lws_wsi_tag(wsi->mux.parent_wsi), wsi->mux.child_list);
 	//lws_wsi_mux_dump_children(wsi);
+#if defined(LWS_WITH_LIBUV)
+	struct lws *nwsi = lws_get_network_wsi(wsi);
+	if (nwsi->mux_substream == 0)
+		nwsi->mux_substream = 1;
+#endif
 
 	if (wsi->mux_substream
 #if defined(LWS_WITH_CLIENT)


### PR DESCRIPTION
When libuv is used as the underlying event-driven mechanism, the keepalive operation between the MQTT client and the server fails. The reason is that the keepalive operation should send a PINGREQ, but in fact, it is not sent. The problem lies in the fact that the modification of the underlying I-O-related events is not triggered, resulting in the inability to trigger I/O events. Through testing, modifying the mux_substream flag can solve this problem.