### PR TITLE
Draft: cmake: skip ESP32/FreeRTOS plat path on IDF Linux target

### DIFF
--- a/CMakeLists-implied-options.txt
+++ b/CMakeLists-implied-options.txt
@@ -30,7 +30,15 @@ endif()
 # Workaround for ESP-IDF
 # Detect ESP_PLATFORM environment flag, if exist, set LWS_WITH_ESP32.
 # Otherwise the user may not be able to run configuration ESP-IDF in the first time.
-if (ESP_PLATFORM)
+#
+# espressif-port patch: skip the ESP32 / FreeRTOS path when building
+# for the IDF Linux target. ESP_PLATFORM is set on every IDF build
+# (including --preview set-target linux), but the Linux target is a
+# POSIX/glibc environment and the FreeRTOS plat shims pull in IDF's
+# newlib platform_include — which uses `__assert_func` (newlib-only)
+# and `<sys/features.h>` (newlib path), neither of which exists on
+# glibc. Fall through to the upstream `plat/unix` path instead.
+if (ESP_PLATFORM AND NOT (DEFINED IDF_TARGET AND IDF_TARGET STREQUAL "linux"))
 	message(STATUS "ESP-IDF enabled")
 	set(LWS_WITH_ESP32 ON)
 	set(LWS_WITH_ZLIB OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 set(LWS_ROLE_RAW 1)
 set(LWS_WITH_POLL 1)
 
-if (ESP_PLATFORM)
+if (ESP_PLATFORM AND NOT (DEFINED IDF_TARGET AND IDF_TARGET STREQUAL "linux"))
 	set(LWS_ESP_PLATFORM 1)
 	#set(CMAKE_TOOLCHAIN_FILE contrib/cross-esp32.cmake)
 	set(LWIP_PROVIDE_ERRNO 1)
@@ -85,7 +85,7 @@ if (PICO_SDK_PATH)
 	pico_sdk_init()
 endif()
 
-if (ESP_PLATFORM)
+if (ESP_PLATFORM AND NOT (DEFINED IDF_TARGET AND IDF_TARGET STREQUAL "linux"))
        include_directories(
 		$ENV{IDF_PATH}/components/esp_hw_support/include/soc/
 		$ENV{IDF_PATH}/components/freertos/include/


### PR DESCRIPTION
> **Status:** Draft. Our local libwebsockets submodule is not at upstream HEAD, so this branch may need rebasing before review. Opening as draft so the discussion can start.

## Problem

`idf.py --preview set-target linux build` fails when libwebsockets is part of an ESP-IDF project. \`CMakeLists-implied-options.txt\` unconditionally sets \`LWS_WITH_ESP32=ON\` whenever \`ESP_PLATFORM\` is defined, which derives \`LWS_PLAT_FREERTOS=1\`, which selects \`plat/freertos\` and pulls in IDF's newlib platform_include into every freertos plat translation unit.

The IDF Linux target uses **host glibc**, not newlib — \`__assert_func\` becomes \`__assert_fail\` (different signature), and \`<sys/features.h>\` becomes \`<features.h>\`. The build fails with:

\`\`\`
error: implicit declaration of function '__assert_func'
error: '__ASSERT_FUNC' undeclared
fatal error: sys/features.h: No such file or directory
\`\`\`

CI repro on Ubuntu inside \`espressif/idf:release-v5.5\`: every \`lib/plat/freertos/*.c\` translation unit fails identically.

## Fix

Gate the ESP32 / freertos auto-enable on \`IDF_TARGET != linux\`. On the Linux IDF target, libwebsockets falls through to its existing \`plat/unix\` selection (POSIX/glibc) and compiles cleanly.

Three sites updated:
1. \`CMakeLists-implied-options.txt:33\` — \`if (ESP_PLATFORM)\` setting \`LWS_WITH_ESP32 ON\`
2. \`CMakeLists.txt:71\` — \`if (ESP_PLATFORM)\` setting \`LWS_ESP_PLATFORM=1\` and \`LWIP_PROVIDE_ERRNO=1\`
3. \`CMakeLists.txt:88\` — \`if (ESP_PLATFORM)\` adding ESP32-specific \`include_directories(...)\`

## Validation

End-to-end build of an ESP-IDF \`webrtc_classic\`-style project with \`idf.py --preview set-target linux build\`: libwebsockets compiles cleanly through unix plat. (Tested in the [espressif-port repo's Linux test harness](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-espressif-port/tree/feat/docker-integration-test/examples/linux_test).)

## Suggested CI follow-up

If this lands, would you consider adding an IDF Linux-target build matrix entry to libwebsockets' CI? Roughly:

\`\`\`yaml
- name: idf-linux
  runs-on: ubuntu-latest
  container: espressif/idf:release-v5.5
  steps:
    - uses: actions/checkout@v4
    - run: |
        . /opt/esp/idf/export.sh
        # minimal LWS-using IDF project here
        idf.py --preview set-target linux build
\`\`\`

That keeps the regression from coming back. Happy to put together a minimal test project as part of this PR if useful.