### PR TITLE
Fix cgi QUERY_STRING key only field truncated

### DIFF
--- a/lib/roles/cgi/cgi-server.c
+++ b/lib/roles/cgi/cgi-server.c
@@ -257,7 +257,7 @@ lws_cgi_via_info(struct lws_cgi_info * cgiinfo)
 			if (*t == '=')
 				*p++ = *t++;
 			i = urlencode(t, i - lws_ptr_diff(t, tok), p, lws_ptr_diff(end, p));
-			if (i > 0) {
+			if (i >= 0) {
 				p += i;
 				*p++ = '&';
 			}


### PR DESCRIPTION
A request like 'http://host?abc' set the QUERY_STRING variable for CGIs to "ab" instead of "abc". This was because the code didn't account for key-only fields, only for key-value ones.