### PR TITLE
mbedTLS 4 / ESP-IDF v6 build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,15 @@ set(LWS_WITH_POLL 1)
 if (ESP_PLATFORM AND NOT (DEFINED IDF_TARGET AND IDF_TARGET STREQUAL "linux"))
 	set(LWS_ESP_PLATFORM 1)
 	#set(CMAKE_TOOLCHAIN_FILE contrib/cross-esp32.cmake)
-	set(LWIP_PROVIDE_ERRNO 1)
+	# IDF v6 (picolibc + mbedtls 4) makes errno thread-local and its lwip does
+	# not provide an errno of its own. Forcing LWIP_PROVIDE_ERRNO here bakes a
+	# non-TLS `extern int errno` into lws_config_private.h, which then fails to
+	# link against picolibc's TLS errno ("TLS definition ... mismatches non-TLS
+	# reference"). Only force it on older IDF (newlib), detected via the absence
+	# of mbedtls 4.
+	if (NOT LWS_HAVE_MBEDTLS_V4)
+		set(LWIP_PROVIDE_ERRNO 1)
+	endif()
 endif()
 
 # it's at this point any toolchain file is brought in

--- a/include/libwebsockets.h
+++ b/include/libwebsockets.h
@@ -604,7 +604,14 @@ int getsockopt(int sockfd, int level, int optname,
 int connect(int sockfd, const struct sockaddr *addr,
                    socklen_t addrlen);
 
+#if defined(ESP_PLATFORM)
+/* IDF v6 (picolibc) makes errno thread-local; a plain "extern int errno" makes
+ * lws objects reference it non-TLS and fail to link ("TLS definition ...
+ * mismatches non-TLS reference"). Use the platform's real errno. */
+#include <errno.h>
+#else
 extern int errno;
+#endif
 
 uint16_t ntohs(uint16_t netshort);
 uint16_t htons(uint16_t hostshort);

--- a/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
+++ b/lib/tls/mbedtls/wrapper/platform/ssl_pm.c
@@ -20,7 +20,9 @@
 
 /* mbedtls include */
 #include "mbedtls/platform.h"
-#if defined(LWS_HAVE_MBEDTLS_NET_SOCKETS)
+#if defined(LWS_HAVE_MBEDTLS_NET_SOCKETS) || defined(LWS_HAVE_MBEDTLS_V4)
+/* mbedTLS 4 removed the legacy mbedtls/net.h; net_sockets.h still carries
+ * mbedtls_net_context and the MBEDTLS_ERR_NET_* codes even with MBEDTLS_NET_C off */
 #include "mbedtls/net_sockets.h"
 #else
 #include "mbedtls/net.h"
@@ -633,7 +635,7 @@ OSSL_HANDSHAKE_STATE ssl_pm_get_state(const SSL *ssl)
         case MBEDTLS_SSL_SERVER_KEY_EXCHANGE:
             state = TLS_ST_SR_KEY_EXCH;
             break;
-#if defined(LWS_HAVE_MBEDTLS_SSL_NEW_SESSION_TICKET)
+#if defined(LWS_HAVE_MBEDTLS_SSL_NEW_SESSION_TICKET) || defined(LWS_HAVE_MBEDTLS_V4)
         case MBEDTLS_SSL_NEW_SESSION_TICKET:
 #else
         case MBEDTLS_SSL_SERVER_NEW_SESSION_TICKET:


### PR DESCRIPTION
ESP-IDF v6 ships mbedTLS 4 (PSA) and picolibc. Two things stop lws building there:

- The OpenSSL-compat wrapper (ssl_pm.c) keys net_sockets.h vs the v4-removed
  net.h, and the session-ticket enum, off LWS_HAVE_MBEDTLS_NET_SOCKETS /
  LWS_HAVE_MBEDTLS_SSL_NEW_SESSION_TICKET. Those probes don't run on FreeRTOS,
  so the v4 path never activates there.
- picolibc's errno is thread-local; lws's LWIP_PROVIDE_ERRNO and its own
  `extern int errno` are non-TLS, so objects fail to link with
  "TLS definition ... mismatches non-TLS reference".

Both gate on LWS_HAVE_MBEDTLS_V4 (plus ESP_PLATFORM for errno), so v3 and
non-ESP builds are unchanged. On FreeRTOS, LWS_HAVE_MBEDTLS_V4 isn't set by
lws's own probe yet (it doesn't run there), so the integrator sets it for now
(as the esp-protocols component does); making lws detect v4 on FreeRTOS is a
sensible follow-up.

Verified by building the esp-protocols libwebsockets client example on
ESP-IDF v6.0.1 (esp32, mbedTLS 4).