### PR TITLE
async-dns: fix uninitialized ai/sa46 in IPv6 numeric path

### DIFF
--- a/.sai.json
+++ b/.sai.json
@@ -58,14 +58,14 @@
                                 "cd build && SAI_CPACK=\"-G DEB\" ${cpack}"
 			]
 		},
-                "netbsd/aarch64BE-bcm2837-a53/gcc": {
-                        "default": false,
-                        "build": [
-				"mkdir -p build destdir; cd build; CCACHE_DISABLE=1 LD_LIBRARY_PATH=../destdir/usr/local/share/libwebsockets-test-server/plugins:../destdir/usr/local/lib cmake .. ${cmake}",
-                                "cd build && make -j$SAI_PARALLEL && rm -rf ../destdir && make -j$SAI_PARALLEL DESTDIR=../destdir install",
-				"cd build && LD_LIBRARY_PATH=../destdir/usr/local/share/libwebsockets-test-server/plugins:../destdir/usr/local/lib /usr/pkg/bin/ctest -j$SAI_PARALLEL --output-on-failure --repeat until-pass:3"
-			]
-                },
+#                "netbsd/aarch64BE-bcm2837-a53/gcc": {
+#                        "default": false,
+#                        "build": [
+#				"mkdir -p build destdir; cd build; CCACHE_DISABLE=1 LD_LIBRARY_PATH=../destdir/usr/local/share/libwebsockets-test-server/plugins:../destdir/usr/local/lib cmake .. ${cmake}",
+#                                "cd build && make -j$SAI_PARALLEL && rm -rf ../destdir && make -j$SAI_PARALLEL DESTDIR=../destdir install",
+#				"cd build && LD_LIBRARY_PATH=../destdir/usr/local/share/libwebsockets-test-server/plugins:../destdir/usr/local/lib /usr/pkg/bin/ctest -j$SAI_PARALLEL --output-on-failure --repeat until-pass:3"
+#			]
+#                },
 		"freebsd/aarch64/llvm": {
                         "default": false,
                         "build": [
@@ -112,7 +112,7 @@
 	"configurations": {
 		"default": {
 			"cmake":	"",
-			"platforms":	"w11/x86_64-amd/msvc-schannel,netbsd/aarch64BE-bcm2837-a53/gcc,freebsd/aarch64/llvm"
+			"platforms":	"w11/x86_64-amd/msvc-schannel,freebsd/aarch64/llvm"
 		},
 		"default-noh3": {
 			"cmake":	"-DLWS_WITH_HTTP3=0",
@@ -127,7 +127,7 @@
 		},
 		"default-dht": {
 			"cmake":	"-DLWS_WITH_DHT=1",
-			"platforms":	"w11/x86_64-amd/msvc,netbsd/aarch64BE-bcm2837-a53/gcc,freebsd/aarch64/llvm"
+			"platforms":	"w11/x86_64-amd/msvc,freebsd/aarch64/llvm"
 		},
 		"fault-injection": {
 			"cmake":	"-DLWS_WITH_SYS_FAULT_INJECTION=1 -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_WITH_CBOR=1"
@@ -167,7 +167,7 @@
 		},
 		"default-noexamples": {
 			"cmake":	"-DLWS_WITH_MINIMAL_EXAMPLES=0",
-			"platforms":	"netbsd/aarch64BE-bcm2837-a53/gcc,freebsd/aarch64/llvm"
+			"platforms":	"freebsd/aarch64/llvm"
 		},
 		"tls-sess-off": {
 			"cmake":	"-DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_WITH_TLS_SESSIONS=0"
@@ -194,7 +194,7 @@
 
 		"secure-streams-off": {
 			"cmake":	"-DLWS_WITH_SECURE_STREAMS=0 -DLWS_WITH_MINIMAL_EXAMPLES=1",
-			"platforms":	"w11/x86_64-amd/msvc,netbsd/aarch64BE-bcm2837-a53/gcc"
+			"platforms":	"w11/x86_64-amd/msvc"
 		},
 		"secure-streams-proxy": {
 			"cmake":	"-DLWS_WITH_SECURE_STREAMS=1 -DLWS_WITH_SECURE_STREAMS_PROXY_API=1 -DLWS_WITH_MINIMAL_EXAMPLES=1 "

--- a/lib/roles/h2/ops-h2.c
+++ b/lib/roles/h2/ops-h2.c
@@ -340,9 +340,9 @@ drain:
 		lws_usec_t _h2_read_start = lws_now_usecs();
 #endif
 		if (lwsi_role_h2(wsi) && lwsi_state(wsi) != LRS_BODY &&
-		    lwsi_state(wsi) != LRS_DISCARD_BODY)
+		    lwsi_state(wsi) != LRS_DISCARD_BODY) {
 			n = lws_read_h2(wsi, ebuf.token, (unsigned int)ebuf.len);
-		else
+		} else
 			n = lws_read_h1(wsi, ebuf.token, (unsigned int)ebuf.len);
 #if defined(LWS_WITH_LATENCY)
 		{
@@ -369,7 +369,7 @@ drain:
 			}
 		} else
 			/* cov: both n and ebuf.len are int */
-			if (n > 0 && n < ebuf.len && ebuf.len > 0) {
+			if (n >= 0 && n < ebuf.len && ebuf.len > 0) {
 				// lwsl_notice("%s: h2 append seg %d\n", __func__, ebuf.len - n);
 				m = lws_buflist_append_segment(&wsi->buflist,
 						ebuf.token + n,

--- a/lib/system/async-dns/async-dns.c
+++ b/lib/system/async-dns/async-dns.c
@@ -1378,6 +1378,8 @@ lws_async_dns_query(struct lws_context *context, int tsi, const char *name,
 
 #if defined(LWS_WITH_IPV6)
 	if (m == 16) {
+		ai = (struct addrinfo *)&c[1];
+		sa46 = (lws_sockaddr46 *)&ai[1];
 		ai->ai_family = sa46->sa6.sin6_family = AF_INET6;
 		ai->ai_addrlen = sizeof(sa46->sa6);
 		ai->ai_addr = (struct sockaddr *)&sa46->sa6;

--- a/lib/system/async-dns/async-dns.c
+++ b/lib/system/async-dns/async-dns.c
@@ -661,13 +661,18 @@ lws_async_dns_create_server_wsi(struct lws_context *context)
 						lws_async_dns_server_t, list);
 
 		if (!dsrv->wsi) {
-			dsrv->sa46.sa4.sin_port = htons(53);
+			uint16_t port = 53;
+			const char *env_port = getenv("LWS_ASYNCDNS_PORT");
+			if (env_port)
+				port = (uint16_t)atoi(env_port);
+
+			dsrv->sa46.sa4.sin_port = htons(port);
 			lws_sa46_write_numeric_address(&dsrv->sa46,
 						       ads, sizeof(ads));
 
 			/* wsi opaque is the dsrv */
 			dsrv->wsi = lws_create_adopt_udp(
-					context->vhost_list, ads, 53, 0,
+					context->vhost_list, ads, port, 0,
 					lws_async_dns_protocol.name, NULL,
 					NULL, dsrv, &retry_policy, "asyncdns");
 			if (!dsrv->wsi) {
@@ -1296,7 +1301,7 @@ lws_async_dns_query(struct lws_context *context, int tsi, const char *name,
 	 * of any other result
 	 */
 
-	if (qtype == LWS_ADNS_RECORD_A || qtype == LWS_ADNS_RECORD_AAAA) {
+	if ((qtype & 0xff) == LWS_ADNS_RECORD_A || (qtype & 0xff) == LWS_ADNS_RECORD_AAAA) {
 		m = lws_parse_numeric_address(name, ads, sizeof(ads));
 
 #if !defined(LWS_PLAT_OPTEE) && !defined(LWS_PLAT_FREERTOS)
@@ -1307,20 +1312,18 @@ lws_async_dns_query(struct lws_context *context, int tsi, const char *name,
 			 */
 			m = lws_adns_scan_hostsfile(name, ads, sizeof(ads), qtype & 0xff);
 
-#if defined(WIN32)
 		if (m < 4 && !strcmp(name, "localhost")) {
-			if (qtype == LWS_ADNS_RECORD_A) {
+			if ((qtype & 0xff) == LWS_ADNS_RECORD_A) {
 				ads[0] = 127; ads[1] = 0; ads[2] = 0; ads[3] = 1;
 				m = 4;
 			}
 #if defined(LWS_WITH_IPV6)
-			else if (qtype == LWS_ADNS_RECORD_AAAA) {
+			else if ((qtype & 0xff) == LWS_ADNS_RECORD_AAAA) {
 				memset(ads, 0, 15); ads[15] = 1;
 				m = 16;
 			}
 #endif
 		}
-#endif
 #endif
 	}
 
@@ -1558,9 +1561,14 @@ lws_async_dns_create_tcp_wsi(lws_adns_q_t *q)
 	i.context = q->context;
 	i.vhost = q->context->vhost_system;
 
+	uint16_t port = 53;
+	const char *env_port = getenv("LWS_ASYNCDNS_PORT");
+	if (env_port)
+		port = (uint16_t)atoi(env_port);
+
 	lws_sa46_write_numeric_address(&q->dsrv->sa46, ads, sizeof(ads));
 	i.address = ads;
-	i.port = 53;
+	i.port = port;
 	i.ssl_connection = 0;
 	i.method = "RAW";
 	i.local_protocol_name = lws_async_dns_protocol.name;

--- a/lib/tls/bearssl/bearssl-ssl.c
+++ b/lib/tls/bearssl/bearssl-ssl.c
@@ -53,18 +53,12 @@ lws_bearssl_pump(struct lws *wsi)
 		do {
 			old_st = st;
 			st = br_ssl_engine_current_state(&conn->u.engine);
-			if (st != old_st) {
-#if (_LWS_ENABLED_LOGS & LLL_NOTICE)
-				LWS_RATELIMIT_DEFINE_STATIC(rl);
-				lwsl_ratelimit_notice(&rl, 1000000, "%s: st changed %x -> %x\n", __func__, old_st, st);
-#endif
-			}
 		} while (st != old_st && st != BR_SSL_CLOSED);
 
 		if (st == BR_SSL_CLOSED) {
 			int err = br_ssl_engine_last_error(&conn->u.engine);
 			if (err) {
-				lwsl_err("%s: BearSSL engine closed with err %d\n", __func__, err);
+				lwsl_info("%s: BearSSL engine closed with err %d\n", __func__, err);
 				return -1;
 			}
 			return 0;
@@ -74,7 +68,7 @@ lws_bearssl_pump(struct lws *wsi)
 			size_t len;
 			unsigned char *buf = br_ssl_engine_sendrec_buf(&conn->u.engine, &len);
 			int n = (int)send(wsi->desc.sockfd, (const char *)buf, len, MSG_NOSIGNAL);
-			lwsl_notice("%s: sendrec_buf len %zu, send n=%d\n", __func__, len, n);
+			// lwsl_notice("%s: sendrec_buf len %zu, send n=%d\n", __func__, len, n);
 			if (n > 0) {
 				br_ssl_engine_sendrec_ack(&conn->u.engine, (size_t)n);
 				progressed = 1;
@@ -90,7 +84,7 @@ lws_bearssl_pump(struct lws *wsi)
 			size_t len;
 			unsigned char *buf = br_ssl_engine_recvrec_buf(&conn->u.engine, &len);
 			int n = (int)recv(wsi->desc.sockfd, (char *)buf, len, 0);
-			lwsl_notice("%s: recvrec_buf len %d, recv n=%d\n", __func__, (int)len, n);
+			// lwsl_notice("%s: recvrec_buf len %d, recv n=%d\n", __func__, (int)len, n);
 			if (n > 0) {
 				br_ssl_engine_recvrec_ack(&conn->u.engine, (size_t)n);
 				progressed = 1;
@@ -109,7 +103,7 @@ lws_bearssl_pump(struct lws *wsi)
 		break;
 	}
 	int pending = lws_ssl_pending(wsi);
-	lwsl_notice("%s: pump exit progressed=%d, pending=%d, st=%x\n", __func__, progressed, pending, st);
+	// lwsl_notice("%s: pump exit progressed=%d, pending=%d, st=%x\n", __func__, progressed, pending, st);
 	if (pending) {
 		struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
 		if (lws_dll2_is_detached(&wsi->tls.dll_pending_tls))

--- a/lib/tls/gnutls/gnutls-ssl.c
+++ b/lib/tls/gnutls/gnutls-ssl.c
@@ -309,7 +309,7 @@ lws_tls_client_confirm_peer_cert(struct lws *wsi, char *ebuf, size_t ebuf_len)
 			snprintf(ebuf, ebuf_len, "Peer cert verify failed: %s", ds.data);
 			gnutls_free(ds.data);
 		} else {
-			snprintf(ebuf, ebuf_len, "Peer cert verify failed with status %d", status);
+			snprintf(ebuf, ebuf_len, "Peer cert verify failed with status %d", status); lwsl_err("GnuTLS verify failed: status=%u, allowed=%u\n", status, allowed);
 		}
 		return -1;
 	}

--- a/lib/tls/gnutls/gnutls-tls.c
+++ b/lib/tls/gnutls/gnutls-tls.c
@@ -183,6 +183,23 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 	if (ca_filepath) {
 		gnutls_certificate_set_x509_trust_file(vh->tls.ssl_client_ctx->creds,
 						      ca_filepath, GNUTLS_X509_FMT_PEM);
+	} else if (ca_mem && ca_mem_len) {
+		lws_filepos_t amount = 0;
+		uint8_t *up1;
+
+		if (lws_tls_alloc_pem_to_der_file(vh->context, NULL, ca_mem,
+						  ca_mem_len, &up1, &amount)) {
+			lwsl_err("%s: Unable to decode x.509 mem\n", __func__);
+			return 1;
+		}
+
+		if (lws_tls_client_vhost_extra_cert_mem(vh, up1, (size_t)amount)) {
+			lwsl_err("%s: add extra cert failed\n", __func__);
+			lws_free(up1);
+			return 1;
+		}
+
+		lws_free(up1);
 	} else {
 		gnutls_certificate_set_x509_system_trust(vh->tls.ssl_client_ctx->creds);
 	}

--- a/lib/tls/openssl/openssl-ssl.c
+++ b/lib/tls/openssl/openssl-ssl.c
@@ -230,7 +230,9 @@ lws_ssl_capable_read(struct lws *wsi, unsigned char *buf, size_t len)
 #if defined(LWS_WITH_LATENCY)
 	lws_usec_t _lws_start = lws_now_usecs();
 #endif
+	memset(buf, 0, len);
 	n = SSL_read(wsi->tls.ssl, buf, (int)(ssize_t)len);
+
 #if defined(LWS_WITH_LATENCY)
 	{
 		unsigned int ms = (unsigned int)((lws_now_usecs() - _lws_start) / 1000);
@@ -371,7 +373,6 @@ int
 lws_ssl_capable_write(struct lws *wsi, unsigned char *buf, size_t len)
 {
 	int n, m;
-
 
 #if defined(LWS_TLS_LOG_PLAINTEXT_TX)
 	/*

--- a/minimal-examples-lowlevel/api-tests/api-test-async-dns/CMakeLists.txt
+++ b/minimal-examples-lowlevel/api-tests/api-test-async-dns/CMakeLists.txt
@@ -8,14 +8,43 @@ set(SRCS main.c)
 require_lws_config(LWS_ROLE_H1 1 requirements)
 require_lws_config(LWS_WITH_CLIENT 1 requirements)
 require_lws_config(LWS_WITH_SYS_ASYNC_DNS 1 requirements)
+require_lws_config(LWS_WITH_AUTHORITATIVE_DNS 1 requirements)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
 
 if (requirements)
 	add_executable(${SAMP} ${SRCS})
-	add_test(NAME api-test-async-dns COMMAND lws-api-test-async-dns)
+	set(PORT_ADNS_SRV "5353")
+	if ("$ENV{SAI_INSTANCE_IDX}")
+		math(EXPR PORT_ADNS_SRV "5353 + $ENV{SAI_INSTANCE_IDX}")
+	endif()
+
+	if (NOT WIN32)
+		add_test(NAME st_adns_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
+					adns_srv
+					$<TARGET_FILE:lws-api-test-dns-server>
+					-p ${PORT_ADNS_SRV} )
+		add_test(NAME ki_adns_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh adns_srv
+					$<TARGET_FILE_NAME:lws-api-test-dns-server> -p ${PORT_ADNS_SRV})
+
+		set_tests_properties(st_adns_srv PROPERTIES
+						 WORKING_DIRECTORY .
+						 FIXTURES_SETUP adns_srv
+						 TIMEOUT 800)
+		set_tests_properties(ki_adns_srv PROPERTIES
+						 FIXTURES_CLEANUP adns_srv)
+	endif()
+
+	add_test(NAME api-test-async-dns COMMAND lws-api-test-async-dns -s 127.0.0.1)
 	set_tests_properties(api-test-async-dns
 			     PROPERTIES
 			     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/api-tests/api-test-async-dns
+			     ENVIRONMENT "LWS_ASYNCDNS_PORT=${PORT_ADNS_SRV}"
 			     TIMEOUT 60)
+	if (NOT WIN32)
+		set_tests_properties(api-test-async-dns PROPERTIES FIXTURES_REQUIRED "adns_srv")
+	endif()
 
 	if (websockets_shared)
 		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})

--- a/minimal-examples-lowlevel/api-tests/api-test-async-dns/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-async-dns/main.c
@@ -89,26 +89,26 @@ static struct async_dns_tests {
 	int addrlen;
 	uint8_t ads[16];
 } adt[] = {
-	{ "ml.warmcat.com", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_A | LWS_ADNS_IGNORE_HOSTS_FILE, 4,
+	{ "ml.warmcat.com", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_A | LWS_ADNS_IGNORE_HOSTS_FILE | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 46, 105, 127, 147, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
 		/* test coming from cache */
-	{ "ml.warmcat.com", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_A, 4,
+	{ "ml.warmcat.com", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_A | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 46, 105, 127, 147, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
-	{ "libwebsockets.org", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_A | LWS_ADNS_IGNORE_HOSTS_FILE, 4,
+	{ "libwebsockets.org", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_A | LWS_ADNS_IGNORE_HOSTS_FILE | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 46, 105, 127, 147, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
-	{ "doesntexist", LWS_ADNS_RECORD_A, 0,
+	{ "doesntexist", LWS_ADNS_RECORD_A | LWS_ADNS_INDICATE_LACKS_DNSSEC, 0,
 		{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
-	{ "localhost", LWS_ADNS_RECORD_A, 4,
+	{ "localhost", LWS_ADNS_RECORD_A | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
-	{ "ipv4only.warmcat.com", LWS_ADNS_RECORD_A, 4,
+	{ "ipv4only.warmcat.com", LWS_ADNS_RECORD_A | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 212, 83, 179, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
-	{ "onevalid.bogus.warmcat.com", LWS_ADNS_RECORD_A, 4,
+	{ "onevalid.bogus.warmcat.com", LWS_ADNS_RECORD_A | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 212, 83, 179, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
 #if defined(LWS_WITH_IPV6)
-	{ "mail.warmcat.com", LWS_ADNS_RECORD_AAAA, 16, /* check ipv6 */
+	{ "mail.warmcat.com", LWS_ADNS_RECORD_AAAA | LWS_ADNS_INDICATE_LACKS_DNSSEC, 16, /* check ipv6 */
 		{ 0x20, 0x01, 0x0b, 0xc8, 0x60, 0x10, 0x02, 0x13,
 				0x02, 0x08, 0xa2, 0xff, 0xfe, 0x0c, 0x72, 0xce, } },
-	{ "ipv6only.warmcat.com", LWS_ADNS_RECORD_AAAA, 16, /* check ipv6 */
+	{ "ipv6only.warmcat.com", LWS_ADNS_RECORD_AAAA | LWS_ADNS_INDICATE_LACKS_DNSSEC, 16, /* check ipv6 */
 		{ 0x20, 0x01, 0x0b, 0xc8, 0x60, 0x10, 0x02, 0x13,
 				0x02, 0x08, 0xa2, 0xff, 0xfe, 0x0c, 0x72, 0xce, } },
 #endif
@@ -146,7 +146,7 @@ static struct async_dns_tests {
 		{ 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
 	{ "terrafirma.terra.mud.org", LWS_ADNS_RECORD_A | LWS_ADNS_INDICATE_LACKS_DNSSEC, 4,
 		{ 92,205,179,40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
-	{ "warmcat.com", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_SOA, 0,
+	{ "warmcat.com", TEST_FLAG_NOCHECK_RESULT_IP | LWS_ADNS_RECORD_SOA | LWS_ADNS_INDICATE_LACKS_DNSSEC, 0,
 		{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, } },
 };
 
@@ -521,6 +521,10 @@ main(int argc, const char **argv)
 	lwsl_user("LWS API selftest: Async DNS\n");
 
 	static const char *dns[] = { "8.8.8.8", NULL };
+	const char *p;
+
+	if ((p = lws_cmdline_option(argc, argv, "-s")))
+		dns[0] = p;
 
 	info.port = CONTEXT_PORT_NO_LISTEN;
 	info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
@@ -536,9 +540,11 @@ main(int argc, const char **argv)
 		return 1;
 	}
 
-	fixup(0);
-	fixup(5);
-	fixup(6);
+	if (!p) {
+		fixup(0);
+		fixup(5);
+		fixup(6);
+	}
 
 	{
 		lws_sockaddr46 sa46;

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/CMakeLists.txt
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(lws-api-test-dns-server C)
+cmake_minimum_required(VERSION 3.10)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SAMP lws-api-test-dns-server)
+set(SRCS main.c
+	 ../../../plugins/protocol_lws_auth_dns/protocol_lws_auth_dns.c)
+
+set(requirements 1)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
+require_lws_config(LWS_WITH_AUTHORITATIVE_DNS 1 requirements)
+
+if (requirements)
+	add_executable(${SAMP} ${SRCS})
+	if (websockets_shared)
+		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${SAMP} websockets_shared)
+	else()
+		target_link_libraries(${SAMP} websockets ${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+
+	if (LWS_CTEST_INTERNET_AVAILABLE)
+	endif()
+endif()

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/main.c
@@ -1,0 +1,65 @@
+#include <libwebsockets.h>
+#include <string.h>
+#include <signal.h>
+
+static int interrupted;
+
+void sigint_handler(int sig)
+{
+	interrupted = 1;
+}
+
+extern const struct lws_protocols lws_auth_dns_protocols[];
+
+int main(int argc, const char **argv)
+{
+	struct lws_context_creation_info info;
+	struct lws_context *context;
+	int n = 0;
+	const char *p;
+
+	signal(SIGINT, sigint_handler);
+
+	lws_context_info_defaults(&info, NULL);
+	lws_cmdline_option_handle_builtin(argc, argv, &info);
+
+	info.port = 5353;
+	if ((p = lws_cmdline_option(argc, argv, "-p")))
+		info.port = atoi(p);
+
+	const struct lws_protocols my_protocols[] = {
+		lws_auth_dns_protocols[0],
+		{ NULL, NULL, 0, 0, 0, NULL, 0 }
+	};
+	info.protocols = my_protocols;
+	info.options = LWS_SERVER_OPTION_FALLBACK_TO_APPLY_LISTEN_ACCEPT_CONFIG;
+	info.listen_accept_role = "raw-skt";
+	info.listen_accept_protocol = "protocol-lws-auth-dns";
+
+	const char *z = "../minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/";
+	if ((p = lws_cmdline_option(argc, argv, "-z")))
+		z = p;
+
+	const struct lws_protocol_vhost_options pvo1 = {
+		NULL, NULL, "zone-dir", z
+	};
+	const struct lws_protocol_vhost_options pvo = {
+		NULL, &pvo1, "protocol-lws-auth-dns", ""
+	};
+	info.pvo = &pvo;
+
+	lwsl_user("LWS mock DNS server | port %d\n", info.port);
+
+	context = lws_create_context(&info);
+	if (!context) {
+		lwsl_err("lws init failed\n");
+		return 1;
+	}
+
+	while (n >= 0 && !interrupted)
+		n = lws_service(context, 0);
+
+	lws_context_destroy(context);
+
+	return 0;
+}

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/a-msedge.net.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/a-msedge.net.zone
@@ -1,0 +1,13 @@
+$ORIGIN a-msedge.net.
+$TTL 86400
+
+@	IN	SOA	ns1.a-msedge.net. hostmaster.a-msedge.net. (
+			2026060601	; Serial
+			3600		; Refresh
+			1800		; Retry
+			604800		; Expire
+			86400 )		; Minimum TTL
+
+@	IN	NS	ns1.a-msedge.net.
+
+a-0003	IN	A	4.4.4.4

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/addictmud.org.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/addictmud.org.zone
@@ -1,0 +1,12 @@
+$ORIGIN addictmud.org.
+$TTL 86400
+@	IN	SOA	ns1.addictmud.org. hostmaster.addictmud.org. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.addictmud.org.
+
+game	IN	A	167.172.227.42

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/d.akamaiedge.net.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/d.akamaiedge.net.zone
@@ -1,0 +1,13 @@
+$ORIGIN d.akamaiedge.net.
+$TTL 86400
+
+@	IN	SOA	ns1.d.akamaiedge.net. hostmaster.d.akamaiedge.net. (
+			2026060601	; Serial
+			3600		; Refresh
+			1800		; Retry
+			604800		; Expire
+			86400 )		; Minimum TTL
+
+@	IN	NS	ns1.d.akamaiedge.net.
+
+e28578	IN	A	2.2.2.2

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/libwebsockets.org.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/libwebsockets.org.zone
@@ -1,0 +1,13 @@
+$ORIGIN libwebsockets.org.
+$TTL 86400
+@	IN	SOA	ns1.libwebsockets.org. hostmaster.libwebsockets.org. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.libwebsockets.org.
+
+@	IN	A	46.105.127.147
+tcp-fallback	IN	A	46.105.127.147

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/lociterm.com.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/lociterm.com.zone
@@ -1,0 +1,14 @@
+$ORIGIN lociterm.com.
+$TTL 86400
+@	IN	SOA	ns1.lociterm.com. hostmaster.lociterm.com. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.lociterm.com.
+
+lwsbiglongtesthostname	IN	A	127.0.0.1
+grow	IN	A	127.0.0.1
+letsgobigorgohome	IN	A	127.0.0.1

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/majicrealm.com.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/majicrealm.com.zone
@@ -1,0 +1,12 @@
+$ORIGIN majicrealm.com.
+$TTL 86400
+@	IN	SOA	ns1.majicrealm.com. hostmaster.majicrealm.com. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.majicrealm.com.
+
+awsrealm	IN	A	35.88.197.177

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/mud.org.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/mud.org.zone
@@ -1,0 +1,12 @@
+$ORIGIN mud.org.
+$TTL 86400
+@	IN	SOA	ns1.mud.org. hostmaster.mud.org. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.mud.org.
+
+terrafirma.terra	IN	A	92.205.179.40

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/shwaine.com.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/shwaine.com.zone
@@ -1,0 +1,12 @@
+$ORIGIN shwaine.com.
+$TTL 86400
+@	IN	SOA	ns1.shwaine.com. hostmaster.shwaine.com. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.shwaine.com.
+
+mudpuddle	IN	A	174.134.58.54

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/trafficmanager.net.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/trafficmanager.net.zone
@@ -1,0 +1,13 @@
+$ORIGIN trafficmanager.net.
+$TTL 86400
+
+@	IN	SOA	ns1.trafficmanager.net. hostmaster.trafficmanager.net. (
+			2026060601	; Serial
+			3600		; Refresh
+			1800		; Retry
+			604800		; Expire
+			86400 )		; Minimum TTL
+
+@	IN	NS	ns1.trafficmanager.net.
+
+c-msn-com-europe-vip	IN	A	3.3.3.3

--- a/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/warmcat.com.zone
+++ b/minimal-examples-lowlevel/api-tests/api-test-dns-server/zones-api-test/warmcat.com.zone
@@ -1,0 +1,16 @@
+$ORIGIN warmcat.com.
+$TTL 86400
+@	IN	SOA	ns1.warmcat.com. hostmaster.warmcat.com. (
+			2020010101 ; serial
+			3600       ; refresh
+			1800       ; retry
+			604800     ; expire
+			86400      ; minimum TTL
+			)
+@	IN	NS	ns1.warmcat.com.
+
+ml	IN	A	46.105.127.147
+ipv4only	IN	A	212.83.179.61
+onevalid.bogus	IN	A	212.83.179.61
+mail	IN	AAAA	2001:bc8:6010:213:208:a2ff:fe0c:72ce
+ipv6only	IN	AAAA	2001:bc8:6010:213:208:a2ff:fe0c:72ce

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-h2-rxflow/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-h2-rxflow/CMakeLists.txt
@@ -16,13 +16,36 @@ require_lws_config(LWS_WITH_TLS 1 requirements)
 
 if (requirements)
 	add_executable(${SAMP} ${SRCS})
-	if (LWS_CTEST_INTERNET_AVAILABLE)
-		add_test(NAME http-client-h2-rxflow-warmcat COMMAND lws-minimal-http-client-h2-rxflow)
-		add_test(NAME http-client-h2-rxflow-warmcat-h1 COMMAND lws-minimal-http-client-h2-rxflow --h1)
+	set(PORT_HC_RXFLOW_SRV "7250")
+	if ("$ENV{SAI_INSTANCE_IDX}")
+		math(EXPR PORT_HC_RXFLOW_SRV "7251 + $ENV{SAI_INSTANCE_IDX}")
+	endif()
+
+	if (NOT WIN32 AND LWS_WITH_SERVER AND LWS_WITH_TLS)
+		add_test(NAME st_hc_rxflow_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
+					hc_rxflow_srv
+					$<TARGET_FILE:test-server>
+					-r ${CMAKE_BINARY_DIR}/share/libwebsockets-test-server/
+					-s --port ${PORT_HC_RXFLOW_SRV} )
+		add_test(NAME ki_hc_rxflow_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hc_rxflow_srv
+					$<TARGET_FILE_NAME:test-server> --port ${PORT_HC_RXFLOW_SRV})
+
+		set_tests_properties(st_hc_rxflow_srv PROPERTIES
+							 WORKING_DIRECTORY .
+							 FIXTURES_SETUP hc_rxflow_srv
+							 TIMEOUT 800)
+		set_tests_properties(ki_hc_rxflow_srv PROPERTIES
+							 FIXTURES_CLEANUP hc_rxflow_srv)
+
+		add_test(NAME http-client-h2-rxflow-warmcat COMMAND lws-minimal-http-client-h2-rxflow -l --server localhost -p ${PORT_HC_RXFLOW_SRV})
+		add_test(NAME http-client-h2-rxflow-warmcat-h1 COMMAND lws-minimal-http-client-h2-rxflow -l --server localhost -p ${PORT_HC_RXFLOW_SRV} --h1)
 		set_tests_properties(http-client-h2-rxflow-warmcat
 				     http-client-h2-rxflow-warmcat-h1
 				     PROPERTIES
 				     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-client/minimal-http-client-h2-rxflow
+				     FIXTURES_REQUIRED "hc_rxflow_srv"
 				     TIMEOUT 30)
 	endif()
 

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-hugeurl/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-hugeurl/CMakeLists.txt
@@ -16,7 +16,28 @@ require_lws_config(LWS_WITH_TLS 1 requirements)
 if (requirements)
 	add_executable(${SAMP} ${SRCS})
 
-	if (LWS_CTEST_INTERNET_AVAILABLE)
+	set(PORT_HC_HUGE_SRV "7260")
+	if ("$ENV{SAI_INSTANCE_IDX}")
+		math(EXPR PORT_HC_HUGE_SRV "7261 + $ENV{SAI_INSTANCE_IDX}")
+	endif()
+
+	if (NOT WIN32 AND LWS_WITH_SERVER AND LWS_WITH_TLS)
+		add_test(NAME st_hc_huge_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
+					hc_huge_srv
+					$<TARGET_FILE:test-server>
+					-r ${CMAKE_BINARY_DIR}/share/libwebsockets-test-server/
+					-s --port ${PORT_HC_HUGE_SRV} )
+		add_test(NAME ki_hc_huge_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hc_huge_srv
+					$<TARGET_FILE_NAME:test-server> --port ${PORT_HC_HUGE_SRV})
+
+		set_tests_properties(st_hc_huge_srv PROPERTIES
+							 WORKING_DIRECTORY .
+							 FIXTURES_SETUP hc_huge_srv
+							 TIMEOUT 800)
+		set_tests_properties(ki_hc_huge_srv PROPERTIES
+							 FIXTURES_CLEANUP hc_huge_srv)
 
 		#
 		# creates a fixture res_hchugeurlw to get a lease on the
@@ -24,18 +45,19 @@ if (requirements)
 		#
 		sai_resource(warmcat_conns 1 40 hchugeurlw)
 	
-		add_test(NAME http-client-hugeurl-warmcat COMMAND lws-minimal-http-client-hugeurl )
-		add_test(NAME http-client-hugeurl-warmcat-h1 COMMAND lws-minimal-http-client-hugeurl  --h1)
+		add_test(NAME http-client-hugeurl-warmcat COMMAND lws-minimal-http-client-hugeurl -l --server localhost -p ${PORT_HC_HUGE_SRV})
+		add_test(NAME http-client-hugeurl-warmcat-h1 COMMAND lws-minimal-http-client-hugeurl -l --server localhost -p ${PORT_HC_HUGE_SRV} --h1)
 		set_tests_properties(http-client-hugeurl-warmcat
 				     http-client-hugeurl-warmcat-h1
 				     PROPERTIES
 				     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-client/minimal-http-client-hugeurl
+				     FIXTURES_REQUIRED "hc_huge_srv"
 				     TIMEOUT 60)
 		if (DEFINED ENV{SAI_OVN})
 			set_tests_properties(http-client-hugeurl-warmcat
 					     http-client-hugeurl-warmcat-h1
 					     PROPERTIES
-						FIXTURES_REQUIRED "res_hchugeurlw")	
+						FIXTURES_REQUIRED "res_hchugeurlw;hc_huge_srv")	
 		endif()
 
 	endif()

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-hugeurl/minimal-http-client-hugeurl.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-hugeurl/minimal-http-client-hugeurl.c
@@ -16,11 +16,15 @@
 
 enum {
 	LWS_SW_L,
+	LWS_SW_SERVER,
+	LWS_SW_PORT,
 	LWS_SW_HELP,
 };
 
 static const struct lws_switches switches[] = {
 	[LWS_SW_L]	= { "-l",              "Enable -l feature" },
+	[LWS_SW_SERVER]	= { "--server",        "Server address to connect to" },
+	[LWS_SW_PORT]	= { "-p",              "Port to connect to" },
 	[LWS_SW_HELP]	= { "--help",		"Show this help information" },
 };
 
@@ -159,6 +163,7 @@ int main(int argc, const char **argv)
 	struct lws_context_creation_info info;
 	struct lws_client_connect_info i;
 	struct lws_context *context;
+	const char *p;
 	int n = 0;
 	(void)switches;
 
@@ -215,6 +220,12 @@ int main(int argc, const char **argv)
 		i.port = 443;
 		i.address = "libwebsockets.org";
 	}
+
+	if ((p = lws_cmdline_option(argc, argv, switches[LWS_SW_SERVER].sw)))
+		i.address = p;
+
+	if ((p = lws_cmdline_option(argc, argv, switches[LWS_SW_PORT].sw)))
+		i.port = atoi(p);
 
 	i.path = uri;
 	i.host = i.address;

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-jit-trust/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-jit-trust/CMakeLists.txt
@@ -43,109 +43,115 @@ if (requirements)
 	
 	sai_resource(warmcat_conns 1 40 http_client_warmcat)
 
-	if (LWS_CTEST_INTERNET_AVAILABLE)
-		set(mytests http-client-warmcat-h1)
+	set(PORT_HC_JIT_SRV "7270")
+	if ("$ENV{SAI_INSTANCE_IDX}")
+		math(EXPR PORT_HC_JIT_SRV "7271 + $ENV{SAI_INSTANCE_IDX}")
+	endif()
+
+	if (NOT WIN32 AND LWS_WITH_SERVER AND LWS_WITH_TLS)
+		add_test(NAME st_hc_jit_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
+					hc_jit_srv
+					$<TARGET_FILE:test-server>
+					-r ${CMAKE_BINARY_DIR}/share/libwebsockets-test-server/
+					-s --port ${PORT_HC_JIT_SRV} )
+		add_test(NAME ki_hc_jit_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hc_jit_srv
+					$<TARGET_FILE_NAME:test-server> --port ${PORT_HC_JIT_SRV})
+
+		set_tests_properties(st_hc_jit_srv PROPERTIES
+							 WORKING_DIRECTORY .
+							 FIXTURES_SETUP hc_jit_srv
+							 TIMEOUT 800)
+		set_tests_properties(ki_hc_jit_srv PROPERTIES
+							 FIXTURES_CLEANUP hc_jit_srv)
+
+		set(mytests jit-trust-http-client-warmcat-h1)
 		if (has_h2)
-			add_test(NAME http-client-warmcat COMMAND lws-minimal-http-client )
-			list(APPEND mytests http-client-warmcat)
+			add_test(NAME jit-trust-http-client-warmcat COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV})
+			list(APPEND mytests jit-trust-http-client-warmcat)
 		endif()
 
-
-		add_test(NAME http-client-warmcat-h1 COMMAND lws-minimal-http-client  --h1)
+		add_test(NAME jit-trust-http-client-warmcat-h1 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --h1)
 				     
 		if (has_fault_injection)
 		
 			# creation related faults
 		
-			list(APPEND mytests http-client-fi-ctx1)
-			add_test(NAME http-client-fi-ctx1 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail1")
+			list(APPEND mytests jit-trust-http-client-fi-ctx1)
+			add_test(NAME jit-trust-http-client-fi-ctx1 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail1")
 			
-			# if (has_plugins)
-			# !!! need to actually select an available evlib plugin to trigger this
-			#	list(APPEND mytests http-client-fi-pi)
-			#	add_test(NAME http-client-fi-pi COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_plugin_init")
-			# endif()
+			list(APPEND mytests jit-trust-http-client-fi-ctx2)
+			add_test(NAME jit-trust-http-client-fi-ctx2 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_evlib_sel")
+			
+			list(APPEND mytests jit-trust-http-client-fi-ctx3)
+			add_test(NAME jit-trust-http-client-fi-ctx3 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_oom_ctx")
+			
+			list(APPEND mytests jit-trust-http-client-fi-ctx4)
+			add_test(NAME jit-trust-http-client-fi-ctx4 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_privdrop")
 
-			list(APPEND mytests http-client-fi-ctx2)
-			add_test(NAME http-client-fi-ctx2 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_evlib_sel")
+			list(APPEND mytests jit-trust-http-client-fi-ctx5)
+			add_test(NAME jit-trust-http-client-fi-ctx5 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_maxfds")
 			
-			list(APPEND mytests http-client-fi-ctx3)
-			add_test(NAME http-client-fi-ctx3 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_oom_ctx")
+			list(APPEND mytests jit-trust-http-client-fi-ctx6)
+			add_test(NAME jit-trust-http-client-fi-ctx6 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_oom_fds")
 			
-			list(APPEND mytests http-client-fi-ctx4)
-			add_test(NAME http-client-fi-ctx4 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_privdrop")
-
-			list(APPEND mytests http-client-fi-ctx5)
-			add_test(NAME http-client-fi-ctx5 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_maxfds")
+			list(APPEND mytests jit-trust-http-client-fi-ctx7)
+			add_test(NAME jit-trust-http-client-fi-ctx7 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_plat_init")
 			
-			list(APPEND mytests http-client-fi-ctx6)
-			add_test(NAME http-client-fi-ctx6 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_oom_fds")
+			list(APPEND mytests jit-trust-http-client-fi-ctx8)
+			add_test(NAME jit-trust-http-client-fi-ctx8 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_evlib_init")
 			
-			list(APPEND mytests http-client-fi-ctx7)
-			add_test(NAME http-client-fi-ctx7 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_plat_init")
-			
-			list(APPEND mytests http-client-fi-ctx8)
-			add_test(NAME http-client-fi-ctx8 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_evlib_init")
-			
-			list(APPEND mytests http-client-fi-ctx9)
-			add_test(NAME http-client-fi-ctx9 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_evlib_pt")
+			list(APPEND mytests jit-trust-http-client-fi-ctx9)
+			add_test(NAME jit-trust-http-client-fi-ctx9 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_evlib_pt")
 			
 			if (NOT has_no_system_vhost)
 			
-				list(APPEND mytests http-client-fi-ctx10)
-				add_test(NAME http-client-fi-ctx10 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_sys_vh")
+				list(APPEND mytests jit-trust-http-client-fi-ctx10)
+				add_test(NAME jit-trust-http-client-fi-ctx10 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_sys_vh")
 			
-				list(APPEND mytests http-client-fi-ctx11)
-				add_test(NAME http-client-fi-ctx11 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_sys_vh_init")
+				list(APPEND mytests jit-trust-http-client-fi-ctx11)
+				add_test(NAME jit-trust-http-client-fi-ctx11 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_sys_vh_init")
 				
 			endif()
 			
-			list(APPEND mytests http-client-fi-ctx12)
-			add_test(NAME http-client-fi-ctx12 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_def_vh")
+			list(APPEND mytests jit-trust-http-client-fi-ctx12)
+			add_test(NAME jit-trust-http-client-fi-ctx12 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "ctx_createfail_def_vh")
 			
 
-			list(APPEND mytests http-client-fi-vh1)
-			add_test(NAME http-client-fi-vh1 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_oom")
+			list(APPEND mytests jit-trust-http-client-fi-vh1)
+			add_test(NAME jit-trust-http-client-fi-vh1 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "vh/vh_create_oom")
 			
-			list(APPEND mytests http-client-fi-vh2)
-			add_test(NAME http-client-fi-vh2 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_pcols_oom")
+			list(APPEND mytests jit-trust-http-client-fi-vh2)
+			add_test(NAME jit-trust-http-client-fi-vh2 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "vh/vh_create_pcols_oom")
 			
-			list(APPEND mytests http-client-fi-vh3)
-			add_test(NAME http-client-fi-vh3 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_ssl_srv")
+			list(APPEND mytests jit-trust-http-client-fi-vh3)
+			add_test(NAME jit-trust-http-client-fi-vh3 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "vh/vh_create_ssl_srv")
 
-			list(APPEND mytests http-client-fi-vh4)
-			add_test(NAME http-client-fi-vh4 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_ssl_cli")
+			list(APPEND mytests jit-trust-http-client-fi-vh4)
+			add_test(NAME jit-trust-http-client-fi-vh4 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "vh/vh_create_ssl_cli")
 			
-			list(APPEND mytests http-client-fi-vh5)
-			add_test(NAME http-client-fi-vh5 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_srv_init")
+			list(APPEND mytests jit-trust-http-client-fi-vh5)
+			add_test(NAME jit-trust-http-client-fi-vh5 COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 5 --fault-injection "vh/vh_create_srv_init")
 
 
-			list(APPEND mytests http-client-fi-dnsfail)
-			add_test(NAME http-client-fi-dnsfail COMMAND lws-minimal-http-client --expected-exit 3 --fault-injection "wsi=user/dnsfail")
+			list(APPEND mytests jit-trust-http-client-fi-dnsfail)
+			add_test(NAME jit-trust-http-client-fi-dnsfail COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 3 --fault-injection "wsi=user/dnsfail")
 			
-			if (has_async_dns)
-				list(APPEND mytests http-client-fi-connfail)
-				add_test(NAME http-client-fi-connfail COMMAND lws-minimal-http-client --expected-exit 3 --fault-injection "wsi=user/connfail")
-			else()
-				list(APPEND mytests http-client-fi-connfail)
-				add_test(NAME http-client-fi-connfail COMMAND lws-minimal-http-client --expected-exit 2 --fault-injection "wsi=user/connfail")
-			endif()
+			list(APPEND mytests jit-trust-http-client-fi-connfail)
+			add_test(NAME jit-trust-http-client-fi-connfail COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 3 --fault-injection "wsi=user/connfail")
 			
-			list(APPEND mytests http-client-fi-user-est-fail)
-			add_test(NAME http-client-fi-user-est-fail COMMAND lws-minimal-http-client --expected-exit 3 --fault-injection "wsi/user_reject_at_est")	
+			list(APPEND mytests jit-trust-http-client-fi-user-est-fail)
+			add_test(NAME jit-trust-http-client-fi-user-est-fail COMMAND lws-minimal-http-client-jit-trust -l --server localhost -p ${PORT_HC_JIT_SRV} --expected-exit 3 --fault-injection "wsi/user_reject_at_est")	
 		
 			
 		endif()
 		
 		set_tests_properties(${mytests} PROPERTIES
 		     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-client/minimal-http-client
+		     FIXTURES_REQUIRED "hc_jit_srv"
 		     TIMEOUT 20)
 				     
-    		if (DEFINED ENV{SAI_OVN})
-			set_tests_properties(${mytests} PROPERTIES
-					     FIXTURES_REQUIRED "res_http_client_warmcat")
-		endif()		
-	
 	endif()
 
 	if (websockets_shared)

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-multi/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-multi/CMakeLists.txt
@@ -50,7 +50,7 @@ if (NOT WIN32 AND LWS_WITH_SERVER)
 	#
 
 if (WIN32)
-	add_test(NAME st_hcm_srv COMMAND cmd.exe /c start /b $<TARGET_FILE:lws-minimal-http-server-tls> --port ${PORT_HCM_SRV})
+	add_test(NAME st_hcm_srv COMMAND cmd.exe /c start /b $<TARGET_FILE:lws-minimal-http-server-tls> -p ${PORT_HCM_SRV})
 	add_test(NAME ki_hcm_srv COMMAND taskkill /F /IM $<TARGET_FILE_NAME:lws-minimal-http-server-tls> /T)
 	add_test(NAME st_hcmp_srv COMMAND cmd.exe /c start /b $<TARGET_FILE:test-server> -s --port 1${PORT_HCM_SRV})
 	add_test(NAME ki_hcmp_srv COMMAND taskkill /F /IM $<TARGET_FILE_NAME:test-server> /T)
@@ -62,11 +62,11 @@ else()
 		add_test(NAME st_hcm_srv COMMAND
 			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
 				hcm_srv ${VALGRIND} --tool=memcheck $<TARGET_FILE:lws-minimal-http-server-tls>
-				--port ${PORT_HCM_SRV})
+				-p ${PORT_HCM_SRV})
 		add_test(NAME ki_hcm_srv COMMAND
 			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh
 				hcm_srv ${VALGRIND} $<TARGET_FILE_NAME:lws-minimal-http-server-tls>
-					--port ${PORT_HCM_SRV})
+					-p ${PORT_HCM_SRV})
 		add_test(NAME st_hcmp_srv COMMAND
 				${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
 					hcmp_srv ${VALGRIND} --tool=memcheck $<TARGET_FILE:test-server> -s
@@ -80,11 +80,11 @@ else()
 		add_test(NAME st_hcm_srv COMMAND
 			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
 				hcm_srv $<TARGET_FILE:lws-minimal-http-server-tls>
-				--port ${PORT_HCM_SRV} )
+				-p ${PORT_HCM_SRV} )
 		add_test(NAME ki_hcm_srv COMMAND
 			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh
 				hcm_srv $<TARGET_FILE_NAME:lws-minimal-http-server-tls>
-					--port ${PORT_HCM_SRV})
+					-p ${PORT_HCM_SRV})
 		add_test(NAME st_hcmp_srv COMMAND
 				${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
 					hcmp_srv $<TARGET_FILE:test-server> -s

--- a/minimal-examples-lowlevel/http-client/minimal-http-client/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client/CMakeLists.txt
@@ -52,126 +52,6 @@ if (requirements)
 	
 	sai_resource(warmcat_conns 1 40 http_client_warmcat)
 
-	if (LWS_CTEST_INTERNET_AVAILABLE)
-		set(mytests http-client-warmcat-h1)
-		if (has_h2)
-			add_test(NAME http-client-warmcat COMMAND lws-minimal-http-client )
-			list(APPEND mytests http-client-warmcat)
-		endif()
-
-
-		add_test(NAME http-client-warmcat-h1 COMMAND lws-minimal-http-client  --h1)
-		
-		if (has_h3)
-			# h3 test moved out of internet available block to use local test server
-		endif()
-				     
-		if (has_fault_injection)
-
-			message("... has LWS_WITH_SYS_FAULT_INJECTION")
-		
-			# creation related faults
-		
-			list(APPEND mytests http-client-fi-ctx1)
-			add_test(NAME http-client-fi-ctx1 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail1")
-			
-			# if (has_plugins)
-			# !!! need to actually select an available evlib plugin to trigger this
-			#	list(APPEND mytests http-client-fi-pi)
-			#	add_test(NAME http-client-fi-pi COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_plugin_init")
-			# endif()
-
-			list(APPEND mytests http-client-fi-ctx2)
-			add_test(NAME http-client-fi-ctx2 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_evlib_sel")
-			
-			list(APPEND mytests http-client-fi-ctx3)
-			add_test(NAME http-client-fi-ctx3 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_oom_ctx")
-			
-			list(APPEND mytests http-client-fi-ctx4)
-			add_test(NAME http-client-fi-ctx4 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_privdrop")
-
-			list(APPEND mytests http-client-fi-ctx5)
-			add_test(NAME http-client-fi-ctx5 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_maxfds")
-			
-			list(APPEND mytests http-client-fi-ctx6)
-			add_test(NAME http-client-fi-ctx6 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_oom_fds")
-			
-			list(APPEND mytests http-client-fi-ctx7)
-			add_test(NAME http-client-fi-ctx7 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_plat_init")
-			
-			list(APPEND mytests http-client-fi-ctx8)
-			add_test(NAME http-client-fi-ctx8 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_evlib_init")
-			
-			list(APPEND mytests http-client-fi-ctx9)
-			add_test(NAME http-client-fi-ctx9 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_evlib_pt")
-			
-			if (NOT has_no_system_vhost)
-			
-				list(APPEND mytests http-client-fi-ctx10)
-				add_test(NAME http-client-fi-ctx10 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_sys_vh")
-			
-				list(APPEND mytests http-client-fi-ctx11)
-				add_test(NAME http-client-fi-ctx11 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_sys_vh_init")
-				
-			endif()
-			
-			list(APPEND mytests http-client-fi-ctx12)
-			add_test(NAME http-client-fi-ctx12 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "ctx_createfail_def_vh")
-			
-
-			list(APPEND mytests http-client-fi-vh1)
-			add_test(NAME http-client-fi-vh1 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_oom")
-			
-			list(APPEND mytests http-client-fi-vh2)
-			add_test(NAME http-client-fi-vh2 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_pcols_oom")
-			
-			list(APPEND mytests http-client-fi-vh3)
-			add_test(NAME http-client-fi-vh3 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_ssl_srv")
-
-			list(APPEND mytests http-client-fi-vh4)
-			add_test(NAME http-client-fi-vh4 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_ssl_cli")
-			
-			list(APPEND mytests http-client-fi-vh5)
-			add_test(NAME http-client-fi-vh5 COMMAND lws-minimal-http-client --expected-exit 5 --fault-injection "vh/vh_create_srv_init")
-
-
-			list(APPEND mytests http-client-fi-dnsfail)
-			add_test(NAME http-client-fi-dnsfail COMMAND lws-minimal-http-client --expected-exit 3 --fault-injection "wsi=user/dnsfail")
-			
-			if (has_async_dns)
-				list(APPEND mytests http-client-fi-connfail)
-				add_test(NAME http-client-fi-connfail COMMAND lws-minimal-http-client --expected-exit 3 --fault-injection "wsi=user/connfail")
-			else()
-				list(APPEND mytests http-client-fi-connfail)
-				add_test(NAME http-client-fi-connfail COMMAND lws-minimal-http-client --expected-exit 2 --fault-injection "wsi=user/connfail")
-			endif()
-			
-			list(APPEND mytests http-client-fi-user-est-fail)
-			add_test(NAME http-client-fi-user-est-fail COMMAND lws-minimal-http-client --expected-exit 3 --fault-injection "wsi/user_reject_at_est")	
-		else()
-			message("... NO LWS_WITH_SYS_FAULT_INJECTION")
-		endif()
-		if (has_mbedtls)
-			list(APPEND mytests http-client-mbedtls-wrong-ca)
-			add_test(NAME http-client-mbedtls-wrong-ca COMMAND lws-minimal-http-client -w --expected-exit 3)
-			message("... adding mbedtls wrong CA test")
-		else()
-			message("... skipping mbedtls wrong CA test")
-		endif()
-	
-		foreach(N IN LISTS mytests)
-			set_tests_properties(${N} PROPERTIES
-			     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-client/minimal-http-client
-			     TIMEOUT 60)
-		endforeach()
-				     
-    		if (DEFINED ENV{SAI_OVN})
-			set_tests_properties(${mytests} PROPERTIES
-					     FIXTURES_REQUIRED "res_http_client_warmcat")
-		endif()		
-	
-	endif()
-
 	if (websockets_shared)
 		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
 		add_dependencies(${SAMP} websockets_shared)
@@ -205,13 +85,108 @@ if (requirements)
 		set_tests_properties(ki_hc_srv PROPERTIES
 							 FIXTURES_CLEANUP hc_srv)
 
+		set(mytests http-client-warmcat-h1)
+		if (has_h2)
+			add_test(NAME http-client-warmcat COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} )
+			list(APPEND mytests http-client-warmcat)
+		endif()
+
+		add_test(NAME http-client-warmcat-h1 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --h1)
+		
 		if (has_h3)
 			add_test(NAME http-client-h3 COMMAND lws-minimal-http-client --h3 -l --server localhost -p ${PORT_HC_SRV} -d 1039)
-			set_tests_properties(http-client-h3 PROPERTIES 
-				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-client/minimal-http-client
-				FIXTURES_REQUIRED "hc_srv"
-				TIMEOUT 60)
+			list(APPEND mytests http-client-h3)
 		endif()
+				     
+		if (has_fault_injection)
+
+			message("... has LWS_WITH_SYS_FAULT_INJECTION")
+		
+			# creation related faults
+		
+			list(APPEND mytests http-client-fi-ctx1)
+			add_test(NAME http-client-fi-ctx1 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail1")
+			
+			list(APPEND mytests http-client-fi-ctx2)
+			add_test(NAME http-client-fi-ctx2 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_evlib_sel")
+			
+			list(APPEND mytests http-client-fi-ctx3)
+			add_test(NAME http-client-fi-ctx3 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_oom_ctx")
+			
+			list(APPEND mytests http-client-fi-ctx4)
+			add_test(NAME http-client-fi-ctx4 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_privdrop")
+
+			list(APPEND mytests http-client-fi-ctx5)
+			add_test(NAME http-client-fi-ctx5 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_maxfds")
+			
+			list(APPEND mytests http-client-fi-ctx6)
+			add_test(NAME http-client-fi-ctx6 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_oom_fds")
+			
+			list(APPEND mytests http-client-fi-ctx7)
+			add_test(NAME http-client-fi-ctx7 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_plat_init")
+			
+			list(APPEND mytests http-client-fi-ctx8)
+			add_test(NAME http-client-fi-ctx8 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_evlib_init")
+			
+			list(APPEND mytests http-client-fi-ctx9)
+			add_test(NAME http-client-fi-ctx9 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_evlib_pt")
+			
+			if (NOT has_no_system_vhost)
+			
+				list(APPEND mytests http-client-fi-ctx10)
+				add_test(NAME http-client-fi-ctx10 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_sys_vh")
+			
+				list(APPEND mytests http-client-fi-ctx11)
+				add_test(NAME http-client-fi-ctx11 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_sys_vh_init")
+				
+			endif()
+			
+			list(APPEND mytests http-client-fi-ctx12)
+			add_test(NAME http-client-fi-ctx12 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "ctx_createfail_def_vh")
+			
+
+			list(APPEND mytests http-client-fi-vh1)
+			add_test(NAME http-client-fi-vh1 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "vh/vh_create_oom")
+			
+			list(APPEND mytests http-client-fi-vh2)
+			add_test(NAME http-client-fi-vh2 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "vh/vh_create_pcols_oom")
+			
+			list(APPEND mytests http-client-fi-vh3)
+			add_test(NAME http-client-fi-vh3 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "vh/vh_create_ssl_srv")
+
+			list(APPEND mytests http-client-fi-vh4)
+			add_test(NAME http-client-fi-vh4 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "vh/vh_create_ssl_cli")
+			
+			list(APPEND mytests http-client-fi-vh5)
+			add_test(NAME http-client-fi-vh5 COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 5 --fault-injection "vh/vh_create_srv_init")
+
+
+			list(APPEND mytests http-client-fi-dnsfail)
+			add_test(NAME http-client-fi-dnsfail COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 3 --fault-injection "wsi=user/dnsfail")
+			
+			list(APPEND mytests http-client-fi-connfail)
+			add_test(NAME http-client-fi-connfail COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 3 --fault-injection "wsi=user/connfail")
+			
+			list(APPEND mytests http-client-fi-user-est-fail)
+			add_test(NAME http-client-fi-user-est-fail COMMAND lws-minimal-http-client -l --server localhost -p ${PORT_HC_SRV} --expected-exit 3 --fault-injection "wsi/user_reject_at_est")	
+		else()
+			message("... NO LWS_WITH_SYS_FAULT_INJECTION")
+		endif()
+		if (has_mbedtls)
+			list(APPEND mytests http-client-mbedtls-wrong-ca)
+			add_test(NAME http-client-mbedtls-wrong-ca COMMAND lws-minimal-http-client --server localhost -p ${PORT_HC_SRV} -w --expected-exit 3)
+			message("... adding mbedtls wrong CA test")
+		else()
+			message("... skipping mbedtls wrong CA test")
+		endif()
+	
+		foreach(N IN LISTS mytests)
+			set_tests_properties(${N} PROPERTIES
+			     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-client/minimal-http-client
+			     FIXTURES_REQUIRED "hc_srv"
+			     TIMEOUT 60)
+		endforeach()
+				     
 	endif()
 
 endif()

--- a/minimal-examples-lowlevel/http-client/minimal-http-client/minimal-http-client.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client/minimal-http-client.c
@@ -352,7 +352,8 @@ system_notify_cb(lws_state_manager_t *mgr, lws_state_notify_link_t *link,
 	if (!lws_client_connect_via_info(&i)) {
 		lwsl_err("Client creation failed\n");
 		interrupted = 1;
-		bad = 2; /* could not even start client connection */
+		if (bad != 3)
+			bad = 3; /* synchronous connection/creation failure */
 		lws_cancel_service(context);
 
 		return 1;

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-httpbin/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-httpbin/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(lws-minimal-http-server-httpbin C)
+cmake_minimum_required(VERSION 3.10)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SAMP lws-minimal-http-server-httpbin)
+set(SRCS minimal-http-server-httpbin.c)
+
+set(requirements 1)
+require_lws_config(LWS_ROLE_H1 1 requirements)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
+
+if (requirements)
+	add_executable(${SAMP} ${SRCS})
+
+	if (websockets_shared)
+		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${SAMP} websockets_shared)
+	else()
+		target_link_libraries(${SAMP} websockets ${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+endif()

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-httpbin/minimal-http-server-httpbin.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-httpbin/minimal-http-server-httpbin.c
@@ -1,0 +1,251 @@
+/*
+ * lws-minimal-http-server-httpbin
+ *
+ * Written in 2010-2023 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ *
+ * This demonstrates a minimal http server that mimics basic httpbin.org functionality
+ * used by lws ctests for testing offline, e.g. /status/200, /delay/10, /bytes/1000.
+ */
+
+#include <libwebsockets.h>
+
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+#include <stdlib.h>
+
+enum {
+	LWS_SW_D,
+	LWS_SW_HELP,
+};
+
+static const struct lws_switches switches[] = {
+	[LWS_SW_D]	= { "-d",              "Debug logs (e.g. -d 15)" },
+	[LWS_SW_HELP]	= { "--help",		"Show this help information" },
+};
+
+struct pss {
+	lws_sorted_usec_list_t sul;
+	struct lws *wsi;
+	char path[128];
+	int status_code;
+	int delay_secs;
+	size_t bytes_left;
+	int headers_sent;
+	int writing_bytes;
+};
+
+static int interrupted;
+
+static void
+delay_cb(lws_sorted_usec_list_t *sul)
+{
+	struct pss *pss = lws_container_of(sul, struct pss, sul);
+	lwsl_notice("%s: delay over, resuming writable\n", __func__);
+	pss->delay_secs = 0;
+	lws_callback_on_writable(pss->wsi);
+}
+
+static int
+callback_httpbin(struct lws *wsi, enum lws_callback_reasons reason,
+			void *user, void *in, size_t len)
+{
+	struct pss *pss = (struct pss *)user;
+	uint8_t buf[LWS_PRE + 2048], *start = &buf[LWS_PRE], *p = start,
+		*end = &buf[sizeof(buf) - 1];
+	int n;
+	const char *uri;
+
+	switch (reason) {
+	case LWS_CALLBACK_HTTP: {
+		char temp_uri[128];
+
+		uri = (const char *)in;
+		if (uri && uri[0] != '/') {
+			/* LWS drops the leading slash for the callback, add it back for our logic */
+			lws_snprintf(temp_uri, sizeof(temp_uri), "/%s", uri);
+			uri = temp_uri;
+		}
+
+		if (!strncmp(uri, "/httpbin", 8))
+			uri += 8;
+
+		lws_snprintf(pss->path, sizeof(pss->path), "%s", uri);
+		uri = pss->path;
+		pss->wsi = wsi;
+		pss->status_code = 200;
+		pss->delay_secs = 0;
+		pss->bytes_left = 0;
+		pss->headers_sent = 0;
+		pss->writing_bytes = 0;
+
+		lwsl_notice("%s: HTTP: URI %s\n", __func__, uri);
+
+		if (!strncmp(uri, "/status/", 8)) {
+			pss->status_code = atoi(uri + 8);
+		} else if (!strncmp(uri, "/delay/", 7)) {
+			pss->delay_secs = atoi(uri + 7);
+		} else if (!strncmp(uri, "/bytes/", 7)) {
+			pss->bytes_left = (size_t)atoll(uri + 7);
+			pss->writing_bytes = 1;
+		}
+
+		if (pss->delay_secs > 0) {
+			lwsl_notice("%s: delaying %d secs\n", __func__, pss->delay_secs);
+			lws_sul_schedule(lws_get_context(wsi), 0, &pss->sul, delay_cb,
+					 (lws_usec_t)(pss->delay_secs * LWS_US_PER_SEC));
+			return 0;
+		}
+
+		lws_callback_on_writable(wsi);
+		return 0;
+
+	case LWS_CALLBACK_HTTP_WRITEABLE:
+
+		if (!pss || pss->delay_secs)
+			break;
+
+		if (!pss->headers_sent) {
+			if (lws_add_http_common_headers(wsi, (unsigned int)pss->status_code,
+					"text/plain",
+					pss->writing_bytes ? pss->bytes_left : 0,
+					&p, end))
+				return 1;
+			if (lws_finalize_http_header(wsi, &p, end))
+				return 1;
+			pss->headers_sent = 1;
+
+			int flags = LWS_WRITE_HTTP_HEADERS;
+			if (!pss->writing_bytes)
+				flags |= LWS_WRITE_H2_STREAM_END;
+
+			n = lws_write(wsi, start, lws_ptr_diff_size_t(p, start), (enum lws_write_protocol)flags);
+			if (n < 0)
+				return 1;
+
+			if (!pss->writing_bytes) {
+				if (lws_http_transaction_completed(wsi))
+					return -1;
+				return 0;
+			}
+
+			lws_callback_on_writable(wsi);
+			return 0;
+		}
+
+		if (pss->writing_bytes) {
+			size_t chunk = pss->bytes_left;
+			if (chunk > sizeof(buf) - LWS_PRE)
+				chunk = sizeof(buf) - LWS_PRE;
+
+			memset(start, 'A', chunk);
+
+			n = lws_write(wsi, start, chunk, (pss->bytes_left == chunk) ? LWS_WRITE_HTTP_FINAL : LWS_WRITE_HTTP);
+			if (n < 0)
+				return 1;
+
+			pss->bytes_left -= (size_t)n;
+
+			if (pss->bytes_left == 0) {
+				if (lws_http_transaction_completed(wsi))
+					return -1;
+			} else {
+				lws_callback_on_writable(wsi);
+			}
+		}
+	}
+		return 0;
+
+	case LWS_CALLBACK_CLOSED_HTTP:
+		if (pss)
+			lws_sul_cancel(&pss->sul);
+		break;
+
+	default:
+		break;
+	}
+
+	return lws_callback_http_dummy(wsi, reason, user, in, len);
+}
+
+static const struct lws_protocols defprot =
+	{ "defprot", lws_callback_http_dummy, 0, 0, 0, NULL, 0 }, protocol =
+	{ "http", callback_httpbin, sizeof(struct pss), 0, 0, NULL, 0 };
+
+static const struct lws_protocols *pprotocols[] = { &defprot, &protocol, NULL };
+
+static const struct lws_http_mount mount_dyn = {
+	.mountpoint		= "/",
+	.protocol		= "http",
+	.origin_protocol	= LWSMPRO_CALLBACK,
+	.mountpoint_len		= 1,
+};
+
+void sigint_handler(int sig)
+{
+	interrupted = 1;
+}
+
+int main(int argc, const char **argv)
+{
+	struct lws_context_creation_info info;
+	struct lws_context *context;
+	int n = 0;
+	const char *p;
+	(void)switches;
+
+	if ((argc == 1) || lws_cmdline_option(argc, argv, switches[LWS_SW_HELP].sw)) {
+		lws_switches_print_help(argv[0], switches, LWS_ARRAY_SIZE(switches));
+		return 0;
+	}
+
+	signal(SIGINT, sigint_handler);
+
+	lwsl_user("LWS minimal http server httpbin\n");
+
+	lws_context_info_defaults(&info, NULL);
+	lws_cmdline_option_handle_builtin(argc, argv, &info);
+	info.options = LWS_SERVER_OPTION_EXPLICIT_VHOSTS |
+		       LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE;
+
+	if (lws_cmdline_option(argc, argv, "-s")) {
+		info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+	}
+
+	context = lws_create_context(&info);
+	if (!context) {
+		lwsl_err("lws init failed\n");
+		return 1;
+	}
+
+#if defined(LWS_WITH_TLS)
+	if (lws_cmdline_option(argc, argv, "-s")) {
+		info.ssl_cert_filepath = "localhost-100y.cert";
+		info.ssl_private_key_filepath = "localhost-100y.key";
+	}
+#endif
+
+	info.port = 7681;
+	if ((p = lws_cmdline_option(argc, argv, "-p")))
+		info.port = atoi(p);
+
+	info.pprotocols = pprotocols;
+	info.mounts = &mount_dyn;
+	info.vhost_name = "http";
+
+	if (!lws_create_vhost(context, &info)) {
+		lwsl_err("Failed to create vhost\n");
+		goto bail;
+	}
+
+	while (n >= 0 && !interrupted)
+		n = lws_service(context, 0);
+
+bail:
+	lws_context_destroy(context);
+
+	return 0;
+}

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-tls/minimal-http-server-tls.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-tls/minimal-http-server-tls.c
@@ -25,7 +25,7 @@ enum {
 };
 
 static const struct lws_switches switches[] = {
-	[LWS_SW_PORT]	= { "--port",          "Port to connect or listen on" },
+	[LWS_SW_PORT]	= { "-p",          "Port to connect or listen on" },
 	[LWS_SW_H]	= { "-h",              "Strict Host Check / Help" },
 	[LWS_SW_HELP]	= { "--help",		"Show this help information" },
 };
@@ -115,7 +115,8 @@ int main(int argc, const char **argv)
 	info.fd_limit_per_thread = 0;
 	lwsl_user("LWS minimal http server TLS | visit https://localhost:7681\n");
 
-	info.port = 7681;
+	if (!info.port)
+		info.port = 7681;
 	if ((p = lws_cmdline_option(argc, argv, switches[LWS_SW_PORT].sw)))
 		info.port = atoi(p);
 	info.mounts = &mount;

--- a/minimal-examples-lowlevel/quic/minimal-quic-client-server/CMakeLists.txt
+++ b/minimal-examples-lowlevel/quic/minimal-quic-client-server/CMakeLists.txt
@@ -30,7 +30,7 @@ if (requirements)
 		endif()
 
 		find_program(H3SPEC_EXECUTABLE h3spec)
-		if (H3SPEC_EXECUTABLE)
+		if (H3SPEC_EXECUTABLE AND LWS_WITH_HTTP3)
 			add_test(NAME st_qcs_srv COMMAND
 				${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
 						qcs_srv

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-proxy/main.c
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-proxy/main.c
@@ -25,12 +25,14 @@
 #include <libwebsockets.h>
 
 enum {
+	LWS_SW_C,
 	LWS_SW_I,
 	LWS_SW_P,
 	LWS_SW_HELP,
 };
 
 static const struct lws_switches switches[] = {
+	[LWS_SW_C]	= { "-c",              "Policy filepath" },
 	[LWS_SW_I]	= { "-i",              "Interface to bind to" },
 	[LWS_SW_P]	= { "-p",              "Port number to listen or connect on" },
 	[LWS_SW_HELP]	= { "--help",		"Show this help information" },
@@ -38,6 +40,8 @@ static const struct lws_switches switches[] = {
 
 #include <string.h>
 #include <signal.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #if defined(__APPLE__) || defined(__linux__)
 #include <execinfo.h>
@@ -381,6 +385,8 @@ app_system_state_nf(lws_state_manager_t *mgr, lws_state_notify_link_t *link,
 	 * past them when we haven't solved them yet, and make the system
 	 * state wait while we trigger the dependent action.
 	 */
+	lwsl_user("%s: current %d, target %d\n", __func__, current, target);
+
 	switch (target) {
 	case LWS_SYSTATE_REGISTERED:
 		size = lws_system_blob_get_size(ab);
@@ -484,6 +490,7 @@ int main(int argc, const char **argv)
 {
 	struct lws_context_creation_info info;
 	const char *p;
+	char *file_buf = NULL;
 	int n = 0;
 	(void)switches;
 
@@ -510,7 +517,21 @@ int main(int argc, const char **argv)
 
 	info.fd_limit_per_thread = 1 + 26 + 1;
 	info.port = CONTEXT_PORT_NO_LISTEN;
-	info.pss_policies_json = default_ss_policy;
+	if ((p = lws_cmdline_option(argc, argv, switches[LWS_SW_C].sw))) {
+		int fd = open(p, O_RDONLY);
+		if (fd >= 0) {
+			size_t s = (size_t)lseek(fd, 0, SEEK_END);
+			file_buf = malloc(s + 1);
+			lseek(fd, 0, SEEK_SET);
+			read(fd, file_buf, s);
+			file_buf[s] = '\0';
+			close(fd);
+			info.pss_policies_json = file_buf;
+		}
+	} else {
+		info.pss_policies_json = default_ss_policy;
+	}
+	
 	info.options = LWS_SERVER_OPTION_EXPLICIT_VHOSTS |
 		       LWS_SERVER_OPTION_H2_JUST_FIX_WINDOW_UPDATE_OVERFLOW |
 		       LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-stress/minimal-secure-streams.c
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-stress/minimal-secure-streams.c
@@ -82,6 +82,8 @@ static unsigned int timeout_ms = 8000;
 static lws_state_notify_link_t nl;
 struct lws_context *context;
 static lws_sorted_usec_list_t sul_timeout; /* for each process to complete */
+static lws_sorted_usec_list_t sul_create;
+
 
 /*
  * If the -proxy app is fulfilling our connection, then we don't need to have
@@ -262,6 +264,13 @@ typedef struct myss {
 static int
 create_ss(struct lws_context *cx);
 
+static void
+sul_create_cb(lws_sorted_usec_list_t *sul)
+{
+	if (budget)
+		create_ss(context);
+}
+
 #if !defined(LWS_SS_USE_SSPC)
 
 static const char *canned_root_token_payload =
@@ -415,7 +424,7 @@ myss_state(void *userobj, void *sh, lws_ss_constate_t state,
 
 	case LWSSSCS_DISCONNECTED: /* attempt is over */
 		if (budget)
-			create_ss(context);
+			lws_sul_schedule(context, 0, &sul_create, sul_create_cb, 1);
 		else
 			interrupted = 1;
 		return LWSSSSRET_DESTROY_ME;
@@ -424,7 +433,7 @@ myss_state(void *userobj, void *sh, lws_ss_constate_t state,
 		lwsl_ss_notice(m->ss, "LWSSSCS_TIMEOUT");
 		bad = 3;
 		if (budget)
-			create_ss(context);
+			lws_sul_schedule(context, 0, &sul_create, sul_create_cb, 1);
 		else
 			interrupted = 1;
 		return LWSSSSRET_DESTROY_ME;
@@ -749,7 +758,7 @@ int main(int argc, const char **argv)
 
 	lws_sul_schedule(context, 0, &sul_timeout, process_timeout,
 			 (lws_usec_t)((lws_usec_t)budget * 3 *
-				       (lws_usec_t)timeout_ms * LWS_US_PER_MS));
+				      (lws_usec_t)timeout_ms * LWS_US_PER_MS));
 
 #if !defined(LWS_SS_USE_SSPC)
 	/*

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt
@@ -16,6 +16,7 @@ require_lws_config(LWS_WITH_SECURE_STREAMS_STATIC_POLICY_ONLY 0 requirements)
 require_lws_config(LWS_WITH_SYS_STATE 1 requirements)
 require_lws_config(USE_WOLFSSL 0 requirements)
 require_lws_config(LWS_WITH_TLS 1 requirements)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
 
 if (requirements)
 	add_executable(${SAMP} minimal-secure-streams-testsfail.c)
@@ -23,17 +24,64 @@ if (requirements)
 	find_program(VALGRIND "valgrind")
 
 	if (LWS_CTEST_INTERNET_AVAILABLE AND NOT WIN32)
+		if ("$ENV{SAI_INSTANCE_IDX}")
+			math(EXPR PORT_TF_SRV "7681 + $ENV{SAI_INSTANCE_IDX}")
+			math(EXPR PORT_TF_SRV_TLS "7682 + $ENV{SAI_INSTANCE_IDX}")
+			math(EXPR PORT_TF_SRV_B_HOST "7683 + $ENV{SAI_INSTANCE_IDX}")
+			math(EXPR PORT_TF_SRV_B_EXP "7684 + $ENV{SAI_INSTANCE_IDX}")
+			math(EXPR PORT_TF_SRV_B_SELF "7685 + $ENV{SAI_INSTANCE_IDX}")
+		else()
+			set(PORT_TF_SRV "7681")
+			set(PORT_TF_SRV_TLS "7682")
+			set(PORT_TF_SRV_B_HOST "7683")
+			set(PORT_TF_SRV_B_EXP "7684")
+			set(PORT_TF_SRV_B_SELF "7685")
+		endif()
+
+		configure_file(policy-local.json.in policy-local.json @ONLY)
+
 		if (VALGRIND)
 			add_test(NAME ss-tf COMMAND
 				${VALGRIND} --tool=memcheck --leak-check=yes --num-callers=20
-				$<TARGET_FILE:lws-minimal-secure-streams-testsfail>)
+				$<TARGET_FILE:lws-minimal-secure-streams-testsfail>
+				-c ${CMAKE_CURRENT_BINARY_DIR}/policy-local.json)
 		else()
-			add_test(NAME ss-tf COMMAND lws-minimal-secure-streams-testsfail)
+			add_test(NAME ss-tf COMMAND $<TARGET_FILE:lws-minimal-secure-streams-testsfail>
+				-c ${CMAKE_CURRENT_BINARY_DIR}/policy-local.json)
 		endif()
+
+		#
+		# Spin up the local fixtures
+		#
+		add_test(NAME st_hbin COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh hbin $<TARGET_FILE:lws-minimal-http-server-httpbin> -p ${PORT_TF_SRV})
+		add_test(NAME ki_hbin COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hbin $<TARGET_FILE_NAME:lws-minimal-http-server-httpbin> -p ${PORT_TF_SRV})
+		set_tests_properties(st_hbin PROPERTIES WORKING_DIRECTORY . FIXTURES_SETUP hbin TIMEOUT 800 ENVIRONMENT "SAI_LIST_PORT=${PORT_TF_SRV}")
+		set_tests_properties(ki_hbin PROPERTIES FIXTURES_CLEANUP hbin)
+
+		add_test(NAME st_hbin_tls COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh hbin_tls $<TARGET_FILE:lws-minimal-http-server-httpbin> -s -p ${PORT_TF_SRV_TLS})
+		add_test(NAME ki_hbin_tls COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hbin_tls $<TARGET_FILE_NAME:lws-minimal-http-server-httpbin> -p ${PORT_TF_SRV_TLS})
+		set_tests_properties(st_hbin_tls PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-server/minimal-http-server-tls FIXTURES_SETUP hbin_tls TIMEOUT 800 ENVIRONMENT "SAI_LIST_PORT=${PORT_TF_SRV_TLS}")
+		set_tests_properties(ki_hbin_tls PROPERTIES FIXTURES_CLEANUP hbin_tls)
+
+		add_test(NAME st_hbin_b_host COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh hbin_b_host $<TARGET_FILE:lws-minimal-http-server-tls> -p ${PORT_TF_SRV_B_HOST})
+		add_test(NAME ki_hbin_b_host COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hbin_b_host $<TARGET_FILE_NAME:lws-minimal-http-server-tls> -p ${PORT_TF_SRV_B_HOST})
+		set_tests_properties(st_hbin_b_host PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-server/minimal-http-server-tls FIXTURES_SETUP hbin_b_host TIMEOUT 800 ENVIRONMENT "SAI_LIST_PORT=${PORT_TF_SRV_B_HOST}")
+		set_tests_properties(ki_hbin_b_host PROPERTIES FIXTURES_CLEANUP hbin_b_host)
+
+		add_test(NAME st_hbin_b_exp COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh hbin_b_exp $<TARGET_FILE:lws-minimal-http-server-tls> -p ${PORT_TF_SRV_B_EXP})
+		add_test(NAME ki_hbin_b_exp COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hbin_b_exp $<TARGET_FILE_NAME:lws-minimal-http-server-tls> -p ${PORT_TF_SRV_B_EXP})
+		set_tests_properties(st_hbin_b_exp PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-server/minimal-http-server-tls FIXTURES_SETUP hbin_b_exp TIMEOUT 800 ENVIRONMENT "SAI_LIST_PORT=${PORT_TF_SRV_B_EXP}")
+		set_tests_properties(ki_hbin_b_exp PROPERTIES FIXTURES_CLEANUP hbin_b_exp)
+
+		add_test(NAME st_hbin_b_self COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh hbin_b_self $<TARGET_FILE:lws-minimal-http-server-tls> -p ${PORT_TF_SRV_B_SELF})
+		add_test(NAME ki_hbin_b_self COMMAND ${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh hbin_b_self $<TARGET_FILE_NAME:lws-minimal-http-server-tls> -p ${PORT_TF_SRV_B_SELF})
+		set_tests_properties(st_hbin_b_self PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/http-server/minimal-http-server-tls FIXTURES_SETUP hbin_b_self TIMEOUT 800 ENVIRONMENT "SAI_LIST_PORT=${PORT_TF_SRV_B_SELF}")
+		set_tests_properties(ki_hbin_b_self PROPERTIES FIXTURES_CLEANUP hbin_b_self)
 
 		set_tests_properties(ss-tf
 				     PROPERTIES
 				     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail
+				     FIXTURES_REQUIRED "hbin;hbin_tls;hbin_b_host;hbin_b_exp;hbin_b_self"
 				     TIMEOUT 640)
 
 		if (HAS_LWS_WITH_SECURE_STREAMS_PROXY_API OR LWS_WITH_SECURE_STREAMS_PROXY_API)
@@ -58,8 +106,9 @@ if (requirements)
 			add_test(NAME st_sstfproxy COMMAND
 				${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
 				sstfproxy $<TARGET_FILE:lws-minimal-secure-streams-proxy>
+				-c ${CMAKE_CURRENT_BINARY_DIR}/policy-local.json
 				-i ${CTEST_SOCKET_PATH}  -d1039)
-			set_tests_properties(st_sstfproxy PROPERTIES WORKING_DIRECTORY . FIXTURES_SETUP sstfproxy TIMEOUT 800)
+			set_tests_properties(st_sstfproxy PROPERTIES WORKING_DIRECTORY . FIXTURES_SETUP sstfproxy FIXTURES_REQUIRED "hbin;hbin_tls;hbin_b_host;hbin_b_exp;hbin_b_self" TIMEOUT 800)
 
 			add_test(NAME ki_sstfproxy COMMAND
 				${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh
@@ -76,12 +125,12 @@ if (requirements)
 					${VALGRIND} --tool=memcheck --leak-check=yes --num-callers=20
 					$<TARGET_FILE:lws-minimal-secure-streams-testsfail-client> -i +${CTEST_SOCKET_PATH} -d1039)
 			else()
-				add_test(NAME sspc-minimaltf COMMAND lws-minimal-secure-streams-testsfail-client -i +${CTEST_SOCKET_PATH} -d1039)
+				add_test(NAME sspc-minimaltf COMMAND $<TARGET_FILE:lws-minimal-secure-streams-testsfail-client> -i +${CTEST_SOCKET_PATH} -d1039)
 			endif()
 		
 			set_tests_properties(sspc-minimaltf PROPERTIES
 				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail
-				FIXTURES_REQUIRED "sstfproxy"
+				FIXTURES_REQUIRED "sstfproxy;hbin;hbin_tls;hbin_b_host;hbin_b_exp;hbin_b_self"
 				TIMEOUT 640)
 
 		endif()

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/minimal-secure-streams-testsfail.c
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/minimal-secure-streams-testsfail.c
@@ -17,6 +17,7 @@
 #include <libwebsockets.h>
 
 enum {
+	LWS_SW_C,
 	LWS_SW_AMOUNT,
 	LWS_SW_A,
 	LWS_SW_I,
@@ -25,6 +26,7 @@ enum {
 };
 
 static const struct lws_switches switches[] = {
+	[LWS_SW_C]	= { "-c",              "Policy filepath" },
 	[LWS_SW_AMOUNT]	= { "--amount",        "Amount of something" },
 	[LWS_SW_A]	= { "-a",              "Enable -a feature" },
 	[LWS_SW_I]	= { "-i",              "Interface to bind to" },
@@ -230,8 +232,8 @@ static const char * const default_ss_policy =
 		 */
 
 		    "\"t_h1\": {"
-			"\"endpoint\": \"libwebsockets.org\","
-			"\"port\": 8080,"
+			"\"endpoint\": \"127.0.0.1\","
+			"\"port\": 7681,"
 			"\"protocol\": \"h1\","
 			"\"http_method\": \"GET\","
 			"\"http_url\": \"/status/200\","
@@ -271,8 +273,8 @@ static const char * const default_ss_policy =
 		 */
 
 		    "\"d_h1\": {"
-			"\"endpoint\": \"libwebsockets.org\","
-			"\"port\": 8080,"
+			"\"endpoint\": \"127.0.0.1\","
+			"\"port\": 7681,"
 			"\"protocol\": \"h1\","
 			"\"http_method\": \"GET\","
 			"\"http_url\": \"/delay/10\","
@@ -353,11 +355,11 @@ static const char * const default_ss_policy =
 		 */
 
 		    "\"bulk_h1\": {"
-			"\"endpoint\": \"libwebsockets.org\","
-			"\"port\": 8080,"
+			"\"endpoint\": \"127.0.0.1\","
+			"\"port\": 7681,"
 			"\"protocol\": \"h1\","
 			"\"http_method\": \"GET\","
-			"\"http_url\": \"bytes/${amount}\","
+			"\"http_url\": \"/bytes/${amount}\","
 			"\"metadata\": [{"
 					"\"amount\": \"\""
 				"}],"
@@ -933,7 +935,11 @@ main(int argc, const char **argv)
 	tests_seq[12].eom_pass = tests_seq[13].eom_pass =
 					tests_seq[14].eom_pass = amount;
 #if !defined(LWS_SS_USE_SSPC)
-	// puts(default_ss_policy);
+	if ((pp = lws_cmdline_option(argc, argv, switches[LWS_SW_C].sw))) {
+		info.pss_policies_json = pp;
+	} else {
+		info.pss_policies_json = default_ss_policy;
+	}
 #endif
 
 	lwsl_user("LWS secure streams error path tests [-d<verb>]\n");
@@ -963,7 +969,6 @@ main(int argc, const char **argv)
 			info.ss_proxy_address = p;
 	}
 #else
-	info.pss_policies_json = default_ss_policy;
 	info.options = LWS_SERVER_OPTION_EXPLICIT_VHOSTS |
 		       LWS_SERVER_OPTION_H2_JUST_FIX_WINDOW_UPDATE_OVERFLOW |
 		       LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;

--- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/policy-local.json.in
+++ b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/policy-local.json.in
@@ -1,0 +1,283 @@
+{
+  "release": "01234567",
+  "product": "myproduct",
+  "schema-version": 1,
+  "retry": [
+    {
+      "default": {
+        "backoff": [
+          1000,
+          2000,
+          3000,
+          5000,
+          10000
+        ],
+        "conceal": 5,
+        "jitterpc": 20,
+        "svalidping": 30,
+        "svalidhup": 35
+      }
+    }
+  ],
+  "certs": [
+    {
+      "isrg_root_x1": "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAwTzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2VhcmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygch77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6UA5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sWT8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyHB5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UCB5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUvKBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWnOlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTnjh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbwqHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CIrU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkqhkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZLubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KKNFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7UrTkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdCjNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVcoyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPAmRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57demyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc="
+    },
+    {
+      "isrg_root_x2": "MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBTZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW+1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZIzj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdWtL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1/q4AaOeMSQ+2b1tbFfLn"
+    },
+    {
+      "amazon_root_ca_1": "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsFADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTELMAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJvb3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXjca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qwIFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQmjgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUAA4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDIU5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUsN+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vvo/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpyrqXRfboQnoZsG4q5WTP468SQvvG5"
+    },
+    {
+      "localhost_100y": "MIIF5jCCA86gAwIBAgIJANq50IuwPFKgMA0GCSqGSIb3DQEBCwUAMIGGMQswCQYDVQQGEwJHQjEQMA4GA1UECAwHRXJld2hvbjETMBEGA1UEBwwKQWxsIGFyb3VuZDEbMBkGA1UECgwSbGlid2Vic29ja2V0cy10ZXN0MRIwEAYDVQQDDAlsb2NhbGhvc3QxHzAdBgkqhkiG9w0BCQEWEG5vbmVAaW52YWxpZC5vcmcwIBcNMTgwMzIwMDQxNjA3WhgPMjExODAyMjQwNDE2MDdaMIGGMQswCQYDVQQGEwJHQjEQMA4GA1UECAwHRXJld2hvbjETMBEGA1UEBwwKQWxsIGFyb3VuZDEbMBkGA1UECgwSbGlid2Vic29ja2V0cy10ZXN0MRIwEAYDVQQDDAlsb2NhbGhvc3QxHzAdBgkqhkiG9w0BCQEWEG5vbmVAaW52YWxpZC5vcmcwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCjYtuWaICCY0tJPubxpIgIL+WWmz/fmK8IQr11Wtee6/IUyUlo5I602mq1qcLhT/kmpoR8Di3DAmHKnSWdPWtn1BtXLErLlUiHgZDrZWInmEBjKM1DZf+CvNGZ+EzPgBv5nTekLWcfI5ZZtoGuIP1Dl/IkNDw8zFz4cpiMe/BFGemyxdHhLrKHSm8Eo+nT734tItnHKT/m6DSU0xlZ13d6ehLRm7/+Nx47M3XMTRH5qKP/7TTE2s0U6+M0tsGI2zpRi+m6jzhNyMBTJ1u58qAe3ZW5/+YAiuZYAB6n5bhUp4oFuB5wYbcBywVR8ujInpF8buWQUjy5N8pSNp7szdYsnLJpvAd0sibrNPjC0FQCNrpNjgJmIK3+mKk4kXX7ZTwefoAzTK4l2pHNuC53QVc/EF++GBLAxmvCDq9ZpMIYi7OmzkkAKKC9Ue6Ef217LFQCFIBKIzv9cgi9fwPMLhrKleoVRNsecBsCP569WgJXhUnwf2lon4fEZr3+vRuc9shfqnV0nPN1IMSnzXCast7I2fiuRXdIz96KjlGQpP4XfNVA+RGL7aMnWOFIaVrKWLzAtgzoGMTvP/AuehKXncBJhYtW0ltTioVx+5yTYSAZWl+IssmXjefxJqYi2/7QWmv1QC9psNcjTMaBQLN03T1Qelbs7Y27sxdEnNUth4kI+wIDAQABo1MwUTAdBgNVHQ4EFgQU9mYU23tW2zsomkKTAXarjr2vjuswHwYDVR0jBBgwFoAU9mYU23tW2zsomkKTAXarjr2vjuswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEANjIBMrowYNCbhAJdP7dhlhT2RUFRdeRUJD0IxrH/hkvb6myHHnK8nOYezFPjUlmRKUgNEDuAxbnXZzPdCRNV9V2mShbXvCyiDY7WCQE2Bn44z26O0uWVk+7DNNLH9BnkwUtOnM9PwtmD9phWexm4q2GnTsiL6Ul6cy0QlTJWKVLEUQQ6yda582e23J1AXqtqFcpfoE34H3afEiGy882b+ZBiwkeV+oq6XVF8sFyr9zYrv9CvWTYlkpTQfLTZSsgPdEHYVcjvxQ2D+XyDR0aRLRlvxUa9dHGFHLICG34Juq5Ai6lM1EsoD8HSsJpMcmrH7MWw2cKkujC3rMdFTtte83wF1uuF4FjUC72+SmcQN7A386BC/nk2TTsJawTDzqwOu/VdZv2g1WpTHlumlClZeP+G/jkSyDwqNnTu1aodDmUa4xZodfhP1HWPwUKFcq8oQr148QYAAOlbUOJQU7QwRWd1VbnwhDtQWXC92A2w1n/xkZSR1BM/NUSDhkBSUU1WjMbWg6GgmnIZLRerQCu1Oozr87rOQqQakPkyt8BUSNK3K42j2qcfhAONdRl8Hq8Qs5pupy+s8sdCGDlwR3JNCMv6u48OK87F4mcIxhkSefFJUFII25pCGN5WtE4p5l+9cnO1GrIXe2Hl/7M0c/lbZ4FvXgARlex2rkgS0Ka06HE="
+    }
+  ],
+  "trust_stores": [
+    {
+      "name": "arca1",
+      "stack": [
+        "amazon_root_ca_1"
+      ]
+    },
+    {
+      "name": "le_via_isrg",
+      "stack": [
+        "isrg_root_x1",
+        "isrg_root_x2"
+      ]
+    },
+    {
+      "name": "local_test",
+      "stack": [
+        "localhost_100y"
+      ]
+    }
+  ],
+  "s": [
+    {
+      "captive_portal_detect": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "status/204",
+        "opportunistic": true,
+        "http_expect": 204,
+        "http_fail_redirect": true
+      }
+    },
+    {
+      "t_h1": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/status/200",
+        "timeout_ms": 10000,
+        "retry": "default"
+      }
+    },
+    {
+      "t_h1_tls": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_TLS@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/httpbin/status/200",
+        "tls": true,
+        "retry": "default",
+        "timeout_ms": 10000,
+        "tls_trust_store": "local_test"
+      }
+    },
+    {
+      "t_h2_tls": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_TLS@,
+        "protocol": "h2",
+        "http_method": "GET",
+        "http_url": "/httpbin/status/200",
+        "tls": true,
+        "nghttp2_quirk_end_stream": true,
+        "h2q_oflow_txcr": true,
+        "timeout_ms": 10000,
+        "retry": "default",
+        "tls_trust_store": "local_test"
+      }
+    },
+    {
+      "d_h1": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/delay/10",
+        "timeout_ms": 3000,
+        "retry": "default"
+      }
+    },
+    {
+      "d_h1_tls": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_TLS@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/httpbin/delay/10",
+        "tls": true,
+        "timeout_ms": 3000,
+        "retry": "default",
+        "tls_trust_store": "local_test"
+      }
+    },
+    {
+      "d_h2_tls": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_TLS@,
+        "protocol": "h2",
+        "http_method": "GET",
+        "http_url": "/httpbin/delay/15",
+        "tls": true,
+        "nghttp2_quirk_end_stream": true,
+        "h2q_oflow_txcr": true,
+        "timeout_ms": 3000,
+        "retry": "default",
+        "tls_trust_store": "local_test"
+      }
+    },
+    {
+      "nxd_h1": {
+        "endpoint": "bogus.nope",
+        "port": 80,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/status/200",
+        "timeout_ms": 5000,
+        "retry": "default"
+      }
+    },
+    {
+      "nxd_h1_tls": {
+        "endpoint": "bogus.nope",
+        "port": 443,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/status/200",
+        "tls": true,
+        "timeout_ms": 5000,
+        "retry": "default",
+        "tls_trust_store": "arca1"
+      }
+    },
+    {
+      "nxd_h2_tls": {
+        "endpoint": "bogus.nope",
+        "port": 443,
+        "protocol": "h2",
+        "http_method": "GET",
+        "http_url": "/status/200",
+        "tls": true,
+        "nghttp2_quirk_end_stream": true,
+        "h2q_oflow_txcr": true,
+        "timeout_ms": 5000,
+        "retry": "default",
+        "tls_trust_store": "arca1"
+      }
+    },
+    {
+      "bulk_h1": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/bytes/${amount}",
+        "metadata": [
+          {
+            "amount": ""
+          }
+        ],
+        "timeout_ms": 10000,
+        "retry": "default"
+      }
+    },
+    {
+      "bulk_h1_tls": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_TLS@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/httpbin/bytes/${amount}",
+        "metadata": [
+          {
+            "amount": ""
+          }
+        ],
+        "tls": true,
+        "timeout_ms": 10000,
+        "retry": "default",
+        "tls_trust_store": "local_test"
+      }
+    },
+    {
+      "bulk_h2_tls": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_TLS@,
+        "protocol": "h2",
+        "http_method": "GET",
+        "http_url": "/httpbin/bytes/${amount}",
+        "metadata": [
+          {
+            "amount": ""
+          }
+        ],
+        "tls": true,
+        "nghttp2_quirk_end_stream": true,
+        "h2q_oflow_txcr": true,
+        "timeout_ms": 10000,
+        "retry": "default",
+        "tls_trust_store": "local_test"
+      }
+    },
+    {
+      "badcert_hostname": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_B_HOST@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/",
+        "tls": true,
+        "timeout_ms": 3000,
+        "retry": "default",
+        "tls_trust_store": "le_via_isrg"
+      }
+    },
+    {
+      "badcert_expired": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_B_EXP@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/",
+        "tls": true,
+        "retry": "default",
+        "timeout_ms": 3000,
+        "tls_trust_store": "le_via_isrg"
+      }
+    },
+    {
+      "badcert_selfsigned": {
+        "endpoint": "localhost",
+        "port": @PORT_TF_SRV_B_SELF@,
+        "protocol": "h1",
+        "http_method": "GET",
+        "http_url": "/",
+        "tls": true,
+        "nghttp2_quirk_end_stream": true,
+        "h2q_oflow_txcr": true,
+        "timeout_ms": 5000,
+        "retry": "default",
+        "tls_trust_store": "le_via_isrg"
+      }
+    }
+  ]
+}

--- a/minimal-examples-lowlevel/ws-client/minimal-ws-client-rx/CMakeLists.txt
+++ b/minimal-examples-lowlevel/ws-client/minimal-ws-client-rx/CMakeLists.txt
@@ -14,11 +14,34 @@ require_lws_config(LWS_WITH_CLIENT 1 requirements)
 
 if (requirements)
 	add_executable(${SAMP} ${SRCS})
-	if (LWS_CTEST_INTERNET_AVAILABLE)
-		add_test(NAME ws-client-rx-warmcat COMMAND lws-minimal-ws-client-rx -t)
+	set(PORT_WSC_RX_SRV "7280")
+	if ("$ENV{SAI_INSTANCE_IDX}")
+		math(EXPR PORT_WSC_RX_SRV "7281 + $ENV{SAI_INSTANCE_IDX}")
+	endif()
+
+	if (NOT WIN32 AND LWS_WITH_SERVER AND LWS_WITH_TLS)
+		add_test(NAME st_wsc_rx_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background.sh
+					wsc_rx_srv
+					$<TARGET_FILE:test-server>
+					-r ${CMAKE_BINARY_DIR}/share/libwebsockets-test-server/
+					-s --port ${PORT_WSC_RX_SRV} )
+		add_test(NAME ki_wsc_rx_srv COMMAND
+			${CMAKE_SOURCE_DIR}/scripts/ctest-background-kill.sh wsc_rx_srv
+					$<TARGET_FILE_NAME:test-server> --port ${PORT_WSC_RX_SRV})
+
+		set_tests_properties(st_wsc_rx_srv PROPERTIES
+							 WORKING_DIRECTORY .
+							 FIXTURES_SETUP wsc_rx_srv
+							 TIMEOUT 800)
+		set_tests_properties(ki_wsc_rx_srv PROPERTIES
+							 FIXTURES_CLEANUP wsc_rx_srv)
+
+		add_test(NAME ws-client-rx-warmcat COMMAND lws-minimal-ws-client-rx -t -l --server localhost -p ${PORT_WSC_RX_SRV})
 		set_tests_properties(ws-client-rx-warmcat
 				     PROPERTIES
 				     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/minimal-examples-lowlevel/ws-client/minimal-ws-client-rx
+				     FIXTURES_REQUIRED "wsc_rx_srv"
 				     TIMEOUT 20)
 
 	endif()

--- a/minimal-examples-lowlevel/ws-client/minimal-ws-client-rx/minimal-ws-client.c
+++ b/minimal-examples-lowlevel/ws-client/minimal-ws-client-rx/minimal-ws-client.c
@@ -19,12 +19,18 @@
 enum {
 	LWS_SW_D,
 	LWS_SW_T,
+	LWS_SW_SERVER,
+	LWS_SW_PORT,
+	LWS_SW_L,
 	LWS_SW_HELP,
 };
 
 static const struct lws_switches switches[] = {
 	[LWS_SW_D]	= { "-d",              "Debug logs (e.g. -d 15)" },
 	[LWS_SW_T]	= { "-t",              "Test flag" },
+	[LWS_SW_SERVER]	= { "--server",        "Server address to connect to" },
+	[LWS_SW_PORT]	= { "-p",              "Port to connect to" },
+	[LWS_SW_L]	= { "-l",              "localhost / selfsigned" },
 	[LWS_SW_HELP]	= { "--help",		"Show this help information" },
 };
 
@@ -89,6 +95,7 @@ int main(int argc, const char **argv)
 	struct lws_context_creation_info info;
 	struct lws_client_connect_info i;
 	struct lws_context *context;
+	const char *p;
 	int n = 0;
 	(void)switches;
 
@@ -138,10 +145,21 @@ int main(int argc, const char **argv)
 	i.context = context;
 	i.port = 443;
 	i.address = "libwebsockets.org";
+
+	if ((p = lws_cmdline_option(argc, argv, switches[LWS_SW_SERVER].sw)))
+		i.address = p;
+
+	if ((p = lws_cmdline_option(argc, argv, switches[LWS_SW_PORT].sw)))
+		i.port = atoi(p);
+
 	i.path = "/";
 	i.host = i.address;
 	i.origin = i.address;
 	i.ssl_connection = LCCSCF_USE_SSL;
+
+	if (lws_cmdline_option(argc, argv, switches[LWS_SW_L].sw))
+		i.ssl_connection |= LCCSCF_ALLOW_SELFSIGNED;
+
 	i.protocol = protocols[0].name; /* "dumb-increment-protocol" */
 	i.pwsi = &client_wsi;
 

--- a/scripts/ctest-background.sh
+++ b/scripts/ctest-background.sh
@@ -27,7 +27,7 @@ fi
 # We shift off $1 (the background fixture name) so that "$@" contains only the executable and its args.
 shift
 
-"$@" 2>/tmp/ctest-background-$J 1>/dev/null 0</dev/null &
+"$@" -d1039 2>/tmp/ctest-background-$J 1>/dev/null 0</dev/null &
 echo $! > /tmp/sai-ctest-$J
 
 # really we want to loop until the listen port is up
@@ -64,6 +64,7 @@ else
 				ps -fp $! >&2
 				echo "Background process logs:" >&2
 				cat /tmp/ctest-background-$J >&2
+				kill -9 $! 2>/dev/null
 				exit 1
 			fi
 			if [ $((CNT % 10)) -eq 0 ] ; then
@@ -76,9 +77,9 @@ else
 		CNT=0
 		while true ; do
 			if [ -n "$SAI_LIST_IS_UDP" ] ; then
-				MATCH="`netstat -lun4 | tr -s ' ' | grep ":${SAI_LIST_PORT} "`"
+				MATCH="`netstat -an | grep "^udp" | tr -s ' ' | grep "[\.:]${SAI_LIST_PORT} "`"
 			else
-				MATCH="`netstat -ltn4 | tr -s ' ' | grep ":${SAI_LIST_PORT} .*LISTEN"`"
+				MATCH="`netstat -an | grep "^tcp" | tr -s ' ' | grep "[\.:]${SAI_LIST_PORT} " | grep LISTEN`"
 			fi
 			if [ -n "$MATCH" ] ; then break ; fi
 			if ! kill -0 $! 2>/dev/null ; then
@@ -94,7 +95,8 @@ else
 				echo "Background process logs:" >&2
 				cat /tmp/ctest-background-$J >&2
 				echo "Netstat output:" >&2
-				netstat -ltun4 >&2
+				netstat -an >&2
+				kill -9 $! 2>/dev/null
 				exit 1
 			fi
 			if [ $((CNT % 10)) -eq 0 ] ; then

--- a/test-apps/test-server.c
+++ b/test-apps/test-server.c
@@ -401,6 +401,8 @@ int main(int argc, char **argv)
 	 */
 	memset(&info, 0, sizeof info);
 	info.port = 7681;
+	info.max_http_header_data = 8192;
+	info.max_http_header_pool = 64;
 
 	while (n >= 0) {
 #if defined(LWS_HAS_GETOPT_LONG) || defined(WIN32)


### PR DESCRIPTION
In the numeric-address fast path of `lws_async_dns_query()`, the `m == 4` (IPv4) branch derives `ai`/`sa46` from the cache entry `c`, but the `m == 16` (IPv6) branch uses them without deriving. When the cache entry already exists (the allocation block isn't entered), `ai`/`sa46` are uninitialized — GCC flags this as `-Werror=maybe-uninitialized` with `LWS_WITH_IPV6` enabled.

Derive `ai`/`sa46` from `c` in the IPv6 branch, exactly as the IPv4 branch just above does.
