### PR TITLE
Add systemd to the PkgConfig file if it's needed by the lib

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -307,6 +307,13 @@ if (LWS_HAVE_LIBCAP)
 		set(lws_requires "libcap")
 	endif()
 endif()
+if (LWS_HAVE_SYSTEMD_H)
+	if (NOT lws_requires STREQUAL "")
+		set(lws_requires "${lws_requires},libsystemd")
+	else()
+		set(lws_requires "libsystemd")
+	endif()
+endif()
 
 
 # Generate and install pkgconfig.

--- a/lib/secure-streams/private-lib-secure-streams.h
+++ b/lib/secure-streams/private-lib-secure-streams.h
@@ -132,17 +132,17 @@ typedef struct lws_ss_handle {
 
 			union {
 				struct { /* LWSSSP_H1 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h1;
 				struct { /* LWSSSP_H2 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h2;
 				struct { /* LWSSSP_WS */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} ws;


### PR DESCRIPTION
Hello,

if I'm compiling an external project using the pkg config file, it fails with the following error on my machine:
```
FAILED: proxy 
: && /usr/bin/cc   CMakeFiles/proxy.dir/proxy.c.o -o proxy -L/opt/libwebsockets/lib -Wl,-rpath,/opt/libwebsockets/lib  -lm  -lwebsockets  -lcap && :
/usr/bin/ld: /opt/libwebsockets/lib/libwebsockets.so: undefined reference to `sd_is_socket_inet'
/usr/bin/ld: /opt/libwebsockets/lib/libwebsockets.so: undefined reference to `sd_listen_fds'
/usr/bin/ld: /opt/libwebsockets/lib/libwebsockets.so: undefined reference to `sd_is_socket_unix'
collect2: error: ld returned 1 exit status
```

This PR adds SystemD to the dependencies of the package if SystemD was detected on disk.

Thanks for this great project,
Mt