### PR TITLE
pollfd: narrow vpt declaration guard to exclude FreeRTOS / Windows (backport from main)

### DIFF
--- a/lib/core-net/pollfd.c
+++ b/lib/core-net/pollfd.c
@@ -27,7 +27,8 @@
 int
 _lws_change_pollfd(struct lws *wsi, int _and, int _or, struct lws_pollargs *pa)
 {
-#if !defined(LWS_WITH_EVENT_LIBS)
+#if !defined(LWS_WITH_EVENT_LIBS) && !defined(LWS_PLAT_FREERTOS) && \
+    !defined(WIN32) && !defined(_WIN32)
 	volatile struct lws_context_per_thread *vpt;
 #endif
 	struct lws_context_per_thread *pt;


### PR DESCRIPTION
On v4.3-stable, the `vpt` declaration in `_lws_change_pollfd` is guarded
only by `!LWS_WITH_EVENT_LIBS`. On FreeRTOS / Windows it ends up unused,
tripping `-Werror=unused-variable` (esp-protocols PR #1061 hits this).
`main` already narrows the guard — backport so v4.3.x builds cleanly
under strict warnings.