### PR TITLE
adjust ssl verification and options after context change

### DIFF
--- a/lib/secure-streams/private-lib-secure-streams.h
+++ b/lib/secure-streams/private-lib-secure-streams.h
@@ -132,17 +132,17 @@ typedef struct lws_ss_handle {
 
 			union {
 				struct { /* LWSSSP_H1 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h1;
 				struct { /* LWSSSP_H2 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h2;
 				struct { /* LWSSSP_WS */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} ws;

--- a/lib/tls/openssl/openssl-server.c
+++ b/lib/tls/openssl/openssl-server.c
@@ -141,6 +141,17 @@ lws_ssl_server_name_cb(SSL *ssl, int *ad, void *arg)
 	/* select the ssl ctx from the selected vhost for this conn */
 	SSL_set_SSL_CTX(ssl, vhost->tls.ssl_ctx);
 
+	/* also, adjust other things we care about */
+	SSL_set_verify(ssl, SSL_CTX_get_verify_mode(vhost->tls.ssl_ctx),
+		SSL_CTX_get_verify_callback(vhost->tls.ssl_ctx));
+	SSL_set_verify_depth(ssl, SSL_CTX_get_verify_depth(vhost->tls.ssl_ctx));
+
+#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
+	SSL_clear_options(ssl, SSL_get_options(ssl) &
+		~SSL_CTX_get_options(vhost->tls.ssl_ctx));
+#endif
+	SSL_set_options(ssl, SSL_CTX_get_options(vhost->tls.ssl_ctx));
+
 	return SSL_TLSEXT_ERR_OK;
 }
 #endif


### PR DESCRIPTION
Fix for a well-known glitch in OpenSSL: when reassigning SSL to a different SSL_CTX certificates gets updated from a new context, but verification mode/depth and options are not updated.

Based on nginx implementation (https://mailman.nginx.org/pipermail/nginx-devel/2011-February/000728.html).