### PR TITLE
mbedtls-server: verify_option and auth_mode options should be valid

### DIFF
--- a/lib/tls/mbedtls/mbedtls-server.c
+++ b/lib/tls/mbedtls/mbedtls-server.c
@@ -39,7 +39,7 @@ lws_tls_server_client_cert_verify_config(struct lws_vhost *vh)
 	}
 
 	if (!lws_check_opt(vh->options, LWS_SERVER_OPTION_PEER_CERT_NOT_REQUIRED))
-		verify_options = SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+		verify_options |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 
 	lwsl_notice("%s: vh %s requires client cert %d\n", __func__, vh->name,
 		    verify_options);

--- a/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
+++ b/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
@@ -255,9 +255,9 @@ static int ssl_pm_reload_crt(SSL *ssl)
     struct pkey_pm *pkey_pm = (struct pkey_pm *)ssl->cert->pkey->pkey_pm;
     struct x509_pm *crt_pm = (struct x509_pm *)ssl->cert->x509->x509_pm;
 
-    if (ssl->verify_mode == SSL_VERIFY_PEER)
+    if ((ssl->verify_mode & SSL_VERIFY_PEER) > 0)
         mode = MBEDTLS_SSL_VERIFY_REQUIRED;
-    else if (ssl->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+    else if ((ssl->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) > 0)
         mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
     else if (ssl->verify_mode == SSL_VERIFY_CLIENT_ONCE)
         mode = MBEDTLS_SSL_VERIFY_UNSET;
@@ -994,9 +994,9 @@ void SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx)
 
 #if defined(LWS_HAVE_mbedtls_ssl_set_hs_authmode)
 
-	if (ctx->verify_mode == SSL_VERIFY_PEER)
+	if ((ctx->verify_mode & SSL_VERIFY_PEER) > 0)
 		mode = MBEDTLS_SSL_VERIFY_REQUIRED;
-	else if (ctx->verify_mode == SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+	else if ((ctx->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) > 0)
 		mode = MBEDTLS_SSL_VERIFY_REQUIRED;
 	else if (ctx->verify_mode == SSL_VERIFY_CLIENT_ONCE)
 		mode = MBEDTLS_SSL_VERIFY_UNSET;


### PR DESCRIPTION
this patch is basically #3257 for 4.3-stable which fixes the client certificate issue.