### PR TITLE
Fix MSVC compilation warnings with mbedTLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1176,8 +1176,13 @@ endif()
 if (MSVC)
 	# Turn off pointless microsoft security warnings.
 	add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
-	# Fail the build if any warnings
-	add_compile_options(/W3 /WX)
+	# Fail the build if any warnings, unless DISABLE_WERROR is set (mirrors
+	# the GCC/Clang -Werror gating above).
+	if ("${DISABLE_WERROR}" STREQUAL "OFF")
+		add_compile_options(/W3 /WX)
+	else()
+		add_compile_options(/W3)
+	endif()
 	# Unbreak MSVC broken preprocessor __VA_ARGS__ behaviour
 	if (MSVC_VERSION GREATER 1925)
 		add_compile_options(/Zc:preprocessor /wd5105)

--- a/lib/tls/mbedtls/mbedtls-client.c
+++ b/lib/tls/mbedtls/mbedtls-client.c
@@ -113,7 +113,7 @@ lws_ssl_client_bio_create(struct lws *wsi)
 		lws_mbedtls_set_alpn(conn->ctx, alpn_comma);
 	}
 
-	conn->net.MBEDTLS_PRIVATE_V30_ONLY(fd) = wsi->desc.sockfd;
+	conn->net.MBEDTLS_PRIVATE_V30_ONLY(fd) = (int)wsi->desc.sockfd;
 	mbedtls_ssl_set_bio(&conn->ssl, &conn->net, lws_plat_mbedtls_net_send, lws_plat_mbedtls_net_recv, NULL);
 
 	return 0;

--- a/lib/tls/mbedtls/mbedtls-server.c
+++ b/lib/tls/mbedtls/mbedtls-server.c
@@ -351,7 +351,7 @@ lws_tls_server_new_nonblocking(struct lws *wsi, lws_sockfd_type accept_fd)
 		return 1;
 	}
 
-	conn->net.MBEDTLS_PRIVATE_V30_ONLY(fd) = accept_fd;
+	conn->net.MBEDTLS_PRIVATE_V30_ONLY(fd) = (int)accept_fd;
 	mbedtls_ssl_set_bio(&conn->ssl, &conn->net, lws_plat_mbedtls_net_send, lws_plat_mbedtls_net_recv, NULL);
 
 	return 0;


### PR DESCRIPTION
- **mbedtls: cast sockfd to int when storing in net_context fd**
- **cmake: honor DISABLE_WERROR on MSVC**
