### PR TITLE
mbedtls/ssl: free cert chain when mbedtls_client_preload_filepath ena…

### DIFF
--- a/lib/secure-streams/private-lib-secure-streams.h
+++ b/lib/secure-streams/private-lib-secure-streams.h
@@ -132,17 +132,17 @@ typedef struct lws_ss_handle {
 
 			union {
 				struct { /* LWSSSP_H1 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h1;
 				struct { /* LWSSSP_H2 */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} h2;
 				struct { /* LWSSSP_WS */
-#if defined(WIN32)
+#if defined(WIN32) || defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 					uint8_t dummy;
 #endif
 				} ws;

--- a/lib/tls/mbedtls/wrapper/library/ssl_lib.c
+++ b/lib/tls/mbedtls/wrapper/library/ssl_lib.c
@@ -226,15 +226,18 @@ SSL_CTX* SSL_CTX_new(const SSL_METHOD *method, void *rngctx)
 
 #if defined(LWS_HAVE_mbedtls_x509_crt_parse_file)
     if (mbedtls_client_preload_filepath) {
-	mbedtls_x509_crt **px = (mbedtls_x509_crt **)ctx->client_CA->x509_pm;
+        mbedtls_x509_crt **px = (mbedtls_x509_crt **)ctx->client_CA->x509_pm;
 
-	*px = malloc(sizeof(**px));
-	mbedtls_x509_crt_init(*px);
-	n = mbedtls_x509_crt_parse_file(*px, mbedtls_client_preload_filepath);
-	if (n < 0)
-		lwsl_err("%s: unable to load cert bundle 0x%x\n", __func__, -n);
-	else
-		lwsl_info("%s: loaded cert bundle %d\n", __func__, n);
+        *px = malloc(sizeof(**px));
+        mbedtls_x509_crt_init(*px);
+        n = mbedtls_x509_crt_parse_file(*px, mbedtls_client_preload_filepath);
+        if (n < 0) {
+            lwsl_err("%s: unable to load cert bundle 0x%x\n", __func__, -n);
+            mbedtls_x509_crt_free(*px);
+            free(*px);
+        } else {
+            lwsl_info("%s: loaded cert bundle %d\n", __func__, n);
+        }
     }
 #endif
 
@@ -256,6 +259,17 @@ void SSL_CTX_free(SSL_CTX* ctx)
     SSL_ASSERT3(ctx);
 
     ssl_cert_free(ctx->cert);
+
+#if defined(LWS_HAVE_mbedtls_x509_crt_parse_file)
+    if (mbedtls_client_preload_filepath) {
+        mbedtls_x509_crt **px = (mbedtls_x509_crt **)ctx->client_CA->x509_pm;
+
+        if (*px) {
+            mbedtls_x509_crt_free(*px);
+            free(*px);
+        }
+    }
+#endif
 
     X509_free(ctx->client_CA);
 


### PR DESCRIPTION
hello, I have encountered some issues while using the mbedtls-wrapper for lws, and I would like to propose incorporating the following fixes:
1. fix the alignment in SSL_CTX_new
2. release memory if failed to parse cert chain in SSL_CTX_new
3. release cert chain during SSL_free call

I would appreciate it if these changes could be considered for inclusion in the project. Thank you for your time and consideration.
Best regards.