### PR TITLE
tls/mbedtls: accept non-NUL-terminated client_ssl_ca_mem for PEM parsing

### DIFF
--- a/lib/tls/mbedtls/mbedtls-client.c
+++ b/lib/tls/mbedtls/mbedtls-client.c
@@ -261,7 +261,28 @@ lws_tls_client_create_vhost_context(struct lws_vhost *vh,
 		if (!ctx->ca_chain)
 			return 1;
 		mbedtls_x509_crt_init(ctx->ca_chain);
-		n = mbedtls_x509_crt_parse(ctx->ca_chain, ca_mem, ca_mem_len);
+		/*
+		 * mbedtls_x509_crt_parse() only treats the buffer as PEM when it
+		 * is NUL-terminated and the length includes that NUL; otherwise
+		 * it falls back to DER and PEM CAs fail with
+		 * MBEDTLS_ERR_X509_INVALID_FORMAT (-0x2180). Callers commonly
+		 * pass the content length without the terminator, so parse a
+		 * NUL-terminated copy when the buffer isn't already terminated.
+		 */
+		if (((const uint8_t *)ca_mem)[ca_mem_len - 1] == '\0')
+			n = mbedtls_x509_crt_parse(ctx->ca_chain, ca_mem,
+						   ca_mem_len);
+		else {
+			uint8_t *tmp = lws_malloc(ca_mem_len + 1, "ca_mem nul");
+
+			if (!tmp)
+				return 1;
+			memcpy(tmp, ca_mem, ca_mem_len);
+			tmp[ca_mem_len] = '\0';
+			n = mbedtls_x509_crt_parse(ctx->ca_chain, tmp,
+						   ca_mem_len + 1);
+			lws_free(tmp);
+		}
 		if (n != 0) {
 			lwsl_err("client CA: x509 parse failed: %d\n", n);
 			return 1;


### PR DESCRIPTION
### Problem

`lws_tls_client_create_vhost_context()` (mbedTLS backend) passes the caller's
`client_ssl_ca_mem` / `client_ssl_ca_mem_len` straight into
`mbedtls_x509_crt_parse()`:

```c
n = mbedtls_x509_crt_parse(ctx->ca_chain, ca_mem, ca_mem_len);
```

`mbedtls_x509_crt_parse()` only treats the buffer as **PEM** when it is
NUL-terminated *and* the passed length includes that NUL byte; otherwise it
parses the buffer as DER and a PEM CA fails with
`MBEDTLS_ERR_X509_INVALID_FORMAT` (`-0x2180`), logged as:

```
client CA: x509 parse failed: -8576
```

Callers commonly pass the *content* length (without the terminator) — which the
OpenSSL backend tolerates — so a PEM CA supplied via `client_ssl_ca_mem` cannot
be loaded on the mbedTLS backend. Note the same file already accounts for this
elsewhere by parsing with `strlen(pem) + 1`.

### Fix

Parse a NUL-terminated copy when the supplied buffer isn't already terminated;
otherwise parse in place. Safe for DER input too (ASN.1 is self-delimiting).

### Reproduced with

AWS Kinesis Video Streams WebRTC C SDK built against mbedTLS 4.1.0 and lws
`main` — the KVS signaling client supplies the AWS root CA bundle via
`client_ssl_ca_mem` with the content length, so every signaling TLS connection
failed to load the CA until the buffer was NUL-terminated.
