### PR TITLE
ops-ws:Fixed the issue where pending has data and buflist has data, which would cause an infinite loop and disconnect the connection.

### DIFF
--- a/lib/roles/ws/ops-ws.c
+++ b/lib/roles/ws/ops-ws.c
@@ -1228,6 +1228,9 @@ drain:
 
 	pending = (unsigned int)lws_ssl_pending(wsi);
 
+	if (!pending && lws_buflist_next_segment_len(&wsi->buflist, NULL))
+		return LWS_HPI_RET_HANDLED;
+
 #if defined(LWS_WITH_CLIENT)
 	if (!pending && (wsi->flags & LCCSCF_PRIORITIZE_READS) &&
 	    lws_buflist_total_len(&wsi->buflist))


### PR DESCRIPTION
Fixed the issue where pending has data and buflist has data, which would cause an infinite loop and disconnect the connection.