### PR TITLE
Allow applications to specify chroot and chdir for CGI mounts

### DIFF
--- a/include/libwebsockets/lws-cgi.h
+++ b/include/libwebsockets/lws-cgi.h
@@ -72,6 +72,10 @@ struct lws_cgi_info {
 	/**< seconds script should be allowed to run */
 	const struct lws_protocol_vhost_options *mp_cgienv;
 	/**< pvo list with per-vhost cgi options to put in env */
+	const char *chroot_path;
+	/**< NULL, or chroot patch for child process */
+	const char *wd;
+	/**< working directory to cd to after fork, NULL defaults to /tmp */
 };
 
 #ifdef LWS_WITH_CGI

--- a/include/libwebsockets/lws-cgi.h
+++ b/include/libwebsockets/lws-cgi.h
@@ -58,7 +58,29 @@ struct lws_cgi_args {
 	int len; /**< length */
 };
 
+/** struct lws_cgi_info - parameters to spawn network-connected cgi
+ *                        process when using lws_cgi_via_info() */
+struct lws_cgi_info {
+	struct lws *wsi;
+	/**< connection to own the process */
+	const char * const *exec_array;
+	/**< array of "exec-name" "arg1" ... "argn" NULL */
+	int script_uri_path_len;
+	/**< how many chars on the left of the uri are the path to the
+	 * cgi, or -1 to spawn without URL-related env vars */
+	int timeout_secs;
+	/**< seconds script should be allowed to run */
+	const struct lws_protocol_vhost_options *mp_cgienv;
+	/**< pvo list with per-vhost cgi options to put in env */
+};
+
 #ifdef LWS_WITH_CGI
+/**
+ * lws_cgi_via_info() - Spawn network-connected cgi process
+ * \param cgiinfo: pointer to lws_cgi_info struct
+ */
+LWS_VISIBLE LWS_EXTERN int lws_cgi_via_info(struct lws_cgi_info * cgiinfo);
+
 /**
  * lws_cgi: spawn network-connected cgi process
  *

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -1382,6 +1382,14 @@ struct lws_http_mount {
 	const char *basic_auth_login_file;
 	/**<NULL, or filepath to use to check basic auth logins against. (requires LWSAUTHM_DEFAULT) */
 
+	const char *cgi_chroot_path;
+	/**< NULL, or chroot patch for child cgi process */
+
+	const char *cgi_wd;
+	/**< working directory to cd to after fork of a cgi process,
+	 * NULL defaults to /tmp
+	 */
+
 	/* Add new things just above here ---^
 	 * This is part of the ABI, don't needlessly break compatibility
 	 */

--- a/lib/roles/cgi/cgi-server.c
+++ b/lib/roles/cgi/cgi-server.c
@@ -117,42 +117,41 @@ lws_cgi_reap_cb(void *opaque, lws_usec_t *accounting, siginfo_t *si,
 }
 
 int
-lws_cgi(struct lws *wsi, const char * const *exec_array,
-	int script_uri_path_len, int timeout_secs,
-	const struct lws_protocol_vhost_options *mp_cgienv)
+lws_cgi_via_info(struct lws_cgi_info * cgiinfo)
 {
-	struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
+	struct lws_context_per_thread *pt = &cgiinfo->wsi->a.context->pt[(int)cgiinfo->wsi->tsi];
 	struct lws_spawn_piped_info info;
 	char *env_array[30], cgi_path[500], e[1024], *p = e,
 	     *end = p + sizeof(e) - 1, tok[256], *t, *sum, *sumend;
 	struct lws_cgi *cgi;
 	int n, m = 0, i, uritok = -1, c;
+	const struct lws_protocol_vhost_options *mp_cgienv = cgiinfo->mp_cgienv;
 
 	/*
 	 * give the cgi stream wsi a cgi struct
 	 */
 
-	wsi->http.cgi = lws_zalloc(sizeof(*wsi->http.cgi), "new cgi");
-	if (!wsi->http.cgi) {
-		lwsl_wsi_err(wsi, "OOM");
+	cgiinfo->wsi->http.cgi = lws_zalloc(sizeof(*cgiinfo->wsi->http.cgi), "new cgi");
+	if (!cgiinfo->wsi->http.cgi) {
+		lwsl_wsi_err(cgiinfo->wsi, "OOM");
 		return -1;
 	}
 
-	wsi->http.cgi->response_code = HTTP_STATUS_OK;
+	cgiinfo->wsi->http.cgi->response_code = HTTP_STATUS_OK;
 
-	cgi = wsi->http.cgi;
-	cgi->wsi = wsi; /* set cgi's owning wsi */
+	cgi = cgiinfo->wsi->http.cgi;
+	cgi->wsi = cgiinfo->wsi; /* set cgi's owning wsi */
 	sum = cgi->summary;
 	sumend = sum + strlen(cgi->summary) - 1;
 
-	if (timeout_secs)
-		lws_set_timeout(wsi, PENDING_TIMEOUT_CGI, timeout_secs);
+	if (cgiinfo->timeout_secs)
+		lws_set_timeout(cgiinfo->wsi, PENDING_TIMEOUT_CGI, cgiinfo->timeout_secs);
 
 	/* the cgi stdout is always sending us http1.x header data first */
-	wsi->hdr_state = LCHS_HEADER;
+	cgiinfo->wsi->hdr_state = LCHS_HEADER;
 
 	/* add us to the pt list of active cgis */
-	lwsl_wsi_debug(wsi, "adding cgi %p to list", wsi->http.cgi);
+	lwsl_wsi_debug(cgiinfo->wsi, "adding cgi %p to list", cgiinfo->wsi->http.cgi);
 	cgi->cgi_list = pt->http.cgi_list;
 	pt->http.cgi_list = cgi;
 
@@ -161,27 +160,27 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 		lws_sul_schedule(pt->context, (int)(pt - pt->context->pt), &pt->sul_cgi,
 				 lws_cgi_sul_cb, 3 * LWS_US_PER_SEC);
 
-	sum += lws_snprintf(sum, lws_ptr_diff_size_t(sumend, sum), "%s ", exec_array[0]);
+	sum += lws_snprintf(sum, lws_ptr_diff_size_t(sumend, sum), "%s ", cgiinfo->exec_array[0]);
 
 	if (0) {
-		char *pct = lws_hdr_simple_ptr(wsi,
+		char *pct = lws_hdr_simple_ptr(cgiinfo->wsi,
 				WSI_TOKEN_HTTP_CONTENT_ENCODING);
 
 		if (pct && !strcmp(pct, "gzip"))
-			wsi->http.cgi->gzip_inflate = 1;
+			cgiinfo->wsi->http.cgi->gzip_inflate = 1;
 	}
 
 	/* prepare his CGI env */
 
 	n = 0;
 
-	if (lws_is_ssl(wsi)) {
+	if (lws_is_ssl(cgiinfo->wsi)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTPS=ON");
 		p++;
 	}
 
-	if (wsi->http.ah) {
+	if (cgiinfo->wsi->http.ah) {
 		static const unsigned char meths[] = {
 			WSI_TOKEN_GET_URI,
 			WSI_TOKEN_POST_URI,
@@ -205,17 +204,17 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 			"CONNECT", "HEAD", ":path"
 		};
 
-		if (script_uri_path_len >= 0)
+		if (cgiinfo->script_uri_path_len >= 0)
 			for (m = 0; m < (int)LWS_ARRAY_SIZE(meths); m++)
-				if (lws_hdr_total_length(wsi, meths[m]) >=
-						script_uri_path_len) {
+				if (lws_hdr_total_length(cgiinfo->wsi, meths[m]) >=
+						cgiinfo->script_uri_path_len) {
 					uritok = meths[m];
 					break;
 				}
 
-		if (script_uri_path_len < 0 && uritok < 0)
+		if (cgiinfo->script_uri_path_len < 0 && uritok < 0)
 			goto bail;
-//		if (script_uri_path_len < 0)
+//		if (cgiinfo->script_uri_path_len < 0)
 //			uritok = 0;
 
 		if (m >= 0) {
@@ -230,9 +229,9 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 			} else {
 				p += lws_snprintf(p, lws_ptr_diff_size_t(end, p),
 						  "REQUEST_METHOD=%s",
-			  lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_COLON_METHOD));
+			  lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_COLON_METHOD));
 				sum += lws_snprintf(sum, lws_ptr_diff_size_t(sumend, sum), "%s ",
-					lws_hdr_simple_ptr(wsi,
+					lws_hdr_simple_ptr(cgiinfo->wsi,
 						  WSI_TOKEN_HTTP_COLON_METHOD));
 #endif
 			}
@@ -241,14 +240,14 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 
 		if (uritok >= 0)
 			sum += lws_snprintf(sum, lws_ptr_diff_size_t(sumend, sum), "%s ",
-					    lws_hdr_simple_ptr(wsi, (enum lws_token_indexes)uritok));
+					    lws_hdr_simple_ptr(cgiinfo->wsi, (enum lws_token_indexes)uritok));
 
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "QUERY_STRING=");
 		/* dump the individual URI Arg parameters */
 		m = 0;
-		while (script_uri_path_len >= 0) {
-			i = lws_hdr_copy_fragment(wsi, tok, sizeof(tok),
+		while (cgiinfo->script_uri_path_len >= 0) {
+			i = lws_hdr_copy_fragment(cgiinfo->wsi, tok, sizeof(tok),
 					     WSI_TOKEN_HTTP_URI_ARGS, m);
 			if (i < 0)
 				break;
@@ -270,7 +269,7 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 
 		if (uritok >= 0) {
 			strcpy(cgi_path, "REQUEST_URI=");
-			c = lws_hdr_copy(wsi, cgi_path + 12,
+			c = lws_hdr_copy(cgiinfo->wsi, cgi_path + 12,
 					 sizeof(cgi_path) - 12, (enum lws_token_indexes)uritok);
 			if (c < 0)
 				goto bail;
@@ -281,88 +280,88 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 
 		sum += lws_snprintf(sum, lws_ptr_diff_size_t(sumend, sum), "%s", env_array[n - 1]);
 
-		if (script_uri_path_len >= 0) {
+		if (cgiinfo->script_uri_path_len >= 0) {
 			env_array[n++] = p;
 			p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "PATH_INFO=%s",
-				      cgi_path + 12 + script_uri_path_len);
+				      cgi_path + 12 + cgiinfo->script_uri_path_len);
 			p++;
 		}
 	}
 #if defined(LWS_WITH_HTTP_UNCOMMON_HEADERS)
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_REFERER)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_REFERER)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_REFERER=%s",
-			      lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_REFERER));
+			      lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_REFERER));
 		p++;
 	}
 #endif
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HOST)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HOST)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_HOST=%s",
-			      lws_hdr_simple_ptr(wsi, WSI_TOKEN_HOST));
+			      lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HOST));
 		p++;
 	}
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_COOKIE)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_COOKIE)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_COOKIE=");
-		m = lws_hdr_copy(wsi, p, lws_ptr_diff(end, p), WSI_TOKEN_HTTP_COOKIE);
+		m = lws_hdr_copy(cgiinfo->wsi, p, lws_ptr_diff(end, p), WSI_TOKEN_HTTP_COOKIE);
 		if (m > 0)
-			p += lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_COOKIE);
+			p += lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_COOKIE);
 		*p++ = '\0';
 	}
 #if defined(LWS_WITH_HTTP_UNCOMMON_HEADERS)
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_USER_AGENT)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_USER_AGENT)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_USER_AGENT=%s",
-			    lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_USER_AGENT));
+			    lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_USER_AGENT));
 		p++;
 	}
 #endif
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_ENCODING)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_CONTENT_ENCODING)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_CONTENT_ENCODING=%s",
-		      lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_CONTENT_ENCODING));
+		      lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_CONTENT_ENCODING));
 		p++;
 	}
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_ACCEPT)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_ACCEPT)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_ACCEPT=%s",
-			      lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_ACCEPT));
+			      lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_ACCEPT));
 		p++;
 	}
-	if (script_uri_path_len >= 0 &&
-	    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_ACCEPT_ENCODING)) {
+	if (cgiinfo->script_uri_path_len >= 0 &&
+	    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_ACCEPT_ENCODING)) {
 		env_array[n++] = p;
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "HTTP_ACCEPT_ENCODING=%s",
-		      lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_ACCEPT_ENCODING));
+		      lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_ACCEPT_ENCODING));
 		p++;
 	}
-	if (script_uri_path_len >= 0 &&
+	if (cgiinfo->script_uri_path_len >= 0 &&
 	    uritok == WSI_TOKEN_POST_URI) {
-		if (lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_TYPE)) {
+		if (lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_CONTENT_TYPE)) {
 			env_array[n++] = p;
 			p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "CONTENT_TYPE=%s",
-			  lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_CONTENT_TYPE));
+			  lws_hdr_simple_ptr(cgiinfo->wsi, WSI_TOKEN_HTTP_CONTENT_TYPE));
 			p++;
 		}
-		if (!wsi->http.cgi->gzip_inflate &&
-		    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH)) {
+		if (!cgiinfo->wsi->http.cgi->gzip_inflate &&
+		    lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH)) {
 			env_array[n++] = p;
 			p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "CONTENT_LENGTH=%s",
-					  lws_hdr_simple_ptr(wsi,
+					  lws_hdr_simple_ptr(cgiinfo->wsi,
 					  WSI_TOKEN_HTTP_CONTENT_LENGTH));
 			p++;
 		}
 
-		if (lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH))
-			wsi->http.cgi->post_in_expected = (lws_filepos_t)
-				atoll(lws_hdr_simple_ptr(wsi,
+		if (lws_hdr_total_length(cgiinfo->wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH))
+			cgiinfo->wsi->http.cgi->post_in_expected = (lws_filepos_t)
+				atoll(lws_hdr_simple_ptr(cgiinfo->wsi,
 						WSI_TOKEN_HTTP_CONTENT_LENGTH));
 	}
 
@@ -372,7 +371,7 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 	p++;
 
 	env_array[n++] = p;
-	p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "SCRIPT_PATH=%s", exec_array[0]);
+	p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "SCRIPT_PATH=%s", cgiinfo->exec_array[0]);
 	p++;
 
 	while (mp_cgienv) {
@@ -380,8 +379,8 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 		p += lws_snprintf(p, lws_ptr_diff_size_t(end, p), "%s=%s", mp_cgienv->name,
 			      mp_cgienv->value);
 		if (!strcmp(mp_cgienv->name, "GIT_PROJECT_ROOT")) {
-			wsi->http.cgi->implied_chunked = 1;
-			wsi->http.cgi->explicitly_chunked = 1;
+			cgiinfo->wsi->http.cgi->implied_chunked = 1;
+			cgiinfo->wsi->http.cgi->explicitly_chunked = 1;
 		}
 		lwsl_info("   Applying mount-specific cgi env '%s'\n",
 			   env_array[n - 1]);
@@ -402,53 +401,69 @@ lws_cgi(struct lws *wsi, const char * const *exec_array,
 
 	memset(&info, 0, sizeof(info));
 	info.env_array = (const char **)env_array;
-	info.exec_array = exec_array;
+	info.exec_array = cgiinfo->exec_array;
 	info.max_log_lines = 20000;
-	info.opt_parent = wsi;
+	info.opt_parent = cgiinfo->wsi;
 	info.timeout_us = 5 * 60 * LWS_US_PER_SEC;
-	info.tsi = wsi->tsi;
-	info.vh = wsi->a.vhost;
+	info.tsi = cgiinfo->wsi->tsi;
+	info.vh = cgiinfo->wsi->a.vhost;
 	info.ops = &role_ops_cgi;
-	info.plsp = &wsi->http.cgi->lsp;
-	info.opaque = wsi;
+	info.plsp = &cgiinfo->wsi->http.cgi->lsp;
+	info.opaque = cgiinfo->wsi;
 	info.reap_cb = lws_cgi_reap_cb;
 
 	/*
 	 * Actually having made the env, as a cgi we don't need the ah
 	 * any more
 	 */
-	if (script_uri_path_len >= 0) {
-		lws_header_table_detach(wsi, 0);
+	if (cgiinfo->script_uri_path_len >= 0) {
+		lws_header_table_detach(cgiinfo->wsi, 0);
 		info.disable_ctrlc = 1;
 	}
 
-	wsi->http.cgi->lsp = lws_spawn_piped(&info);
-	if (!wsi->http.cgi->lsp) {
+	cgiinfo->wsi->http.cgi->lsp = lws_spawn_piped(&info);
+	if (!cgiinfo->wsi->http.cgi->lsp) {
 		lwsl_err("%s: spawn failed\n", __func__);
 		goto bail;
 	}
 
-	wsi->http.cgi->pi = wsi->http.cgi->lsp->child_pid;
+	cgiinfo->wsi->http.cgi->pi = cgiinfo->wsi->http.cgi->lsp->child_pid;
 
 	/* we are the parent process */
 
-	wsi->a.context->count_cgi_spawned++;
+	cgiinfo->wsi->a.context->count_cgi_spawned++;
 
 	/* inform cgi owner of the child PID */
-	n = user_callback_handle_rxflow(wsi->a.protocol->callback, wsi,
+	n = user_callback_handle_rxflow(cgiinfo->wsi->a.protocol->callback, cgiinfo->wsi,
 				    LWS_CALLBACK_CGI_PROCESS_ATTACH,
-				    wsi->user_space, NULL, (unsigned int)cgi->lsp->child_pid);
+				    cgiinfo->wsi->user_space, NULL, (unsigned int)cgi->lsp->child_pid);
 	(void)n;
 
 	return 0;
 
 bail:
-	lws_sul_cancel(&wsi->http.cgi->sul_grace);
-	lws_free_set_NULL(wsi->http.cgi);
+	lws_sul_cancel(&cgiinfo->wsi->http.cgi->sul_grace);
+	lws_free_set_NULL(cgiinfo->wsi->http.cgi);
 
 	lwsl_err("%s: failed\n", __func__);
 
 	return -1;
+}
+
+int
+lws_cgi(struct lws *wsi, const char * const *exec_array,
+	int script_uri_path_len, int timeout_secs,
+	const struct lws_protocol_vhost_options *mp_cgienv)
+{
+	struct lws_cgi_info cgiinfo;
+
+	memset (&cgiinfo, 0, sizeof (cgiinfo));
+	cgiinfo.wsi = wsi;
+	cgiinfo.exec_array = exec_array;
+	cgiinfo.script_uri_path_len = script_uri_path_len;
+	cgiinfo.timeout_secs = timeout_secs;
+	cgiinfo.mp_cgienv = mp_cgienv;
+	return lws_cgi_via_info (&cgiinfo);
 }
 
 /* we have to parse out these headers in the CGI output */

--- a/lib/roles/cgi/cgi-server.c
+++ b/lib/roles/cgi/cgi-server.c
@@ -411,6 +411,8 @@ lws_cgi_via_info(struct lws_cgi_info * cgiinfo)
 	info.plsp = &cgiinfo->wsi->http.cgi->lsp;
 	info.opaque = cgiinfo->wsi;
 	info.reap_cb = lws_cgi_reap_cb;
+	info.chroot_path = cgiinfo->chroot_path;
+	info.wd = cgiinfo->wd;
 
 	/*
 	 * Actually having made the env, as a cgi we don't need the ah

--- a/lib/roles/http/server/lejp-conf.c
+++ b/lib/roles/http/server/lejp-conf.c
@@ -99,6 +99,8 @@ static const char * const paths_vhosts[] = {
 	"vhosts[].mounts[].extra-mimetypes",
 	"vhosts[].mounts[].interpret.*",
 	"vhosts[].mounts[].interpret",
+	"vhosts[].mounts[].cgi-chroot",
+	"vhosts[].mounts[].cgi-chdir",
 	"vhosts[].mounts[]",
 	"vhosts[].ws-protocols[].*.*",
 	"vhosts[].ws-protocols[].*",
@@ -173,6 +175,8 @@ enum lejp_vhost_paths {
 	LEJPVP_MOUNT_EXTRA_MIMETYPES_base,
 	LEJPVP_MOUNT_INTERPRET,
 	LEJPVP_MOUNT_INTERPRET_base,
+	LEJPVP_CGI_CHROOT,
+	LEJPVP_CGI_CHDIR,
 
 	LEJPVP_MOUNTS,
 
@@ -802,6 +806,14 @@ lejp_vhosts_cb(struct lejp_ctx *ctx, char reason)
 		a->p += n;
 		a->pvo_int->value = a->p;
 		a->pvo_int->options = NULL;
+		break;
+
+	case LEJPVP_CGI_CHROOT:
+		a->m.cgi_chroot_path = a->p;
+		break;
+
+	case LEJPVP_CGI_CHDIR:
+		a->m.cgi_wd = a->p;
 		break;
 
 	case LEJPVP_ENABLE_CLIENT_SSL:

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -1974,6 +1974,8 @@ lws_http_action(struct lws *wsi)
 		cgiinfo.script_uri_path_len = hit->mountpoint_len;
 		cgiinfo.timeout_secs = (int)n;
 		cgiinfo.mp_cgienv = hit->cgienv;
+		cgiinfo.chroot_path = hit->cgi_chroot_path;
+		cgiinfo.wd = hit->cgi_wd;
 
 		n = (unsigned int)lws_cgi_via_info(&cgiinfo);
 		if (n) {

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -1959,6 +1959,7 @@ lws_http_action(struct lws *wsi)
 			NULL, /* replace with cgi path */
 			NULL
 		};
+		struct lws_cgi_info cgiinfo;
 
 		lwsl_debug("%s: cgi\n", __func__);
 		cmd[0] = hit->origin;
@@ -1967,8 +1968,14 @@ lws_http_action(struct lws *wsi)
 		if (hit->cgi_timeout)
 			n = (unsigned int)hit->cgi_timeout;
 
-		n = (unsigned int)lws_cgi(wsi, cmd, hit->mountpoint_len, (int)n,
-			    hit->cgienv);
+		memset (&cgiinfo, 0, sizeof (cgiinfo));
+		cgiinfo.wsi = wsi;
+		cgiinfo.exec_array = cmd;
+		cgiinfo.script_uri_path_len = hit->mountpoint_len;
+		cgiinfo.timeout_secs = (int)n;
+		cgiinfo.mp_cgienv = hit->cgienv;
+
+		n = (unsigned int)lws_cgi_via_info(&cgiinfo);
 		if (n) {
 			lwsl_err("%s: cgi failed\n", __func__);
 			return -1;

--- a/minimal-examples-lowlevel/client-server/minimal-ws-proxy/minimal-ws-proxy.c
+++ b/minimal-examples-lowlevel/client-server/minimal-ws-proxy/minimal-ws-proxy.c
@@ -51,6 +51,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-basicauth/minimal-http-server-basicauth.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-basicauth/minimal-http-server-basicauth.c
@@ -43,6 +43,8 @@ static const struct lws_http_mount mount_secret = {
 	/* .origin_protocol */		LWSMPRO_FILE, /* dynamic */
 	/* .mountpoint_len */		7,		/* char count */
 	/* .basic_auth_login_file */	"./ba-passwords",
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* default mount serves the URL space from ./mount-origin */
@@ -66,6 +68,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-cgi/minimal-http-server.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-cgi/minimal-http-server.c
@@ -39,6 +39,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_CGI,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-custom-headers/minimal-http-server-custom-headers.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-custom-headers/minimal-http-server-custom-headers.c
@@ -128,6 +128,8 @@ static const struct lws_http_mount mount_dyn = {
 	/* .origin_protocol */		LWSMPRO_CALLBACK, /* dynamic */
 	/* .mountpoint_len */		4,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* default mount serves the URL space from ./mount-origin */
@@ -151,6 +153,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-deaddrop/minimal-http-server-deaddrop.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-deaddrop/minimal-http-server-deaddrop.c
@@ -64,6 +64,8 @@ static const struct lws_http_mount mount_upload = {
 	/* .origin_protocol */		LWSMPRO_CALLBACK,
 	/* .mountpoint_len */		7,		/* char count */
 	/* .basic_auth_login_file */	"./ba-passwords",
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* wire up /get URLs to the upload directory (protected by basic auth) */
@@ -87,6 +89,8 @@ static const struct lws_http_mount mount_get = {
 	/* .origin_protocol */		LWSMPRO_FILE, /* dynamic */
 	/* .mountpoint_len */		4,		/* char count */
 	/* .basic_auth_login_file */	"./ba-passwords",
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* wire up / to serve from ./mount-origin (protected by basic auth) */
@@ -110,6 +114,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	"./ba-passwords",
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* pass config options to the deaddrop plugin using pvos */

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-dynamic/minimal-http-server-dynamic.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-dynamic/minimal-http-server-dynamic.c
@@ -242,6 +242,8 @@ static const struct lws_http_mount mount_dyn = {
 	/* .origin_protocol */		LWSMPRO_CALLBACK, /* dynamic */
 	/* .mountpoint_len */		4,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* default mount serves the URL space from ./mount-origin */
@@ -265,6 +267,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-custom/minimal-http-server.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-custom/minimal-http-server.c
@@ -294,6 +294,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /*

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-demos/minimal-http-server-eventlib-demos.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-demos/minimal-http-server-eventlib-demos.c
@@ -60,6 +60,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	LWSMPRO_FILE,	/* origin points to a callback */
 	14,			/* strlen("/ziptest"), ie length of the mountpoint */
 	NULL,
+	NULL,
+	NULL,
 }, mount_ziptest = {
 	(struct lws_http_mount *)&mount_ziptest_uncomm,			/* linked-list pointer to next*/
 	"/ziptest",		/* mountpoint in URL namespace on this vhost */
@@ -78,6 +80,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	0,
 	LWSMPRO_FILE,	/* origin points to a callback */
 	8,			/* strlen("/ziptest"), ie length of the mountpoint */
+	NULL,
+	NULL,
 	NULL,
 
 }, mount_post = {
@@ -99,6 +103,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	LWSMPRO_CALLBACK,	/* origin points to a callback */
 	9,			/* strlen("/formtest"), ie length of the mountpoint */
 	NULL,
+	NULL,
+	NULL,
 
 }, mount = {
 	/* .mount_next */		&mount_post,	/* linked-list "next" */
@@ -119,6 +125,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void signal_cb(void *handle, int signum)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-foreign/minimal-http-server-eventlib-foreign.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-foreign/minimal-http-server-eventlib-foreign.c
@@ -57,6 +57,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-smp/minimal-http-server-eventlib-smp.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib-smp/minimal-http-server-eventlib-smp.c
@@ -51,6 +51,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void *thread_service(void *threadid)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib/minimal-http-server-eventlib.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-eventlib/minimal-http-server-eventlib.c
@@ -39,6 +39,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void signal_cb(void *handle, int signum)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-form-get/minimal-http-server-form-get.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-form-get/minimal-http-server-form-get.c
@@ -98,6 +98,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-form-post-file/minimal-http-server-form-post-file.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-form-post-file/minimal-http-server-form-post-file.c
@@ -213,6 +213,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-form-post-lwsac/minimal-http-server-form-post.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-form-post-lwsac/minimal-http-server-form-post.c
@@ -165,6 +165,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-form-post/minimal-http-server-form-post.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-form-post/minimal-http-server-form-post.c
@@ -159,6 +159,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-fulltext-search/minimal-http-server.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-fulltext-search/minimal-http-server.c
@@ -59,6 +59,8 @@ static const struct lws_http_mount mount_fts = {
 	/* .origin_protocol */		LWSMPRO_CALLBACK, /* dynamic */
 	/* .mountpoint_len */		4,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static const struct lws_http_mount mount = {
@@ -80,6 +82,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-mimetypes/minimal-http-server-mimetypes.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-mimetypes/minimal-http-server-mimetypes.c
@@ -45,6 +45,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-multivhost/minimal-http-server.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-multivhost/minimal-http-server.c
@@ -38,6 +38,8 @@ static const struct lws_http_mount mount_localhost1 = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 }, mount_localhost2 = {
 	/* .mount_next */		NULL,		/* linked-list "next" */
 	/* .mountpoint */		"/",		/* mountpoint URL */
@@ -57,6 +59,8 @@ static const struct lws_http_mount mount_localhost1 = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 }, mount_localhost3 = {
 	/* .mount_next */		NULL,		/* linked-list "next" */
 	/* .mountpoint */		"/",		/* mountpoint URL */
@@ -76,6 +80,8 @@ static const struct lws_http_mount mount_localhost1 = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-proxy/minimal-http-server-proxy.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-proxy/minimal-http-server-proxy.c
@@ -33,6 +33,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_HTTPS,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-smp/minimal-http-server-smp.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-smp/minimal-http-server-smp.c
@@ -53,6 +53,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void *thread_service(void *threadid)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-sse-ring/minimal-http-server-sse-ring.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-sse-ring/minimal-http-server-sse-ring.c
@@ -332,6 +332,8 @@ static const struct lws_http_mount mount_sse = {
 	/* .origin_protocol */		LWSMPRO_CALLBACK, /* dynamic */
 	/* .mountpoint_len */		4,		  /* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* default mount serves the URL space from ./mount-origin */
@@ -355,6 +357,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-sse/minimal-http-server-sse.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-sse/minimal-http-server-sse.c
@@ -152,6 +152,8 @@ static const struct lws_http_mount mount_sse = {
 	/* .origin_protocol */		LWSMPRO_CALLBACK, /* dynamic */
 	/* .mountpoint_len */		4,		  /* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* default mount serves the URL space from ./mount-origin */
@@ -175,6 +177,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-tls-80/minimal-http-server-tls-80.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-tls-80/minimal-http-server-tls-80.c
@@ -44,6 +44,8 @@ static const struct lws_http_mount mount80 = {
 	/* .origin_protocol */		LWSMPRO_REDIR_HTTPS, /* https redir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static const struct lws_http_mount mount = {
@@ -65,6 +67,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-tls-mem/minimal-http-server-tls-mem.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-tls-mem/minimal-http-server-tls-mem.c
@@ -41,6 +41,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /* the cert and key as PEM */

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-tls/minimal-http-server-tls.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-tls/minimal-http-server-tls.c
@@ -76,6 +76,8 @@ static const struct lws_http_mount
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 #if !defined(WIN32)

--- a/minimal-examples-lowlevel/raw/minimal-raw-fallback-http-server/minimal-raw-fallback-http-server.c
+++ b/minimal-examples-lowlevel/raw/minimal-raw-fallback-http-server/minimal-raw-fallback-http-server.c
@@ -46,6 +46,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static int

--- a/minimal-examples-lowlevel/raw/minimal-raw-proxy-fallback/minimal-raw-proxy-fallback.c
+++ b/minimal-examples-lowlevel/raw/minimal-raw-proxy-fallback/minimal-raw-proxy-fallback.c
@@ -50,6 +50,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static int interrupted;

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-broker/minimal-ws-broker.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-broker/minimal-ws-broker.c
@@ -48,6 +48,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-raw-proxy/minimal-ws-raw-proxy.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-raw-proxy/minimal-ws-raw-proxy.c
@@ -394,6 +394,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-pmd-bulk/minimal-ws-server-pmd-bulk.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-pmd-bulk/minimal-ws-server-pmd-bulk.c
@@ -70,6 +70,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static const struct lws_extension extensions[] = {

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-pmd-corner/minimal-ws-server-pmd-corner.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-pmd-corner/minimal-ws-server-pmd-corner.c
@@ -47,6 +47,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static const struct lws_extension extensions[] = {

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-pmd/minimal-ws-server-pmd.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-pmd/minimal-ws-server-pmd.c
@@ -47,6 +47,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 static const struct lws_extension extensions[] = {

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-ring/minimal-ws-server-ring.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-ring/minimal-ws-server-ring.c
@@ -48,6 +48,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-threadpool/minimal-ws-server-threadpool.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-threadpool/minimal-ws-server-threadpool.c
@@ -59,6 +59,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /*

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-threads-foreign-libuv-smp/minimal-ws-server.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-threads-foreign-libuv-smp/minimal-ws-server.c
@@ -65,6 +65,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /*

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-threads-smp/minimal-ws-server.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-threads-smp/minimal-ws-server.c
@@ -63,6 +63,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /*

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-threads/minimal-ws-server.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-threads/minimal-ws-server.c
@@ -59,6 +59,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 /*

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server-timer/minimal-ws-server.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server-timer/minimal-ws-server.c
@@ -79,6 +79,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 void sigint_handler(int sig)

--- a/minimal-examples-lowlevel/ws-server/minimal-ws-server/minimal-ws-server.c
+++ b/minimal-examples-lowlevel/ws-server/minimal-ws-server/minimal-ws-server.c
@@ -54,6 +54,8 @@ static const struct lws_http_mount mount = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 #if defined(LWS_WITH_PLUGINS)

--- a/test-apps/test-server.c
+++ b/test-apps/test-server.c
@@ -280,6 +280,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	LWSMPRO_FILE,	/* origin points to a callback */
 	14,			/* strlen("/ziptest"), ie length of the mountpoint */
 	NULL,
+	NULL,
+	NULL,
 }, mount_ziptest = {
 	(struct lws_http_mount *)&mount_ziptest_uncomm,			/* linked-list pointer to next*/
 	"/ziptest",		/* mountpoint in URL namespace on this vhost */
@@ -298,6 +300,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	0,
 	LWSMPRO_FILE,	/* origin points to a callback */
 	8,			/* strlen("/ziptest"), ie length of the mountpoint */
+	NULL,
+	NULL,
 	NULL,
 }, mount_post = {
 	(struct lws_http_mount *)&mount_ziptest, /* linked-list pointer to next*/
@@ -318,6 +322,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	LWSMPRO_CALLBACK,	/* origin points to a callback */
 	9,			/* strlen("/formtest"), ie length of the mountpoint */
 	NULL,
+	NULL,
+	NULL,
 }, mount = {
 	/* .mount_next */		&mount_post,	/* linked-list "next" */
 	/* .mountpoint */		"/",		/* mountpoint URL */
@@ -337,6 +343,8 @@ static const struct lws_http_mount mount_ziptest_uncomm = {
 	/* .origin_protocol */		LWSMPRO_FILE,	/* files in a dir */
 	/* .mountpoint_len */		1,		/* char count */
 	/* .basic_auth_login_file */	NULL,
+	/* .cgi_chroot_path */		NULL,
+	/* .cgi_wd */			NULL,
 };
 
 


### PR DESCRIPTION
When an application initializes an `lws_http_mount` for a CGI, it can now provide fields `cgi_chroot_path` and `cgi_wd` to change the root path and the working directory of the spawned child. If these fields are left NULL, the old behaviour is kept.

The CGI API now provides an additional `..._via_info` API that supports providing these fields. The old API remains there.

All examples have been updated so that they still compile with the new additions to `lws_http_mount` structure.

`lejp-conf.c` now understands keys `vhosts[].mounts[].cgi-chroot` and `vhosts[].mounts[].cgi-chdir` when reading a JSON config to initialize a mount.