### PR TITLE
unix: Fix linker errors when building without sdevent

### DIFF
--- a/lib/plat/unix/CMakeLists.txt
+++ b/lib/plat/unix/CMakeLists.txt
@@ -63,7 +63,7 @@ if (LWS_WITH_NETWORK)
 			list(APPEND SOURCES plat/unix/unix-resolv.c)
 		endif()
 	endif()
-	if (LWS_HAVE_SYSTEMD_H)
+	if (LWS_WITH_SDEVENT AND LWS_HAVE_SYSTEMD_H)
 		list(APPEND SOURCES
 			plat/unix/unix-systemd.c
 		)


### PR DESCRIPTION
When building without systemd event support (-DLWS_WITH_SDEVENT=OFF) on a system that has libsystemd headers installed, lib/plat/unix-systemd.c is build in anyway.
The final libwebsockets library has then references to symbols from libsystemd even though it won't be linked.

Resulting in the follwoing linker errros:
--
/usr/bin/ld: /usr/local/lib/libwebsockets.so: undefined reference to `sd_is_socket_inet' /usr/bin/ld: /usr/local/lib/libwebsockets.so: undefined reference to `sd_is_socket_unix' /usr/bin/ld: /usr/local/lib/libwebsockets.so: undefined reference to `sd_listen_fds' 
--

This commit ensures that unix-system.c is only build when LWS_WITH_SDEVENT is set and the system has libsystemd headers installed.