### PR TITLE
solaris/illumos build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,6 +696,9 @@ else()
 endif()
 CHECK_C_SOURCE_COMPILES("#include <systemd/sd-daemon.h>\nvoid main(void) { while(1) ; } void xxexit(void){}" LWS_HAVE_SYSTEMD_H)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+	unset(LWS_HAVE_CTIME_R CACHE)
+endif()
 
 
 if (LWS_EXT_PTHREAD_INCLUDE_DIR)
@@ -933,6 +936,13 @@ if (COMPILER_IS_CLANG)
 	if (UNIX AND LWS_HAVE_PTHREAD_H)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -Wno-error=unused-command-line-argument" )
 	endif()
+endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+		list(APPEND LIB_LIST_AT_END -lsocket)
+		if ((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX))
+			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-conversion")
+		endif()
 endif()
 
 if (WINCE)

--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -47,6 +47,12 @@ extern "C" {
 #if defined(_WIN32) && !defined(ETHER_ADDR_LEN)
 #define ETHER_ADDR_LEN 6
 #endif
+#if defined (__sun)
+	#include <sys/ethernet.h>
+	#if !defined(ETHER_ADDR_LEN) && defined(ETHERADDRL)
+		#define ETHER_ADDR_LEN ETHERADDRL
+	#endif
+#endif
 #define LWS_ETHER_ADDR_LEN ETHER_ADDR_LEN
 
 #include <stddef.h>

--- a/lib/plat/unix/private-lib-plat-unix.h
+++ b/lib/plat/unix/private-lib-plat-unix.h
@@ -141,6 +141,13 @@ typedef pthread_mutex_t lws_mutex_t;
 # define TCP_KEEPCNT   TCPCTL_KEEPCNT
 #endif
 
+#if defined (__sun)
+	#include <sys/ethernet.h>
+	#if !defined(ETHER_ADDR_LEN) && defined(ETHERADDRL)
+		#define ETHER_ADDR_LEN ETHERADDRL
+	#endif
+#endif
+
 #define LWS_ERRNO errno
 #define LWS_EAGAIN EAGAIN
 #define LWS_EALREADY EALREADY


### PR DESCRIPTION
In Solaris, the build fails in wol.c because solaris does not define ETHERADDRL instead it defines ETHER_ADDR_LEN.
Also, link with -lsocket needs unlike linux.

While building the tests, 
I have to add -Wno-conversion due to a build error related to FD_SET,
ctime_r is defined slightly different than Linux. I just added unset for solaris, but check using CHECK_C_SOURCE_COMPILES might be more better approach.