### PR TITLE
h2: client: fix interop with strict servers and large response headers

### DIFF
--- a/lib/roles/h2/http2.c
+++ b/lib/roles/h2/http2.c
@@ -2558,7 +2558,19 @@ lws_h2_client_handshake(struct lws *wsi)
 	 * receives an unexpected stream identifier MUST respond with a
 	 * connection error (Section 5.4.1) of type PROTOCOL_ERROR.
 	 */
-	unsigned int sid = nwsi->h2.h2n->highest_sid_opened + 2;
+	unsigned int sid = wsi->mux.my_sid;
+
+	/*
+	 * If this stream was already bound to a sid (the first client stream is
+	 * bound to sid 1 at the h2 upgrade), keep it.  Only streams that don't
+	 * yet have a sid get one allocated here, at header-send time, so that
+	 * concurrently-opening streams still get monotonically-increasing sids.
+	 * Without this guard the first stream's sid 1 was overwritten with
+	 * highest_sid_opened + 2 (= 3), which strict servers (e.g. Google's GFE)
+	 * reject with PROTOCOL_ERROR since the first client stream must be 1.
+	 */
+	if (!sid)
+		sid = nwsi->h2.h2n->highest_sid_opened + 2;
 
 	lwsl_debug("%s\n", __func__);
 
@@ -2570,7 +2582,9 @@ lws_h2_client_handshake(struct lws *wsi)
 	 * open streams in ascending sid order
 	 */
 
-	wsi->mux.my_sid = nwsi->h2.h2n->highest_sid_opened = sid;
+	wsi->mux.my_sid = sid;
+	if (sid > nwsi->h2.h2n->highest_sid_opened)
+		nwsi->h2.h2n->highest_sid_opened = sid;
 	lwsl_info("%s: %s: assigning SID %d at header send\n", __func__,
 			lws_wsi_tag(wsi), sid);
 
@@ -2663,16 +2677,14 @@ lws_h2_client_handshake(struct lws *wsi)
 
 //	n = lws_hdr_total_length(wsi, _WSI_TOKEN_CLIENT_ORIGIN);
 //	simp = lws_hdr_simple_ptr(wsi, _WSI_TOKEN_CLIENT_ORIGIN);
-#if 0
+	/*
+	 * h2 carries the request authority in the :authority pseudo-header,
+	 * not a Host header (RFC 7540 8.1.2.3).  Sending only Host (as this
+	 * path used to) makes strict servers such as Google's GFE reject the
+	 * stream with PROTOCOL_ERROR; :authority is accepted by all h2 servers.
+	 */
 	if (n && simp && lws_add_http_header_by_token(wsi,
 				WSI_TOKEN_HTTP_COLON_AUTHORITY,
-				(unsigned char *)simp, n, &p, end))
-		goto fail_length;
-#endif
-
-
-	if (/*!wsi->client_h2_alpn && */n && simp &&
-	    lws_add_http_header_by_token(wsi, WSI_TOKEN_HOST,
 				(unsigned char *)simp, n, &p, end))
 		goto fail_length;
 

--- a/lib/roles/h2/ops-h2.c
+++ b/lib/roles/h2/ops-h2.c
@@ -78,12 +78,19 @@ const struct http2_settings lws_h2_stock_settings = { {
 	 * way to precisely control it when we do want to.
 	 */
 	/* H2SET_MAX_FRAME_SIZE */		       16384,
-	/* H2SET_MAX_HEADER_LIST_SIZE */	        4096,
+	/* H2SET_MAX_HEADER_LIST_SIZE */	       65536,
 	/*< This advisory setting informs a peer of the maximum size of
 	 * header list that the sender is prepared to accept, in octets.
 	 * The value is based on the uncompressed size of header fields,
 	 * including the length of the name and value in octets plus an
 	 * overhead of 32 octets for each header field.
+	 *
+	 * The previous stock value of 4096 is smaller than the response
+	 * headers many real servers send (github.com, Google's GFE,
+	 * wikipedia), and the public http2_settings[] override can't reach
+	 * this index, so such servers' streams were GOAWAY'd with
+	 * ENHANCE_YOUR_CALM.  The actual header storage is still bounded by
+	 * max_http_header_data.
 	 */
 	/* H2SET_RESERVED7 */				   0,
 	/* H2SET_ENABLE_CONNECT_PROTOCOL */		   1,


### PR DESCRIPTION
Three independent h2-client bugs surfaced testing fetch against real
servers (txiki.js).  Symptoms ranged from connections dropped right after
ALPN to RST_STREAM(PROTOCOL_ERROR); they only bit a subset of servers, so
they had gone unnoticed against lenient peers (nghttp2, Cloudflare).

1. lws_h2_client_handshake() unconditionally reassigned the stream's sid
   to highest_sid_opened + 2 at header-send time, overwriting the sid 1
   the first client stream is already bound to (-> 3).  Strict servers
   (Google's GFE) reject a first client stream that isn't sid 1 with
   PROTOCOL_ERROR.  Only allocate a sid here when the stream doesn't
   already have one, and advance highest_sid_opened monotonically.

2. The client sent a Host header and no :authority pseudo-header (the
   :authority code was #if 0'd and the Host-skip guard commented out).
   h2 carries the authority in :authority (RFC 7540 8.1.2.3); GFE rejects
   a request with only Host as PROTOCOL_ERROR.  Send :authority instead;
   it is accepted by all h2 servers.

3. The stock SETTINGS_MAX_HEADER_LIST_SIZE of 4096 is smaller than the
   response headers many real servers send (github.com, GFE, wikipedia),
   so their streams were GOAWAY'd with ENHANCE_YOUR_CALM.  The public
   http2_settings[] override can't reach this index (the apply loop is
   bounded by LWS_H2_SETTINGS_LEN), so raise the stock default to 64KiB;
   actual header storage stays bounded by max_http_header_data.
