### PR TITLE
Add preprocessor conditional to disable HTTP secure streams data transfer tests

### DIFF
--- a/.sai.json
+++ b/.sai.json
@@ -41,7 +41,7 @@
 			"cmake":	"-DLWS_WITH_SYS_FAULT_INJECTION=1 -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_WITH_CBOR=1"
 		},
 		"default-examples-awslc": {
-			"cmake":	"-DLWS_WITH_AWSLC=1 -DLWS_OPENSSL_INCLUDE_DIRS=\"/usr/aws-lc/include\" -DLWS_OPENSSL_LIBRARIES=\"/usr/aws-lc/lib64/libssl.so;/usr/aws-lc/lib64/libcrypto.so\" -DLWS_WITH_MINIMAL_EXAMPLES=1",
+			"cmake":	"-DLWS_WITH_AWSLC=1 -DLWS_WITH_SS_TESTS_HTTP_ONLY=0 -DLWS_OPENSSL_INCLUDE_DIRS=\"/usr/aws-lc/include\" -DLWS_OPENSSL_LIBRARIES=\"/usr/aws-lc/lib64/libssl.so;/usr/aws-lc/lib64/libcrypto.so\" -DLWS_WITH_MINIMAL_EXAMPLES=1",
 			"platforms":	"none, rocky9/aarch64-a72a55-rk3588/gcc"
 		},
 		"default-examples-boringssl": {

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt
@@ -18,7 +18,13 @@ require_lws_config(USE_WOLFSSL 0 requirements)
 require_lws_config(LWS_WITH_TLS 1 requirements)
 
 if (requirements)
+    option(LWS_WITH_SS_TESTS_HTTP_ONLY "Enable HTTP-only tests that require a local go-httpbin in secure streams test suite" ON)
+
 	add_executable(${SAMP} minimal-secure-streams-testsfail.c)
+
+	if(LWS_WITH_SS_TESTS_HTTP_ONLY)
+    	target_compile_definitions(${SAMP} PRIVATE LWS_WITH_SS_TESTS_HTTP_ONLY)
+	endif()
 
 	find_program(VALGRIND "valgrind")
 

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/minimal-secure-streams-testsfail.c
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/minimal-secure-streams-testsfail.c
@@ -24,6 +24,12 @@ static lws_state_notify_link_t nl;
 struct lws_context *context;
 size_t amount = 12345;
 
+#if defined(LWS_WITH_SS_TESTS_HTTP_ONLY)
+#define TESTS_COUNT 18  /* Original number of tests */
+#else
+#define TESTS_COUNT 16  /* Number of tests with HTTP ones removed */
+#endif
+
 static void
 tests_start_next(lws_sorted_usec_list_t *sul);
 
@@ -187,7 +193,9 @@ static const char * const default_ss_policy =
 			"\"http_no_content_length\": true,"
 			"\"retry\": \"default\","
 			"\"tls_trust_store\": \"api_amazon_com\""
-		"}},{"
+		"}},"
+#if defined(LWS_WITH_SS_TESTS_HTTP_ONLY)
+		"{"
 
 		/*
 		 * Just get a 200 from httpbin
@@ -204,7 +212,9 @@ static const char * const default_ss_policy =
 			"\"http_url\": \"/status/200\","
 			"\"timeout_ms\": 10000,"
 			"\"retry\": \"default\""
-		"}},{"
+		"}},"
+#endif
+		"{"
 		    "\"t_h1_tls\": {"
 			"\"endpoint\": \"libwebsockets.org\","
 			"\"port\": 443,"
@@ -310,7 +320,9 @@ static const char * const default_ss_policy =
 			"\"timeout_ms\": 10000,"
 			"\"retry\": \"default\","
 			"\"tls_trust_store\": \"arca1\""
-		"}},{"
+		"}},"
+#if defined(LWS_WITH_SS_TESTS_HTTP_ONLY)
+		"{"
 
 		/*
 		 * bulk payload transfer from httpbin.org
@@ -330,7 +342,9 @@ static const char * const default_ss_policy =
 				"}],"
 			"\"timeout_ms\": 10000,"
 			"\"retry\": \"default\""
-		"}},{"
+		"}},"
+#endif
+		"{"
 		    "\"bulk_h1_tls\": {"
 			"\"endpoint\": \"libwebsockets.org\","
 			"\"port\": 443,"
@@ -438,7 +452,7 @@ struct tests_seq {
 	/*
 	 * We just get a 200 from httpbin.org as a sanity check first
 	 */
-
+#if defined(LWS_WITH_SS_TESTS_HTTP_ONLY)
 	{
 		"h1:80 just get 200",
 		"t_h1", 15 * LWS_US_PER_SEC, LWSSSCS_QOS_ACK_REMOTE,
@@ -446,6 +460,7 @@ struct tests_seq {
 					 (1 << LWSSSCS_ALL_RETRIES_FAILED),
 		0
 	},
+#endif
 	{
 		"h1:443 just get 200",
 		"t_h1_tls", 15 * LWS_US_PER_SEC, LWSSSCS_QOS_ACK_REMOTE,
@@ -544,7 +559,7 @@ struct tests_seq {
 	/*
 	 * Let's request some bulk data from httpbin.org
 	 */
-
+#if defined(LWS_WITH_SS_TESTS_HTTP_ONLY)
 	{
 		"h1:80 read bulk",
 		"bulk_h1", 15 * LWS_US_PER_SEC, LWSSSCS_QOS_ACK_REMOTE,
@@ -552,6 +567,7 @@ struct tests_seq {
 		(1 << LWSSSCS_ALL_RETRIES_FAILED),
 		12345
 	},
+#endif
 	{
 		"h1:443 read bulk",
 		"bulk_h1_tls", 15 * LWS_US_PER_SEC, LWSSSCS_QOS_ACK_REMOTE,
@@ -724,7 +740,7 @@ tests_start_next(lws_sorted_usec_list_t *sul)
 
 	doing_a_retry = 0;
 
-	if ((unsigned int)tests >= LWS_ARRAY_SIZE(tests_seq)) {
+	if ((unsigned int)tests >= TESTS_COUNT) {
 		lwsl_notice("Completed all tests\n");
 		interrupted = 1;
 		return;
@@ -803,6 +819,16 @@ sigint_handler(int sig)
 	interrupted = 1;
 }
 
+static void 
+set_bulk_test_payloads(size_t payload_size) 
+{
+    for (size_t i = 0; i < TESTS_COUNT; i++) {
+        if (strstr(tests_seq[i].name, "read bulk")) {
+            tests_seq[i].eom_pass = payload_size;
+        }
+    }
+}
+
 int
 main(int argc, const char **argv)
 {
@@ -818,9 +844,8 @@ main(int argc, const char **argv)
 		amount = (size_t)atoi(pp);
 
 	/* set the expected payload for the bulk-related tests to amount */
+	set_bulk_test_payloads(amount);
 
-	tests_seq[12].eom_pass = tests_seq[13].eom_pass =
-					tests_seq[14].eom_pass = amount;
 #if !defined(LWS_SS_USE_SSPC)
 	// puts(default_ss_policy);
 #endif


### PR DESCRIPTION
This PR adds LWS_WITH_SS_TESTS_HTTP_ONLY as a cmake option to disable http secure streams data transfer tests. All tests are turned on by default and can be turned off by setting -DLWS_WITH_SS_TESTS_HTTP_ONLY=0 during compilation. 

This PR also changes some processing around the test case array to accommodate this conditional. 

From #3424 