### PR TITLE
Add OpenHiTLS TLS backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ option(LWS_WITH_BEARSSL "Use BearSSL replacement for OpenSSL. When setting this,
 set(LWS_BEARSSL_PROFILE "full" CACHE STRING "BearSSL profile to use (e.g. full, client, minimal)")
 option(LWS_WITH_BORINGSSL "Use BoringSSL replacement for OpenSSL" OFF)
 option(LWS_WITH_AWSLC "Use AWSLC replacement for OpenSSL" OFF)
-option(LWS_WITH_OPENHITLS "Use OpenHITLS replacement for OpenSSL. When setting this, you also may need to specify OPENHITLS_LIBRARIES and OPENHITLS_INCLUDE_DIRS" OFF)
+option(LWS_WITH_OPENHITLS "Use openHITLS replacement for OpenSSL. When setting this, you also may need to specify OPENHITLS_LIBRARIES and OPENHITLS_INCLUDE_DIRS" OFF)
 option(LWS_WITH_CYASSL "Use CyaSSL replacement for OpenSSL. When setting this, you also need to specify LWS_CYASSL_LIBRARIES and LWS_CYASSL_INCLUDE_DIRS" OFF)
 option(LWS_WITH_WOLFSSL "Use wolfSSL replacement for OpenSSL. When setting this, you also may need to specify LWS_WOLFSSL_LIBRARIES and LWS_WOLFSSL_INCLUDE_DIRS" OFF)
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ quic/h3 is enabled for build by default... necessitating GnuTLS instead of OpenS
 | **mbedTLS**   | **Yes** | **Yes** | Needs patch | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** |
 | **SChannel**  | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **No** | **Yes** |
 | **BearSSL**   | **Yes** | **Yes** | **No** | **Yes** | **Yes** | **Yes** | **No** | **Yes** | **Yes** | **Yes** |
-| **OpenHiTLS** | **Yes** | **Yes** | **No** | **Yes** | **Yes** | **Yes** | Yes (not SRTP) | **Yes** | **Yes** | **Yes** |
+| **openHiTLS** | **Yes** | **Yes** | **No** | **Yes** | **Yes** | **Yes** | Yes (not SRTP) | **Yes** | **Yes** | **Yes** |
 
 
 \* *Note: 1) Upstream OpenSSL does not provide the necessary QUIC TLS API (`SSL_set_quic_method`) to act as a cryptographic engine for LWS's QUIC transport. If you need QUIC/HTTP3 support, we recommend using BoringSSL, GnuTLS, WolfSSL, or the `quictls` fork of OpenSSL.*
-\* *Note: 2) OpenHiTLS does not provide the necessary QUIC TLS API *
+\* *Note: 2) openHiTLS does not provide the necessary QUIC TLS API *
 
  - DHT support built-in: `-DLWS_WITH_DHT=1`
 

--- a/READMEs/README.build.md
+++ b/READMEs/README.build.md
@@ -339,7 +339,7 @@ plugins and lwsws.
  - If cpu and memory is not super restricted and you care about TLS speed,
    OpenSSL or a directly compatible variant like Boring SSL is a good choice.
 
- - To build with OpenHITLS (from https://gitcode.com/openhitls/openhitls.git example shown if built in `/opt/openhitls/build`) , use:
+ - To build with openHITLS (from https://gitcode.com/openhitls/openhitls.git example shown if built in `/opt/openhitls/build`) , use:
    `cmake .. -DLWS_WITH_OPENHITLS=1 -DOPENHITLS_INCLUDE_DIRS=/opt/openhitls/include -DOPENHITLS_LIBRARIES=/opt/openhitls/build/libhitls_tls.so;/opt/openhitls/build/libhitls_pki.so;/opt/openhitls/build/libhitls_crypto.so;/opt/openhitls/build/libhitls_bsl.so;/opt/openhitls/build/libhitls_auth.so`
  
 Just building lws against stock Fedora OpenSSL or stock Fedora mbedTLS, for

--- a/lib/tls/CMakeLists.txt
+++ b/lib/tls/CMakeLists.txt
@@ -448,7 +448,7 @@ if (LWS_WITH_SSL)
 		message("OpenHITLS libraries: ${OPENHITLS_LIBRARIES}")
 		if (OPENHITLS_INCLUDE_DIRS)
 			set(LWS_PUBLIC_INCLUDES ${LWS_PUBLIC_INCLUDES} "${OPENHITLS_INCLUDE_DIRS}")
-			# Add the subdirectories that OpenHiTLS headers need
+			# Add the subdirectories that openHiTLS headers need
 			if (EXISTS "${OPENHITLS_INCLUDE_DIRS}/bsl")
 				set(LWS_PUBLIC_INCLUDES ${LWS_PUBLIC_INCLUDES} "${OPENHITLS_INCLUDE_DIRS}/bsl")
 			endif()

--- a/lib/tls/openhitls/lws-genaes.c
+++ b/lib/tls/openhitls/lws-genaes.c
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  *
  *  lws_genaes provides an AES abstraction api in lws that works the
- *  same whether you are using openssl or OpenHiTLS cipher functions underneath.
+ *  same whether you are using openssl or openHiTLS cipher functions underneath.
  */
 #include "private-lib-core.h"
 #include "private.h"
@@ -241,7 +241,7 @@ int lws_genaes_create(struct lws_genaes_ctx *ctx, enum enum_aes_operation op,
 	ctx->taglen = 0;
 	memset(ctx->tag, 0, sizeof(ctx->tag));
 
-	/* engine parameter is not used for OpenHiTLS */
+	/* engine parameter is not used for openHiTLS */
 	(void)engine;
 
 	cipherId = lws_genaes_mode_to_hitls_cipher_id(mode, el->len);

--- a/lib/tls/openhitls/lws-gendtls.c
+++ b/lib/tls/openhitls/lws-gendtls.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * OpenHiTLS generic DTLS operations
+ * openHiTLS generic DTLS operations
  */
 
 #include "private-lib-core.h"
@@ -278,9 +278,9 @@ lws_gendtls_create(struct lws_gendtls_ctx *ctx,
 	ctx->timeout_ms = info->timeout_ms ? info->timeout_ms :
 					     LWS_OPENHITLS_GENDTLS_TIMEOUT_DEFAULT;
 
-	/* OpenHiTLS supports plain DTLS here; DTLS-SRTP is an explicit gap. */
+	/* openHiTLS supports plain DTLS here; DTLS-SRTP is an explicit gap. */
 	if (info->use_srtp) {
-		lwsl_err("%s: OpenHiTLS DTLS-SRTP is not supported\n",
+		lwsl_err("%s: openHiTLS DTLS-SRTP is not supported\n",
 			 __func__);
 		return -1;
 	}

--- a/lib/tls/openhitls/lws-genec.c
+++ b/lib/tls/openhitls/lws-genec.c
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  *
  *  lws_genec provides an EC abstraction api in lws that works the
- *  same whether you are using openssl or OpenHiTLS crypto functions underneath.
+ *  same whether you are using openssl or openHiTLS crypto functions underneath.
  */
 #include "private-lib-core.h"
 #include "private.h"
@@ -118,7 +118,7 @@ lws_ecdsa_sig_der_to_jws(const uint8_t *der_sig, uint32_t der_len, int keybytes,
 	return 0;
 }
 
-/* Initialize OpenHiTLS random number generator if not already done
+/* Initialize openHiTLS random number generator if not already done
  * This is exported for use by lws-genrsa.c as well */
 int lws_hitls_init_rand(void)
 {
@@ -126,7 +126,7 @@ int lws_hitls_init_rand(void)
 		return 0;
 
 	/*
-	 * Prefer OpenHiTLS CTR-DRBG path and tolerate repeat init from
+	 * Prefer openHiTLS CTR-DRBG path and tolerate repeat init from
 	 * other callsites.
 	 */
 	int32_t ret = CRYPT_EAL_RandInit(CRYPT_RAND_SHA256, NULL, NULL,
@@ -154,7 +154,7 @@ lws_genecdh_create(struct lws_genec_ctx *ctx, struct lws_context *context,
 	ctx->context = context;
 	ctx->ctx[0] = NULL;
 	ctx->ctx[1] = NULL;
-	/* Use OpenHiTLS curve table if NULL is passed */
+	/* Use openHiTLS curve table if NULL is passed */
 	ctx->curve_table = curve_table ? curve_table : lws_ec_curves;
 	ctx->genec_alg = LEGENEC_ECDH;
 
@@ -168,7 +168,7 @@ lws_genecdsa_create(struct lws_genec_ctx *ctx, struct lws_context *context,
 	ctx->context = context;
 	ctx->ctx[0] = NULL;
 	ctx->ctx[1] = NULL;
-	/* Use OpenHiTLS curve table if NULL is passed */
+	/* Use openHiTLS curve table if NULL is passed */
 	ctx->curve_table = curve_table ? curve_table : lws_ec_curves;
 	ctx->genec_alg = LEGENEC_ECDSA;
 
@@ -542,10 +542,10 @@ lws_genecdsa_hash_sign_jws(struct lws_genec_ctx *ctx, const uint8_t *in,
 		return -1;
 	}
 
-	/* Sign into temporary buffer - OpenHiTLS returns DER-encoded signature */
+	/* Sign into temporary buffer - openHiTLS returns DER-encoded signature */
 	outLen = sizeof(der_buf);
 
-	/* OpenHiTLS native ECDSA sign */
+	/* openHiTLS native ECDSA sign */
 	ret = CRYPT_EAL_PkeySignData(ctx->ctx[0], in,
 				     (uint32_t)lws_genhash_size(hash_type),
 				     der_buf, &outLen);
@@ -581,7 +581,7 @@ lws_genecdsa_hash_sig_verify_jws(struct lws_genec_ctx *ctx, const uint8_t *in,
 		return -1;
 	}
 
-	/* OpenHiTLS native ECDSA verify */
+	/* openHiTLS native ECDSA verify */
 	uint8_t der_sig[256];
 	int der_len = lws_ecdsa_sig_jws_to_der(sig, keybytes, der_sig, sizeof(der_sig));
 	if (der_len < 0) {
@@ -628,7 +628,7 @@ lws_genecdh_compute_shared_secret(struct lws_genec_ctx *ctx, uint8_t *ss,
 }
 
 /*
- * OpenHiTLS currently exposes CRYPT_PKEY_ED25519 but not CRYPT_PKEY_ED448 in
+ * openHiTLS currently exposes CRYPT_PKEY_ED25519 but not CRYPT_PKEY_ED448 in
  * the public EAL pkey API.  Keep Ed448 as an explicit unsupported boundary.
  */
 #define LWS_OPENHITLS_ED25519_KEYLEN		32
@@ -652,7 +652,7 @@ lws_openhitls_eddsa_alg_from_curve(const struct lws_gencrypto_keyelem *el,
 
 	if ((crv->len == 5 || crv->len == 6) &&
 	    !strncmp((const char *)crv->buf, "Ed448", 5))
-		lwsl_notice("%s: OpenHiTLS Ed448 is not supported\n", __func__);
+		lwsl_notice("%s: openHiTLS Ed448 is not supported\n", __func__);
 
 	return -1;
 }
@@ -670,7 +670,7 @@ lws_openhitls_eddsa_curve_name_to_alg(const char *curve_name,
 	}
 
 	if (!strcmp(curve_name, "Ed448"))
-		lwsl_notice("%s: OpenHiTLS Ed448 is not supported\n", __func__);
+		lwsl_notice("%s: openHiTLS Ed448 is not supported\n", __func__);
 
 	return -1;
 }

--- a/lib/tls/openhitls/lws-genrsa.c
+++ b/lib/tls/openhitls/lws-genrsa.c
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  *
  *  lws_genrsa provides an RSA abstraction api in lws that works the
- *  same whether you are using openssl or OpenHiTLS crypto functions underneath.
+ *  same whether you are using openssl or openHiTLS crypto functions underneath.
  */
 #include "private-lib-core.h"
 #include "private.h"

--- a/lib/tls/openhitls/openhitls-client.c
+++ b/lib/tls/openhitls/openhitls-client.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * OpenHiTLS TLS client implementation
+ * openHiTLS TLS client implementation
  */
 
 #include <hitls_pki_errno.h>
@@ -233,7 +233,7 @@ static int lws_openhitls_store_ctx_set_error(HITLS_CERT_StoreCtx *store_ctx,
 }
 
 /*
- * OpenHiTLS verify callback return convention:
+ * openHiTLS verify callback return convention:
  *   return 0 (HITLS_PKI_SUCCESS) = OK / override and accept
  *   return non-zero              = reject / propagate error
  * Note: the first argument is errCode (0 = cert passed, non-zero = cert failed),
@@ -272,7 +272,7 @@ static int32_t OpenHiTLS_client_verify_callback(int32_t verify_code,
 					HITLS_X509_STORECTX_GET_ERROR, &vr,
 					sizeof(int32_t));
 		if (vr != HITLS_X509_V_OK) {
-			/* OpenHiTLS uses ROOT_CERT_NOT_FOUND for self-signed
+			/* openHiTLS uses ROOT_CERT_NOT_FOUND for self-signed
 			 * certs */
 			if (vr == HITLS_X509_ERR_ROOT_CERT_NOT_FOUND &&
 			    wsi->tls.use_ssl & LCCSCF_ALLOW_SELFSIGNED) {
@@ -372,7 +372,7 @@ static int32_t OpenHiTLS_client_verify_callback(int32_t verify_code,
 		}
 	}
 	/*
-	 * Both lws user callback and OpenHiTLS verify callback use
+	 * Both lws user callback and openHiTLS verify callback use
 	 * 0 = OK, so pass through directly.
 	 *
 	 */
@@ -451,7 +451,7 @@ int lws_ssl_client_bio_create(struct lws *wsi)
 	HITLS_SetVerifyCb(ssl, OpenHiTLS_client_verify_callback);
 
 	/*
-	 * OpenHiTLS may abort the handshake with
+	 * openHiTLS may abort the handshake with
 	 * HITLS_CERT_ERR_VERIFY_CERT_CHAIN before the verify callback is
 	 * ever called (e.g. when the server cert chain cannot be built to a
 	 * trusted root).  Set VerifyNoneSupport so the handshake is allowed
@@ -859,7 +859,7 @@ int lws_tls_client_create_vhost_context(
 			goto bail_cfg;
 		}
 	} else if (cipher_list || info->client_tls_1_3_plus_cipher_list) {
-		lwsl_info("%s: OpenHiTLS ignores OpenSSL cipher-list fields; "
+		lwsl_info("%s: openHiTLS ignores OpenSSL cipher-list fields; "
 			  "use client_tls_ciphers_iana\n", __func__);
 	}
 

--- a/lib/tls/openhitls/openhitls-server.c
+++ b/lib/tls/openhitls/openhitls-server.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * OpenHiTLS TLS server implementation
+ * openHiTLS TLS server implementation
  */
 
 #include "private-lib-core.h"
@@ -57,7 +57,7 @@ lws_openhitls_log_error_string(const char *prefix, const char *subject,
 }
 
 /*
- * OpenHiTLS verify callback return convention:
+ * openHiTLS verify callback return convention:
  *   return 0 = OK / accept
  *   return non-zero = reject / propagate error
  *
@@ -420,7 +420,7 @@ lws_tls_server_vhost_backend_init(const struct lws_context_creation_info *info,
 			return 1;
 		}
 	} else if (info->ssl_cipher_list || info->tls1_3_plus_cipher_list) {
-		lwsl_info("%s: OpenHiTLS ignores OpenSSL cipher-list fields; "
+		lwsl_info("%s: openHiTLS ignores OpenSSL cipher-list fields; "
 			  "use tls_ciphers_iana\n", __func__);
 	}
 
@@ -810,7 +810,7 @@ lws_tls_acme_sni_cert_create(struct lws_vhost *vhost, const char *san_a,
 		goto bail;
 
 	/*
-	 * OpenHiTLS PKI copies ctrl payloads into the cert; the temporary DN
+	 * openHiTLS PKI copies ctrl payloads into the cert; the temporary DN
 	 * and SAN lists remain caller-owned and must be freed after ctrl.
 	 */
 	if (lws_openhitls_prepare_san(&san, san_a, san_b))
@@ -890,7 +890,7 @@ lws_openhitls_csr_add_subject(const char *elements[], HITLS_X509_Csr *csr)
 	for (n = 0; n < LWS_TLS_REQ_ELEMENT_COUNT; n++) {
 		if (dn_cid[n] == BSL_CID_UNKNOWN || !elements[n]) {
 			if (n == LWS_TLS_REQ_ELEMENT_EMAIL && elements[n])
-				lwsl_debug("%s: OpenHiTLS PKI omits email DN\n",
+				lwsl_debug("%s: openHiTLS PKI omits email DN\n",
 					   __func__);
 			continue;
 		}

--- a/lib/tls/openhitls/openhitls-session.c
+++ b/lib/tls/openhitls/openhitls-session.c
@@ -391,7 +391,7 @@ lws_tls_session_dump_save(struct lws_vhost *vh, const char *host, uint16_t port,
 	if (d.blob) {
 		uint32_t used_len = 0;
 		/*
-		 * OpenHiTLS serializes its own native session format here.
+		 * openHiTLS serializes its own native session format here.
 		 * These blobs are intentionally backend-private and are not
 		 * compatible with OpenSSL SSL_SESSION DER.
 		 */
@@ -467,7 +467,7 @@ lws_tls_session_dump_load(struct lws_vhost *vh, const char *host, uint16_t port,
 	if (!sess)
 		goto bail;
 
-	/* See save path: the cold-storage blob is OpenHiTLS-native only. */
+	/* See save path: the cold-storage blob is openHiTLS-native only. */
 	if (d.blob_len > UINT32_MAX ||
 	    HITLS_SESS_Decode(&sess, d.blob, (uint32_t)d.blob_len) !=
 								HITLS_SUCCESS) {

--- a/lib/tls/openhitls/openhitls-ssl.c
+++ b/lib/tls/openhitls/openhitls-ssl.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * OpenHiTLS core SSL/TLS operations
+ * openHiTLS core SSL/TLS operations
  */
 
 #include "private-lib-core.h"
@@ -533,7 +533,7 @@ lws_ssl_context_destroy(struct lws_context *context)
 {
 	(void)context;
 
-	/* OpenHiTLS doesn't require global cleanup */
+	/* openHiTLS doesn't require global cleanup */
 }
 
 lws_tls_ctx *

--- a/lib/tls/openhitls/openhitls-tls.c
+++ b/lib/tls/openhitls/openhitls-tls.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * OpenHiTLS TLS context and global initialization
+ * openHiTLS TLS context and global initialization
  */
 
 #include "private-lib-core.h"
@@ -54,7 +54,7 @@ lws_tls_err_describe_clear(void)
 static void
 lws_openssl_lock_callback(int mode, int type, const char *file, int line)
 {
-	/* OpenHiTLS does not support this locking mechanism */
+	/* openHiTLS does not support this locking mechanism */
 	(void)file;
 	(void)line;
 	(void)mode;
@@ -64,7 +64,7 @@ lws_openssl_lock_callback(int mode, int type, const char *file, int line)
 static unsigned long
 lws_openssl_thread_id(void)
 {
-	/* OpenHiTLS does not support this threading mechanism */
+	/* openHiTLS does not support this threading mechanism */
 	return 0;
 }
 #endif
@@ -95,12 +95,12 @@ lws_context_init_ssl_library(struct lws_context *cx,
 	}
 
 #if defined(LWS_WITH_NETWORK)
-	/* OpenHiTLS does not require ex indexes like OpenSSL */
+	/* openHiTLS does not require ex indexes like OpenSSL */
 #endif
 
 #if LWS_MAX_SMP != 1
 		/*
-		 * OpenHiTLS does not support this locking mechanism
+		 * openHiTLS does not support this locking mechanism
 		 */
 
 		(void)lws_openssl_thread_id;
@@ -119,7 +119,7 @@ lws_context_deinit_ssl_library(struct lws_context *context)
 		return;
 #endif
 	(void)context;
-	/* OpenHiTLS does not require global cleanup */
+	/* openHiTLS does not require global cleanup */
 }
 
 int

--- a/lib/tls/openhitls/private.h
+++ b/lib/tls/openhitls/private.h
@@ -200,7 +200,7 @@ lws_openhitls_apply_cipher_suites(HITLS_Config *config, const char *list,
 	if (!count || bad)
 		return -1;
 
-	/* OpenHiTLS backend now consumes only RFC/IANA suite names from
+	/* openHiTLS backend now consumes only RFC/IANA suite names from
 	 * tls_ciphers_iana / client_tls_ciphers_iana; OpenSSL cipher
 	 * expression and alias conversion is intentionally not provided.
 	 */

--- a/lib/tls/tls.c
+++ b/lib/tls/tls.c
@@ -133,12 +133,12 @@ alpn_cb_openhitls(HITLS_Ctx *ctx, uint8_t **selectedProto,
 				HITLS_ALPN_ERR_OK : HITLS_ALPN_ERR_NOACK;
 
 	if (ret == HITLS_NULL_INPUT || ret == HITLS_CONFIG_INVALID_LENGTH) {
-		lwsl_err("%s: OpenHiTLS ALPN select failed: 0x%x\n",
+		lwsl_err("%s: openHiTLS ALPN select failed: 0x%x\n",
 			 __func__, (unsigned int)ret);
 		return HITLS_ALPN_ERR_ALERT_FATAL;
 	}
 
-	lwsl_info("%s: OpenHiTLS ALPN had no protocol match: 0x%x\n",
+	lwsl_info("%s: openHiTLS ALPN had no protocol match: 0x%x\n",
 		  __func__, (unsigned int)ret);
 
 	return HITLS_ALPN_ERR_NOACK;

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-acme-csr/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-acme-csr/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-acme-csr
  *
- * Focused OpenHiTLS ACME temporary certificate and CSR tests.
+ * Focused openHiTLS ACME temporary certificate and CSR tests.
  */
 
 #include <libwebsockets.h>
@@ -282,7 +282,7 @@ main(int argc, const char **argv)
 		logs = atoi(p);
 
 	lws_set_log_level(logs, NULL);
-	lwsl_user("LWS API selftest: OpenHiTLS ACME CSR\n");
+	lwsl_user("LWS API selftest: openHiTLS ACME CSR\n");
 
 	if (init_openhitls())
 		e = 1;

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-eddsa/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-eddsa/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-eddsa
  *
- * Unit tests for OpenHiTLS EdDSA / OKP generic crypto.
+ * Unit tests for openHiTLS EdDSA / OKP generic crypto.
  */
 
 #include <libwebsockets.h>
@@ -32,8 +32,8 @@ copy_okp_public(struct lws_gencrypto_keyelem *dst,
 static int
 test_ed25519_roundtrip(void)
 {
-	static const uint8_t msg[] = "OpenHiTLS Ed25519 generic signing";
-	static const uint8_t bad_msg[] = "OpenHiTLS Ed25519 bad payload";
+	static const uint8_t msg[] = "openHiTLS Ed25519 generic signing";
+	static const uint8_t bad_msg[] = "openHiTLS Ed25519 bad payload";
 	struct lws_gencrypto_keyelem key[LWS_GENCRYPTO_MAX_KEYEL_COUNT];
 	struct lws_gencrypto_keyelem pub[LWS_GENCRYPTO_MAX_KEYEL_COUNT];
 	struct lws_genec_ctx signer, verifier, imported;

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-genaes/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-genaes/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-genaes
  *
- * Unit tests for the OpenHiTLS AES abstraction layer in
+ * Unit tests for the openHiTLS AES abstraction layer in
  * lib/tls/openhitls/lws-genaes.c
  *
  * Tests:
@@ -476,7 +476,7 @@ main(int argc, const char **argv)
 		logs = atoi(p);
 
 	lws_set_log_level(logs, NULL);
-	lwsl_user("LWS API selftest: OpenHiTLS genaes\n");
+	lwsl_user("LWS API selftest: openHiTLS genaes\n");
 
 	memset(&info, 0, sizeof(info));
 	info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
@@ -509,7 +509,7 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
-	lwsl_user("LWS API selftest: OpenHiTLS genaes (SKIP)\n");
+	lwsl_user("LWS API selftest: openHiTLS genaes (SKIP)\n");
 
 	return 0;
 }

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-gendtls/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-gendtls/main.c
@@ -271,8 +271,8 @@ bail:
 static int
 exchange_appdata(struct lws_gendtls_ctx *client, struct lws_gendtls_ctx *server)
 {
-	static const uint8_t msg1[] = "first OpenHiTLS DTLS record";
-	static const uint8_t msg2[] = "second OpenHiTLS DTLS record";
+	static const uint8_t msg1[] = "first openHiTLS DTLS record";
+	static const uint8_t msg2[] = "second openHiTLS DTLS record";
 	uint8_t rec1[2048], rec2[2048], rx[128];
 	int n1, n2, n3, r1, r2;
 
@@ -381,7 +381,7 @@ main(int argc, const char **argv)
 		};
 
 		if (!lws_gendtls_create(&srtp_ctx, &ci)) {
-			lwsl_err("%s: OpenHiTLS accepted unsupported DTLS-SRTP\n",
+			lwsl_err("%s: openHiTLS accepted unsupported DTLS-SRTP\n",
 				 __func__);
 			lws_gendtls_destroy(&srtp_ctx);
 			goto bail_context;

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-genec/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-genec/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-genec
  *
- * Unit tests for OpenHiTLS EC cryptography (lws-genec.c):
+ * Unit tests for openHiTLS EC cryptography (lws-genec.c):
  *   - ECDH key generation and shared secret computation
  *   - ECDSA sign / verify roundtrip
  *   - Curve interoperability (P-256, P-384)
@@ -599,7 +599,7 @@ main(int argc, const char **argv)
 		logs = atoi(p);
 
 	lws_set_log_level(logs, NULL);
-	lwsl_user("LWS API selftest: OpenHiTLS genec (EC crypto)\n");
+	lwsl_user("LWS API selftest: openHiTLS genec (EC crypto)\n");
 
 	memset(&info, 0, sizeof(info));
 	info.port = CONTEXT_PORT_NO_LISTEN;
@@ -641,7 +641,7 @@ main(int argc, const char **argv)
 int
 main(void)
 {
-	lwsl_user("LWS API selftest: OpenHiTLS genec: skipped "
+	lwsl_user("LWS API selftest: openHiTLS genec: skipped "
 		  "(LWS_WITH_OPENHITLS or LWS_WITH_GENCRYPTO not enabled)\n");
 
 	return 0;

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-genhash/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-genhash/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-genhash
  *
- * unit tests for OpenHiTLS generic hash / HMAC abstraction
+ * unit tests for openHiTLS generic hash / HMAC abstraction
  *
  * Tests lws_genhash_init/update/destroy for MD5, SHA1, SHA256, SHA384, SHA512
  * and lws_genhmac_init/update/destroy for SHA256, SHA384, SHA512.
@@ -449,7 +449,7 @@ main(int argc, const char **argv)
 		logs = atoi(p);
 
 	lws_set_log_level(logs, NULL);
-	lwsl_user("LWS API selftest: OpenHiTLS genhash / genhmac\n");
+	lwsl_user("LWS API selftest: openHiTLS genhash / genhmac\n");
 
 	memset(&info, 0, sizeof(info));
 #if defined(LWS_WITH_NETWORK)

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-genrsa/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-genrsa/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-genrsa
  *
- * Unit tests for OpenHiTLS RSA operations in lib/tls/openhitls/lws-genrsa.c
+ * Unit tests for openHiTLS RSA operations in lib/tls/openhitls/lws-genrsa.c
  *
  * Covers:
  *   - lws_genrsa_new_keypair  (key generation)
@@ -511,7 +511,7 @@ test_sign_verify_pss(struct lws_context *context)
 	n = lws_genrsa_hash_sign(&ctx, hash, LWS_GENHASH_TYPE_SHA256,
 				 sig, key_bytes);
 	if (n < 0) {
-		lwsl_user("    skipped - OpenHiTLS PSS signing unsupported in this build\n");
+		lwsl_user("    skipped - openHiTLS PSS signing unsupported in this build\n");
 		ret = 0;
 		goto bail;
 	}
@@ -639,7 +639,7 @@ main(int argc, const char **argv)
 		logs = atoi(p);
 
 	lws_set_log_level(logs, NULL);
-	lwsl_user("LWS API selftest: OpenHiTLS RSA (lws-genrsa)\n");
+	lwsl_user("LWS API selftest: openHiTLS RSA (lws-genrsa)\n");
 
 	memset(&info, 0, sizeof(info));
 	info.port = CONTEXT_PORT_NO_LISTEN;
@@ -676,7 +676,7 @@ main(int argc, const char **argv)
 int
 main(void)
 {
-	lwsl_user("LWS API selftest: OpenHiTLS RSA - skipped (needs "
+	lwsl_user("LWS API selftest: openHiTLS RSA - skipped (needs "
 		  "LWS_WITH_OPENHITLS && LWS_WITH_GENCRYPTO)\n");
 
 	return 0;

--- a/minimal-examples-lowlevel/api-tests/api-test-openhitls-session-dump/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-openhitls-session-dump/main.c
@@ -1,7 +1,7 @@
 /*
  * lws-api-test-openhitls-session-dump
  *
- * Focused tests for OpenHiTLS session dump/load cold-storage blobs.
+ * Focused tests for openHiTLS session dump/load cold-storage blobs.
  */
 
 #include <libwebsockets.h>
@@ -319,7 +319,7 @@ main(int argc, const char **argv)
 		logs = atoi(p);
 
 	lws_set_log_level(logs, NULL);
-	lwsl_user("LWS API selftest: OpenHiTLS session dump\n");
+	lwsl_user("LWS API selftest: openHiTLS session dump\n");
 
 	if (init_openhitls())
 		e = 1;

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-certfail/minimal-http-client-openhitls-certfail.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-certfail/minimal-http-client-openhitls-certfail.c
@@ -6,13 +6,13 @@
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
  *
- * Verifies OpenHiTLS correctly rejects TLS handshakes when certificate
+ * Verifies openHiTLS correctly rejects TLS handshakes when certificate
  * verification fails:
  *   R6: Self-signed cert rejected without LCCSCF_ALLOW_SELFSIGNED
  *   R7: Hostname mismatch (CN/SAN != connected hostname)
  *   R8: mTLS client cert required but not provided
  *
- * Gated to compile only under OpenHiTLS builds.
+ * Gated to compile only under openHiTLS builds.
  */
 
 #include <libwebsockets.h>

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-https/minimal-http-client-openhitls-https.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-https/minimal-http-client-openhitls-https.c
@@ -8,7 +8,7 @@
  *
  * This demonstrates a minimal https client that connects to a local TLS server,
  * performs a GET, and verifies it receives an HTTP 200 response.  Gated to
- * compile only under OpenHiTLS builds.
+ * compile only under openHiTLS builds.
  */
 
 #include <libwebsockets.h>

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-mtls-file-positive/minimal-http-client-openhitls-mtls-file-positive.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-mtls-file-positive/minimal-http-client-openhitls-mtls-file-positive.c
@@ -6,7 +6,7 @@
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
  *
- * Verifies a successful OpenHiTLS mutual TLS handshake using certificate
+ * Verifies a successful openHiTLS mutual TLS handshake using certificate
  * files on both sides.  The client trusts a local test CA, presents a client
  * certificate and encrypted private key from files, and then validates:
  *
@@ -329,7 +329,7 @@ int main(int argc, const char **argv)
 	info.ssl_cert_filepath = TEST_SERVER_CERT;
 	info.ssl_private_key_filepath = TEST_SERVER_KEY;
 	/*
-	 * The current OpenHiTLS server setup path binds the server password
+	 * The current openHiTLS server setup path binds the server password
 	 * callback before it knows only the client key is encrypted.
 	 */
 	info.ssl_private_key_password = TEST_CLIENT_KEY_PASS;

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-mtls-mem-positive/minimal-http-client-openhitls-mtls-mem-positive.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-mtls-mem-positive/minimal-http-client-openhitls-mtls-mem-positive.c
@@ -6,10 +6,10 @@
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
  *
- * Verifies a successful OpenHiTLS mutual TLS handshake using in-memory
+ * Verifies a successful openHiTLS mutual TLS handshake using in-memory
  * server leaf cert/key and client CA / cert / key material.  The server still
  * loads the CA used for client-cert trust from a local PEM file because the
- * current OpenHiTLS server backend only wires that trust path through
+ * current openHiTLS server backend only wires that trust path through
  * `ssl_ca_filepath`.
  */
 

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-mtls-mem-positive/mtls-mem-materials.h
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-mtls-mem-positive/mtls-mem-materials.h
@@ -3,7 +3,7 @@
  *
  * Reuses the local CA / server / client chain created for the file-backed
  * mTLS positive test, but embeds the server leaf cert/key and the full client
- * trust+identity material directly in memory so the OpenHiTLS *_mem branches
+ * trust+identity material directly in memory so the openHiTLS *_mem branches
  * are exercised on successful handshakes.
  */
 

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-policy-override-positive/minimal-http-client-openhitls-policy-override-positive.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-policy-override-positive/minimal-http-client-openhitls-policy-override-positive.c
@@ -6,7 +6,7 @@
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
  *
- * Verifies supported positive OpenHiTLS client-policy overrides by pairing
+ * Verifies supported positive openHiTLS client-policy overrides by pairing
  * each scenario with:
  *
  * - an initial connection without the policy flag that must fail

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-session/minimal-http-client-openhitls-session.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-session/minimal-http-client-openhitls-session.c
@@ -6,12 +6,12 @@
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
  *
- * This demonstrates TLS session reuse with OpenHiTLS.  The program performs
+ * This demonstrates TLS session reuse with openHiTLS.  The program performs
  * two sequential HTTPS (or WSS) connections to the same TLS server within a
  * single lws_context, and verifies that the second connection reuses the
  * cached TLS session via lws_tls_session_is_reused().
  *
- * Gated to compile only under OpenHiTLS + TLS sessions builds.
+ * Gated to compile only under openHiTLS + TLS sessions builds.
  */
 
 #include <libwebsockets.h>
@@ -363,7 +363,7 @@ int main(int argc, const char **argv)
 		n = lws_service(context, 0);
 
 	/*
-	 * OpenHiTLS currently traps in context teardown when a WSS client and
+	 * openHiTLS currently traps in context teardown when a WSS client and
 	 * embedded TLS server share the same context.  The test outcome is
 	 * already determined once the event loop exits, so let process exit
 	 * reclaim the context in this specific mode.

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-sni-multivhost-positive/minimal-http-client-openhitls-sni-multivhost-positive.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-sni-multivhost-positive/minimal-http-client-openhitls-sni-multivhost-positive.c
@@ -7,7 +7,7 @@
  * Universal Public Domain Dedication.
  *
  * Verifies successful SNI-based vhost and certificate selection with
- * OpenHiTLS.  Two TLS vhosts share a single listen port, and the client
+ * openHiTLS.  Two TLS vhosts share a single listen port, and the client
  * connects to each by name while dialing 127.0.0.1.
  */
 
@@ -425,7 +425,7 @@ int main(int argc, const char **argv)
 
 done:
 	/*
-	 * The explicit multi-vhost OpenHiTLS teardown currently aborts after
+	 * The explicit multi-vhost openHiTLS teardown currently aborts after
 	 * the successful SNI coverage path completes.  Exit the short-lived
 	 * test process directly once the assertions are finished.
 	 */

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-ssl-info-positive/minimal-http-client-openhitls-ssl-info-positive.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-openhitls-ssl-info-positive/minimal-http-client-openhitls-ssl-info-positive.c
@@ -6,7 +6,7 @@
  * This file is made available under the Creative Commons CC0 1.0
  * Universal Public Domain Dedication.
  *
- * Verifies a successful OpenHiTLS HTTPS exchange while SSL info callbacks
+ * Verifies a successful openHiTLS HTTPS exchange while SSL info callbacks
  * are enabled on the vhost.  The server sends the response in multiple
  * writes so the client and server exercise buffered TLS read / write flow
  * before the connection closes cleanly.

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-openhitls-mtls-crl/minimal-http-server-openhitls-mtls-crl.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-openhitls-mtls-crl/minimal-http-server-openhitls-mtls-crl.c
@@ -261,7 +261,7 @@ int main(int argc, const char **argv)
 
 cleanup:
 	/*
-	 * OpenHiTLS currently traps in context teardown when a client and
+	 * openHiTLS currently traps in context teardown when a client and
 	 * embedded TLS server share the same context.  The test verdict is
 	 * known when the loop exits, so allow process exit to reclaim it.
 	 */

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-openhitls-sni-mismatch/minimal-http-server-openhitls-sni-mismatch.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-openhitls-sni-mismatch/minimal-http-server-openhitls-sni-mismatch.c
@@ -296,7 +296,7 @@ int main(int argc, const char **argv)
         lwsl_user("Stage %d: Completed\n\n", stage);
 
         /*
-         * OpenHiTLS currently traps in context teardown when a client
+         * openHiTLS currently traps in context teardown when a client
          * and embedded TLS server share the same context.  The test
          * verdict is known when the loop exits, so allow process exit
          * to reclaim it.

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-openhitls-tls13/minimal-http-server-openhitls-tls13.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-openhitls-tls13/minimal-http-server-openhitls-tls13.c
@@ -281,7 +281,7 @@ int main(int argc, const char **argv)
 	lwsl_user("========================================\n");
 
 	/*
-	 * OpenHiTLS currently traps in context teardown when a client and
+	 * openHiTLS currently traps in context teardown when a client and
 	 * embedded TLS server share the same context.  The test verdict is
 	 * known when the loop exits, so allow process exit to reclaim it.
 	 */

--- a/minimal-examples-lowlevel/ws-client/minimal-ws-client-openhitls-wss/minimal-ws-client-openhitls-wss.c
+++ b/minimal-examples-lowlevel/ws-client/minimal-ws-client-openhitls-wss/minimal-ws-client-openhitls-wss.c
@@ -8,7 +8,7 @@
  *
  * This demonstrates a WSS client connecting to an embedded WS echo server
  * within the same lws_context, sending a test message, and verifying the
- * echoed response matches.  Gated to compile only under OpenHiTLS + WS builds.
+ * echoed response matches.  Gated to compile only under openHiTLS + WS builds.
  */
 
 #include <libwebsockets.h>
@@ -314,7 +314,7 @@ int main(int argc, const char **argv)
 		n = lws_service(context, 0);
 
 	/*
-	 * OpenHiTLS currently traps in context teardown when a WSS client and
+	 * openHiTLS currently traps in context teardown when a WSS client and
 	 * embedded TLS server share the same context.  The test verdict is
 	 * known when the loop exits, so allow process exit to reclaim it.
 	 */


### PR DESCRIPTION
This PR adds OpenHiTLS as a new TLS backend option for libwebsockets, providing full integration with the OpenHiTLS cryptographic library.