### PR TITLE
core-net: client: don't fan out parallel connects on foreign event loops

### DIFF
--- a/lib/core-net/client/connect3.c
+++ b/lib/core-net/client/connect3.c
@@ -516,8 +516,26 @@ lws_client_connect_3_connect(struct lws *wsi, const char *ads,
 				}
 			}
 		} else {
-			/* timer fired, or no specific fd. Just proceed to pop next if available */
-			if (!wsi->dns_sorted_list.count || wsi->parallel_count >= LWS_MAX_PARALLEL_CONNS)
+			/*
+			 * A connect-completion timer fired (happy-eyeballs, or
+			 * the win32 async connect-check) with no specific fd that
+			 * completed yet.  Falling through from here opens an
+			 * additional *parallel* connect socket on the same wsi.
+			 *
+			 * That is only safe on the lws "poll" core loop, which
+			 * itself polls every fd in pt->fds.  A foreign event loop
+			 * (event_lib_custom: libuv/libev/libevent/glib/sd) tracks
+			 * one fd per wsi and cannot poll the extra parallel
+			 * sockets; adopting one corrupts the wsi's fds-table
+			 * bookkeeping (position_in_fds_table).  The happy-eyeballs
+			 * timer is already gated on the "poll" loop where it is
+			 * scheduled, but the win32 async connect-check is scheduled
+			 * regardless of the loop, so gate the parallel fan-out here
+			 * too.
+			 */
+			if (!wsi->dns_sorted_list.count ||
+			    wsi->parallel_count >= LWS_MAX_PARALLEL_CONNS ||
+			    strcmp(wsi->a.context->event_loop_ops->name, "poll"))
 				return wsi;
 		}
 	}


### PR DESCRIPTION
The win32 async connect-completion poller (lws_client_win32_conn_async_check,
scheduled unconditionally on Windows in lws_client_connect_3_connect) re-enters
connect_3 with no specific fd. When it fires while the primary connect is still
in progress and DNS returned more than one address, the "else" branch falls
through and opens an additional *parallel* connect socket on the same wsi
(is_parallel = lws_socket_is_valid(wsi->desc.sockfd)).

Parallel connect sockets are only serviceable on the built-in "poll" core loop,
which polls every fd in pt->fds itself. A foreign event loop (event_lib_custom:
libuv/libev/libevent/glib/sd) tracks one fd per wsi via its io/sock_accept ops
and cannot poll the extra parallel sockets; adopting one corrupts the wsi's
fds-table bookkeeping. Observed on a libuv-based custom event lib on Windows:
__remove_wsi_socket_from_fds() trips

  assert(m == LWS_NO_FDS_POS || (m >= 0 && (unsigned int)m < pt->fds_count))

(pollfd.c) because position_in_fds_table is left out of range; in NDEBUG builds
the same out-of-range index is used silently (OOB on pt->fds[]), and the
detached primary TLS socket stalls until SECS_WAITING_FOR_SSL ("Timed out
waiting SSL").

The happy-eyeballs timer is already gated on the "poll" loop where it is
scheduled; the win32 connect-check is scheduled regardless of the loop, so gate
the parallel fan-out itself: only fall through to spawn a parallel socket when
the context's event loop is the built-in "poll" core. Foreign loops fall back to
sequential connect, driven by their own POLLOUT, exactly as before happy
eyeballs.
