### PR TITLE
cookie: fix stash-NULL crash in lws_cookie_attach_cookies

### DIFF
--- a/lib/roles/http/cookie.c
+++ b/lib/roles/http/cookie.c
@@ -472,10 +472,37 @@ lws_cookie_attach_cookies(struct lws *wsi, char *buf, char *end)
 	if (!wsi)
 		return -1;
 
-	stash = wsi->stash ? wsi->stash : lws_get_network_wsi(wsi)->stash;
-	if (!stash || (!stash->cis[CIS_HOST] && !stash->cis[CIS_ADDRESS]) ||
-			   !stash->cis[CIS_PATH])
-		return -1;
+	/*
+	 * stash is only guaranteed during the connect phase; lws frees it
+	 * early when LWS_WITH_SOCKS5 is on. Fall back to HTTP headers
+	 * (same pattern as lws_cookie_write_nsc()).
+	 */
+	{
+		const char *fb_domain, *fb_path;
+
+		stash = wsi->stash ? wsi->stash :
+			lws_get_network_wsi(wsi)->stash;
+		if (stash && stash->cis[CIS_HOST] &&
+			    stash->cis[CIS_PATH]) {
+			fb_domain = stash->cis[CIS_HOST] ?
+				stash->cis[CIS_HOST] :
+				stash->cis[CIS_ADDRESS];
+			fb_path   = stash->cis[CIS_PATH];
+		} else {
+			fb_domain = lws_hdr_simple_ptr(wsi,
+					_WSI_TOKEN_CLIENT_HOST);
+			if (!fb_domain)
+				fb_domain = lws_hdr_simple_ptr(wsi,
+					_WSI_TOKEN_CLIENT_PEER_ADDRESS);
+			fb_path = lws_hdr_simple_ptr(wsi,
+					_WSI_TOKEN_CLIENT_URI);
+		}
+		if (!fb_domain || !fb_path)
+			return -1;
+
+		domain = fb_domain;
+		path = fb_path;
+	}
 
 	l1 = wsi->a.context->l1;
 	if (!l1 || !wsi->a.context->nsc){
@@ -484,9 +511,6 @@ lws_cookie_attach_cookies(struct lws *wsi, char *buf, char *end)
 	}
 
 	memset(&c, 0, sizeof(c));
-
-	domain = stash->cis[CIS_HOST] ? stash->cis[CIS_HOST] : stash->cis[CIS_ADDRESS];
-	path = stash->cis[CIS_PATH];
 
 	if (!domain || !path)
 		return -1;


### PR DESCRIPTION
## Problem

`lws_cookie_attach_cookies()` tries to look up matching cookies from the cookie jar before sending a request, using the wsi's stash for the target host and path:

```c
stash = wsi->stash ? wsi->stash : lws_get_network_wsi(wsi)->stash;
if (!stash || (!stash->cis[CIS_HOST] && !stash->cis[CIS_ADDRESS]) ||
               !stash->cis[CIS_PATH])
        return -1;
```

The stash is freed early in `lws_http_client_connect_via_info2()` when `LWS_WITH_SOCKS5` is enabled (even without an actual SOCKS5 proxy):

```c
#if defined(LWS_WITH_SOCKS5)
        if (!wsi->a.vhost->socks_proxy_port)
                lws_free_set_NULL(wsi->stash);
#endif
```

So by the time the HTTP request headers are assembled and `lws_cookie_send_cookies()` calls `lws_cookie_attach_cookies()`, the stash is already NULL and the function returns -1 without ever querying the cookie jar. The cookie is silently dropped.

This is an asymmetry: `lws_cookie_write_nsc()` — the function that saves cookies from `Set-Cookie` responses — already handles a NULL stash via a fallback to `lws_hdr_simple_ptr()`. The send path was simply missed.

## Fix

Add the same header-based fallback to `lws_cookie_attach_cookies()` that `lws_cookie_write_nsc()` already uses: when the stash is NULL (or its host/path fields are empty), read `_WSI_TOKEN_CLIENT_HOST`, `_WSI_TOKEN_CLIENT_PEER_ADDRESS`, and `_WSI_TOKEN_CLIENT_URI` directly from the wsi's HTTP headers. These were populated from the stash before it was freed, so they carry the same information.