### PR TITLE
h2: Fix build when H2 and TLS are disabled

### DIFF
--- a/lib/roles/http/client/client-http.c
+++ b/lib/roles/http/client/client-http.c
@@ -264,7 +264,10 @@ start_ws_handshake:
 
 	case LRS_H1C_ISSUE_HANDSHAKE2:
 
+#if defined(LWS_ROLE_H2) || defined(LWS_WITH_TLS)
 hs2:
+#endif
+
 		p = lws_generate_client_handshake(wsi, p,
 						  lws_ptr_diff_size_t(end, p));
 		if (p == NULL) {


### PR DESCRIPTION
Fixes build error with `-DLWS_WITH_HTTP2:BOOL=OFF -DLWS_WITH_SSL:BOOL=OFF`:

```
...
[ 42%] Building C object lib/CMakeFiles/websockets.dir/roles/http/client/client-http.c.o
<snip>/libwebsockets/lib/roles/http/client/client-http.c:267:1: error: unused label 'hs2' [-Werror,-Wunused-label]
  267 | hs2:
      | ^~~~
1 error generated.
...
```