### PR TITLE
[cleanup] Simplify conditional route pointer declarations in lws_sort_dns()

### DIFF
--- a/lib/core-net/client/sort-dns.c
+++ b/lib/core-net/client/sort-dns.c
@@ -605,13 +605,9 @@ lws_sort_dns(struct lws *wsi, const struct addrinfo *result)
 	 */
 
 	while (ai) {
-#if defined(LWS_WITH_NETLINK) || \
-	(defined(LWS_WITH_NETLINK) && defined(LWS_WITH_IPV6))
-		lws_route_t
 #if defined(LWS_WITH_NETLINK)
-			*estr = NULL
-#endif
-#if defined(LWS_WITH_NETLINK) && defined(LWS_WITH_IPV6)
+		lws_route_t *estr = NULL
+#if defined(LWS_WITH_IPV6)
 			, *bestsrc = NULL
 #endif
 		;


### PR DESCRIPTION
### Description
Simplified the preprocessor logic in `lws_sort_dns()`.

The previous logic:
`defined(LWS_WITH_NETLINK) || (defined(LWS_WITH_NETLINK) && defined(LWS_WITH_IPV6))`
is logically equivalent to just:
`defined(LWS_WITH_NETLINK)`

This change improves readability by removing redundant checks and flattening the conditional declarations of `estr` and `bestsrc`.

### Impact
- No functional change.
- Reduces preprocessor noise.
- Verified with `LWS_WITH_NETLINK` enabled/disabled.