### PR TITLE
ws-over-h2: don't conflate nwsi buffered output with the stream's par…

### DIFF
--- a/lib/roles/h2/http2.c
+++ b/lib/roles/h2/http2.c
@@ -706,7 +706,7 @@ int lws_h2_frame_write(struct lws *wsi, int type, int flags,
 	if (type == LWS_H2_FRAME_TYPE_DATA) {
 #if defined(LWS_ROLE_WS)
 		if (wsi->h23_stream_carries_ws &&
-		    (lws_has_buffered_out(wsi) ||
+		    (wsi->buflist_out ||
 		     lws_h2_tx_cr_get(wsi) < (int)len)) {
 			/*
 			 * ws-over-h2 (RFC 8441): not enough h2 flow-control
@@ -768,7 +768,13 @@ lws_h2_ws_drain_parked_tx(struct lws *nwsi, struct lws *wsi)
 {
 	uint8_t out[LWS_H2_FRAME_HEADER_LENGTH + 4096];
 
-	while (lws_has_buffered_out(wsi)) {
+	/*
+	 * Test the stream's own buflist directly: lws_has_buffered_out()
+	 * additionally reports the nwsi's buffer, which fills up whenever
+	 * lws_issue_raw() below takes a partial socket write and must not
+	 * keep us looping after our own parked frames are gone.
+	 */
+	while (wsi->buflist_out) {
 		uint8_t *seg = NULL;
 		size_t sl = lws_buflist_next_segment_len(&wsi->buflist_out,
 							 &seg);

--- a/lib/roles/h2/ops-h2.c
+++ b/lib/roles/h2/ops-h2.c
@@ -1089,13 +1089,20 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 
 		/* priority 1: post compression-transform buffered output */
 
-		if (lws_has_buffered_out(w)) {
 #if defined(LWS_ROLE_WS)
-			if (w->h23_stream_carries_ws) {
-				/*
-				 * ws-over-h2: whole DATA frames parked by
-				 * lws_h2_frame_write() waiting for tx credit
-				 */
+		if (w->h23_stream_carries_ws) {
+			/*
+			 * ws-over-h2: whole DATA frames parked by
+			 * lws_h2_frame_write() waiting for tx credit.  Gate
+			 * and re-arm on the stream's OWN buflist, not
+			 * lws_has_buffered_out(): that also reports the
+			 * nwsi's buffer (eg, another stream's partial socket
+			 * write), which must neither pull us into the drain
+			 * with nothing parked nor block re-arming the user
+			 * once our own frames are gone.  If nothing of ours
+			 * is parked, fall through to normal servicing.
+			 */
+			if (w->buflist_out) {
 				if (lws_h2_ws_drain_parked_tx(wsi, w) < 0) {
 					lwsl_info("%s signalling to close\n",
 						  __func__);
@@ -1105,7 +1112,7 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 					wa = &wsi->mux.child_list;
 					goto next_child;
 				}
-				if (!lws_has_buffered_out(w))
+				if (!w->buflist_out)
 					/* fully drained: let the user write */
 					lws_callback_on_writable(w);
 				/*
@@ -1115,7 +1122,9 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 				wa = &wsi->mux.child_list;
 				goto next_child;
 			}
+		} else
 #endif
+		if (lws_has_buffered_out(w)) {
 			lwsl_debug("%s: completing partial\n", __func__);
 			if (lws_issue_raw(w, NULL, 0) < 0) {
 				lwsl_info("%s signalling to close\n", __func__);

--- a/lib/tls/gnutls/gnutls-quic.c
+++ b/lib/tls/gnutls/gnutls-quic.c
@@ -351,10 +351,10 @@ lws_tls_quic_init(struct lws *wsi, lws_tls_quic_secret_cb cb)
 			char *comma = strchr(p, ',');
 			alpn[i].data = (uint8_t *)p;
 			if (comma) {
-				alpn[i].size = (unsigned int)(comma - p);
+				alpn[i].size = (unsigned int)lws_ptr_diff_size_t(comma, p);
 				p = comma + 1;
 			} else {
-				alpn[i].size = (unsigned int)(end - p);
+				alpn[i].size = (unsigned int)lws_ptr_diff_size_t(end, p);
 				p = end;
 			}
 			/* Replace comma with NUL for cleaner logging, though gnutls only uses size */

--- a/lib/tls/gnutls/gnutls-ssl.c
+++ b/lib/tls/gnutls/gnutls-ssl.c
@@ -201,6 +201,7 @@ lws_tls_client_connect(struct lws *wsi, char *errbuf, size_t len)
 #if defined(LWS_WITH_TLS_SESSIONS)
 		lws_tls_session_new_gnutls(wsi);
 #endif
+		lws_tls_server_conn_alpn(wsi);
 		return LWS_SSL_CAPABLE_DONE;
 	}
 

--- a/lib/tls/gnutls/gnutls-tls.c
+++ b/lib/tls/gnutls/gnutls-tls.c
@@ -479,7 +479,26 @@ lws_ssl_client_bio_create(struct lws *wsi)
 	lws_tls_reuse_session(wsi);
 #endif
 
-	if (wsi->a.vhost->tls.alpn_ctx.len) {
+	if (wsi->alpn[0]) {
+		gnutls_datum_t alpn[4];
+		unsigned int i = 0;
+		char *p = wsi->alpn;
+		char *end = p + strlen(p);
+		
+		while (p < end && i < 4) {
+			char *comma = strchr(p, ',');
+			alpn[i].data = (uint8_t *)p;
+			if (comma) {
+				alpn[i].size = (unsigned int)lws_ptr_diff_size_t(comma, p);
+				p = comma + 1;
+			} else {
+				alpn[i].size = (unsigned int)lws_ptr_diff_size_t(end, p);
+				p = end;
+			}
+			i++;
+		}
+		gnutls_alpn_set_protocols(session, alpn, i, 0);
+	} else if (wsi->a.vhost->tls.alpn_ctx.len) {
 		gnutls_datum_t alpn[4];
 		unsigned int i = 0, p = 0;
 		while (p < wsi->a.vhost->tls.alpn_ctx.len && i < 4) {

--- a/lib/tls/openssl/openssl-quic.c
+++ b/lib/tls/openssl/openssl-quic.c
@@ -301,7 +301,6 @@ lws_tls_quic_init(struct lws *wsi, lws_tls_quic_secret_cb cb)
 		if (wsi->a.vhost && (wsi->a.vhost->options & LWS_SERVER_OPTION_ALLOW_EARLY_DATA)) {
 #if !defined(USE_WOLFSSL) && !defined(LWS_WITH_MBEDTLS)
 			SSL_set_early_data_enabled(wsi->tls.ssl, 1);
-			SSL_set_max_early_data(wsi->tls.ssl, wsi->a.context->quic_0rtt_max_size ? wsi->a.context->quic_0rtt_max_size : 0xFFFFFFFF);
 #endif
 		}
 		SSL_set_accept_state(wsi->tls.ssl);
@@ -617,18 +616,10 @@ lws_tls_quic_init(struct lws *wsi, lws_tls_quic_secret_cb cb)
 	SSL_set_app_data(wsi->tls.ssl, wsi);
 
 	if (lwsi_role_client(wsi)) {
-		if (wsi->flags & LCCSCF_ALLOW_EARLY_DATA) {
-#if !defined(USE_WOLFSSL) && !defined(LWS_WITH_MBEDTLS)
-			SSL_set_early_data_enabled(wsi->tls.ssl, 1);
-#endif
-		}
 		SSL_set_connect_state(wsi->tls.ssl);
 	} else {
 		if (wsi->a.vhost && (wsi->a.vhost->options & LWS_SERVER_OPTION_ALLOW_EARLY_DATA)) {
-#if !defined(USE_WOLFSSL) && !defined(LWS_WITH_MBEDTLS)
-			SSL_set_early_data_enabled(wsi->tls.ssl, 1);
 			SSL_set_max_early_data(wsi->tls.ssl, wsi->a.context->quic_0rtt_max_size ? wsi->a.context->quic_0rtt_max_size : 0xFFFFFFFF);
-#endif
 		}
 		SSL_set_accept_state(wsi->tls.ssl);
 	}

--- a/lib/tls/schannel/schannel-quic.c
+++ b/lib/tls/schannel/schannel-quic.c
@@ -283,7 +283,7 @@ lws_tls_quic_advance_handshake(struct lws *wsi, int level,
 
 		while (p && *p) {
 			const char *comma = strchr(p, ',');
-			size_t item_len = comma ? (size_t)(comma - p) : strlen(p);
+			size_t item_len = comma ? lws_ptr_diff_size_t(comma, p) : strlen(p);
 			if (item_len > 255 || (pData + item_len + 1 - alpn_u.buf) > 256) break;
 			*pData++ = (uint8_t)item_len;
 			memcpy(pData, p, item_len);
@@ -327,7 +327,7 @@ lws_tls_quic_advance_handshake(struct lws *wsi, int level,
 
 		while (p && *p) {
 			const char *comma = strchr(p, ',');
-			size_t item_len = comma ? (size_t)(comma - p) : strlen(p);
+			size_t item_len = comma ? lws_ptr_diff_size_t(comma, p) : strlen(p);
 			if (item_len > 255 || (pData + item_len + 1 - alpn_u.buf) > 256) break;
 			*pData++ = (uint8_t)item_len;
 			memcpy(pData, p, item_len);

--- a/lib/tls/schannel/schannel-ssl.c
+++ b/lib/tls/schannel/schannel-ssl.c
@@ -151,7 +151,7 @@ lws_tls_client_connect(struct lws *wsi, char *errbuf, size_t len)
                while (p < end) {
                        const char *comma = strchr(p, ',');
                        size_t item_len;
-                       if (comma) item_len = comma - p;
+                       if (comma) item_len = lws_ptr_diff_size_t(comma, p);
                        else item_len = strlen(p);
 
                        if (item_len > 0 && item_len < 256) {
@@ -417,7 +417,7 @@ lws_tls_server_accept(struct lws *wsi)
 
                while (p && *p) {
                        const char *comma = strchr(p, ',');
-                       size_t item_len = comma ? (size_t)(comma - p) : strlen(p);
+                       size_t item_len = comma ? lws_ptr_diff_size_t(comma, p) : strlen(p);
                        if (item_len > 255 || (pData + item_len + 1 - alpn_buf) > 256) break;
                        *pData++ = (uint8_t)item_len;
                        memcpy(pData, p, item_len);


### PR DESCRIPTION
…ked frames

The tx flow-control parking introduced in 57effc65 gates the park, drain and re-arm logic on lws_has_buffered_out(), which for an h2 stream also reports the NETWORK wsi's buflist_out -- the buffer that fills whenever lws_issue_raw() takes a partial socket write.  The drain logic, however, assumes the predicate describes the stream's OWN parked frames, which breaks four ways under ordinary socket-level backpressure:

 - lws_h2_ws_drain_parked_tx(): after the stream's last parked frame is consumed, a partial write left by its own lws_issue_raw(nwsi) keeps the while (lws_has_buffered_out(wsi)) loop alive via the nwsi branch; the next iteration reads the empty stream buflist and returns -1, and rops_perform_user_POLLOUT_h2() closes a healthy stream that had just flushed everything it owned.

 - rops_perform_user_POLLOUT_h2(): the post-drain re-arm is skipped whenever the nwsi still holds a partial, on the assumption that a WINDOW_UPDATE will re-arm the child.  When the peer's window is large (tx credit ample, bottleneck is the socket) no WINDOW_UPDATE is coming, requested_POLLOUT was already consumed, and the pending- writable accounting then drops POLLOUT on the connection: the user callback never fires again and the transfer stalls permanently.

 - the same gate pulls a SIBLING ws stream -- nothing of its own parked, POLLOUT requested -- into the drain once an earlier child's drain congests the nwsi in the same service pass, hitting the identical empty-buflist close.

 - lws_h2_frame_write(): the parking predicate fires on nwsi congestion caused by another stream, needlessly deferring fully-credited frames into the drain path instead of letting lws_issue_raw(nwsi) append them in order.

Test the stream's own buflist_out directly in all four places, and let a carries-ws child with nothing of its own parked fall through to normal servicing.  The existing api-test doesn't catch these because its drip-fed WINDOW_UPDATEs continually re-arm every child and localhost doesn't produce partial writes.