### PR TITLE
fix initialization discards 'const' qualifier from pointer target type

### DIFF
--- a/lib/core-net/client/client.c
+++ b/lib/core-net/client/client.c
@@ -31,7 +31,7 @@ lws_set_proxy(struct lws_vhost *vhost, const char *proxy)
 {
 	char authstring[96];
 	int brackets = 0;
-	char *p;
+	const char *p;
 
 	if (!proxy)
 		return -1;
@@ -103,7 +103,6 @@ lws_set_proxy(struct lws_vhost *vhost, const char *proxy)
 		return -1;
 	}
 	if (p) {
-		*p = '\0';
 		vhost->http.http_proxy_port = (unsigned int)atoi(p + 1);
 	}
 

--- a/lib/plat/unix/unix-caps.c
+++ b/lib/plat/unix/unix-caps.c
@@ -51,7 +51,8 @@ _lws_plat_apply_caps(unsigned int mode, const cap_value_t *cv, int count)
 int
 lws_plat_user_colon_group_to_ids(const char *u_colon_g, uid_t *puid, gid_t *pgid)
 {
-	char *colon = strchr(u_colon_g, ':'), u[33];
+	const char *colon = strchr(u_colon_g, ':');
+	char u[33];
 	struct group *g;
 	struct passwd *p;
 	size_t ulen;

--- a/lib/roles/http/cookie.c
+++ b/lib/roles/http/cookie.c
@@ -286,7 +286,8 @@ lws_cookie_write_nsc(struct lws *wsi, struct lws_cookie *c)
 	const char *ads, *path;
 	struct lws_cache_ttl_lru *l1;
 	struct client_info_stash *stash;
-	char *cookie_string = NULL, *dl;
+	char *cookie_string = NULL;
+	const char *dl;
 	 /* 6 tabs + 20 for max time_t + 2 * TRUE/FALSE + null */
 	size_t size = 6 + 20 + 10 + 1;
 	time_t expires = 0;

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -2411,7 +2411,8 @@ raw_transition:
 		if (wsi->a.context->reject_service_keywords) {
 			const struct lws_protocol_vhost_options *rej =
 					wsi->a.context->reject_service_keywords;
-			char ua[384], *msg = NULL;
+			char ua[384];
+			const char *msg = NULL;
 
 			if (lws_hdr_copy(wsi, ua, sizeof(ua) - 1,
 					 WSI_TOKEN_HTTP_USER_AGENT) > 0) {


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html