### PR TITLE
client-http: authorize LWS_...COMPLETED_CLIENT_HTTP to be called if status code is 204

### DIFF
--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -1386,14 +1386,16 @@ lws_client_interpret_server_handshake(struct lws *wsi)
 		 * completed at the end of the header processing...
 		 * We also completed it if the request method is HEAD which as
 		 * no content leftover.
+		 * Or if the response status code is 204 : No Content
 		 */
 		simp = lws_hdr_simple_ptr(wsi, _WSI_TOKEN_CLIENT_METHOD);
 		if (!wsi->mux_substream &&
 		    !wsi->client_mux_substream &&
-		    lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH) &&
-		    (!wsi->http.rx_content_length ||
-		      (simp && !strcmp(simp,"HEAD"))))
-		        return !!lws_http_transaction_completed_client(wsi);
+			(204 == lws_http_client_http_response(wsi) ||
+			(lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_CONTENT_LENGTH) &&
+				(!wsi->http.rx_content_length ||
+				(simp && !strcmp(simp,"HEAD"))))))
+				return !!lws_http_transaction_completed_client(wsi);
 
 		/*
 		 * We can also get a case where it's http/1 and there's no


### PR DESCRIPTION
Hello Andy,

I met an issue when trying to pipeline a new HTTP request after getting an HTTP response 204 (No content) which has no content-length header.
The LWS_CALLBACK_COMPLETED_CLIENT_HTTP is never called and then following HTTP request with same wsi is not calling  LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER.

This patch seem to fix the issue as i experiment it.


Thanks
Simon
