### PR TITLE
windows-specific install options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,9 @@ endif()
 if (MSVC)
 	option(LWS_MSVC_STATIC_RUNTIME "Link to static MSVC runtime" OFF)
 endif()
+if (WIN32)
+    option(LWS_APPEND_DEBUG_SUFFIX_D "Append 'd' to library name when CMAKE_BUILD_TYPE=Debug" OFF)
+endif()
 
 #
 # to use miniz, enable both LWS_WITH_ZLIB and LWS_WITH_MINIZ

--- a/READMEs/README.coding.md
+++ b/READMEs/README.coding.md
@@ -31,7 +31,7 @@ one after the other and gets the same benefit from the same code.
 Isolating and collating the protocol code in one place also makes it very easy
 to maintain and understand.
 
-So it if highly recommended you put your protocol-specific code into the
+So it is highly recommended you put your protocol-specific code into the
 form of a "plugin" at the source level, even if you have no immediate plan to
 use it dynamically-loaded.
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -190,6 +190,10 @@ if (LWS_WITH_STATIC)
 			OUTPUT_NAME websockets_static)
 	endif()
 	
+	if (LWS_APPEND_DEBUG_SUFFIX_D)
+		set_target_properties(websockets PROPERTIES DEBUG_POSTFIX d)
+	endif()
+
 endif()
 
 if (LWS_WITH_SHARED)
@@ -238,6 +242,10 @@ if (LWS_WITH_SHARED)
 				target_link_libraries(websockets_shared dl)
 			endif()
 		endif()
+	endif()
+
+	if (LWS_APPEND_DEBUG_SUFFIX_D)
+		set_target_properties(websockets_shared PROPERTIES DEBUG_POSTFIX d)
 	endif()
 
 endif()


### PR DESCRIPTION
* Provides new top-level option `LWS_APPEND_DEBUG_SUFFIX_D` to allow user to indicate that Debug compile version should have a name with a `d` suffix, thereby enabling the release-mode version to live alongside it.
* Adds logic to include the .pdb file in the install for Debug and RelWithDebInfo modes -- for the shared library only (of course).