### PR TITLE
ESP-IDF: Removed explicit `esp_task_wdt_reset` call

### DIFF
--- a/lib/plat/freertos/freertos-service.c
+++ b/lib/plat/freertos/freertos-service.c
@@ -27,15 +27,8 @@
 int
 lws_plat_service(struct lws_context *context, int timeout_ms)
 {
-	int n = _lws_plat_service_tsi(context, timeout_ms, 0);
-
-#if !defined(LWS_AMAZON_RTOS) && defined(LWS_ESP_PLATFORM) && defined(CONFIG_ESP_INT_WDT)
-	esp_task_wdt_reset();
-#endif
-
-	return n;
+	return _lws_plat_service_tsi(context, timeout_ms, 0);
 }
-
 
 int
 _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)

--- a/lib/plat/freertos/private-lib-plat-freertos.h
+++ b/lib/plat/freertos/private-lib-plat-freertos.h
@@ -69,7 +69,6 @@
 #endif
 #endif
  #include <esp_system.h>
- #include <esp_task_wdt.h>
 #endif
 
 #if defined(LWS_WITH_ESP32)

--- a/lib/secure-streams/private-lib-secure-streams.h
+++ b/lib/secure-streams/private-lib-secure-streams.h
@@ -132,17 +132,17 @@ typedef struct lws_ss_handle {
 
 			union {
 				struct { /* LWSSSP_H1 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h1;
 				struct { /* LWSSSP_H2 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h2;
 				struct { /* LWSSSP_WS */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} ws;

--- a/minimal-examples/embedded/esp32/esp-c3dev/private-lib-plat-freertos.h
+++ b/minimal-examples/embedded/esp32/esp-c3dev/private-lib-plat-freertos.h
@@ -64,7 +64,6 @@ gai_strerror(int);
  #include "freertos/timers.h"
  #include <esp_attr.h>
  #include <esp_system.h>
- #include <esp_task_wdt.h>
 #endif
 
 #if defined(LWS_WITH_ESP32)

--- a/minimal-examples/embedded/lhp/main.h
+++ b/minimal-examples/embedded/lhp/main.h
@@ -5,7 +5,6 @@
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include <esp_task_wdt.h>
 #include <driver/gpio.h>
 
 #include <libwebsockets.h>


### PR DESCRIPTION
Why is `esp_task_wdt_reset` needed?:
- If the task is running for longer without yielding, this leads to the task watchdog to trigger, then one should reset the task watchdog with the mentioned API.

Points under consideration while removing the call:
- `lws_service()` function call is not unyielding, meaning, it does wait on socket select. Even if this function is called in a loop, it should be the caller's responsibility to yield or call `esp_task_wdt_reset`.
-  Rightly so, the examples here do yield calling `taskYIELD`
- Calling `esp_task_wdt_reset` without calling `esp_task_wdt_add` has no real use and only leads benign errors.
