### PR TITLE
cache-ttl: heap: don't spin in eviction loop when lru list is empty

### DIFF
--- a/lib/misc/cache-ttl/heap.c
+++ b/lib/misc/cache-ttl/heap.c
@@ -368,11 +368,12 @@ lws_cache_heap_write(struct lws_cache_ttl_lru *_c, const char *specific_key,
 	 * caching a single large item even if it is above the limits
 	 */
 
-	while ((cache->cache.info.max_footprint &&
+	while (((cache->cache.info.max_footprint &&
 	        cache->cache.current_footprint + size >
 					     cache->cache.info.max_footprint) ||
 	       (cache->cache.info.max_items &&
-		cache->items_lru.count + 1 > cache->cache.info.max_items))
+		cache->items_lru.count + 1 > cache->cache.info.max_items)) &&
+	       cache->items_lru.head)
 		lws_cache_item_evict_lru(cache);
 
 	/* remove any existing entry of the same key */


### PR DESCRIPTION
## Problem

`lws_cache_heap_write()` tries to keep the cache under its limits before inserting a new item:

```c
while ((cache->cache.info.max_footprint &&
        cache->cache.current_footprint + size > cache->cache.info.max_footprint) ||
       (cache->cache.info.max_items &&
        cache->items_lru.count + 1 > cache->cache.info.max_items))
        lws_cache_item_evict_lru(cache);
```

`lws_cache_item_evict_lru()` silently returns without doing anything when the lru list is empty. So if the loop condition is still true after the cache has been fully emptied — eg, a single item with `size` larger than `max_footprint` — the condition never changes and the loop spins forever, wedging the service thread at 100% CPU inside the write, never returning to the event loop.

This is not just theoretical: we hit it in production through the context ALPN cache (`max_footprint` 4096, written on every TLS client handshake). On lws versions that predate the `current_footprint` accounting fix that landed as part of 5087313 ("mbedtls-quic-OOT"), `current_footprint` was incremented by the *uninitialized* `item->size` before it was assigned, so the footprint got corrupted upwards over time and the eviction loop eventually spun with an empty lru list after a few dozen successful client handshakes (stack: `lws_tls_client_connect` → ALPN cache write → `lws_cache_heap_write`, process pinned at 100% CPU, event loop starved). Current main has the accounting fixed, but the unguarded loop remains reachable via the single-large-item case, and is a footgun for any future accounting drift.

## Fix

Bail out of the eviction loop once the lru list is empty. This also makes the existing comment above the loop — "this will always allow caching a single large item even if it is above the limits" — actually hold; before this change that case hung instead of being allowed.

Verified on a txiki.js-based runtime (lws client + mbedtls) where the spin was reproducible within a handful of HTTPS fetches on the affected versions: with the guard the same workload (400 sequential HTTPS fetches, plus the original ~320-profile proxy-probe workload that uncovered it) completes without the hang.
