### PR TITLE
http: server-side Digest Auth with htdigest file support

### DIFF
--- a/CMakeLists-implied-options.txt
+++ b/CMakeLists-implied-options.txt
@@ -274,6 +274,7 @@ endif()
 
 if (LWS_WITH_HTTP_DIGEST_AUTH)
 	set(LWS_WITH_GENCRYPTO 1)
+	set(LWS_WITH_HTTP_BASIC_AUTH 1)
 endif()
 
 if (APPLE)

--- a/include/libwebsockets/lws-context-vhost.h
+++ b/include/libwebsockets/lws-context-vhost.h
@@ -1505,7 +1505,8 @@ enum lws_mount_protocols {
  */
 enum lws_authentication_mode {
 	LWSAUTHM_DEFAULT = 0, /**< default authenticate only if basic_auth_login_file is provided */
-	LWSAUTHM_BASIC_AUTH_CALLBACK = 1 << 28 /**< Basic auth with a custom verifier */
+	LWSAUTHM_BASIC_AUTH_CALLBACK = 1 << 28, /**< Basic auth with a custom verifier */
+	LWSAUTHM_DIGEST_AUTH = 2 << 28  /**< Digest auth via htdigest-format file (requires LWS_WITH_HTTP_DIGEST_AUTH) */
 };
 
 /** The authentication mode is stored in the top 4 bits of lws_http_mount.auth_mask */
@@ -1556,6 +1557,12 @@ struct lws_http_mount {
 
 	const char *basic_auth_login_file;
 	/**<NULL, or filepath to use to check basic auth logins against. (requires LWSAUTHM_DEFAULT) */
+
+	const char *basic_auth_realm;
+	/**< NULL (defaults to "lwsws"), or realm string sent in the WWW-Authenticate challenge
+	 * for both Basic and Digest auth. For Digest auth (LWSAUTHM_DIGEST_AUTH), this must
+	 * match the realm stored in the htdigest file.
+	 */
 
 	const char *cgi_chroot_path;
 	/**< NULL, or chroot patch for child cgi process */

--- a/lib/core-net/close.c
+++ b/lib/core-net/close.c
@@ -144,6 +144,11 @@ __lws_reset_wsi(struct lws *wsi)
 		lws_free(wsi->http.digest_auth_hdr);
 		wsi->http.digest_auth_hdr = NULL;
 	}
+	if (wsi->http.digest_auth_nonce) {
+		lws_free(wsi->http.digest_auth_nonce);
+		wsi->http.digest_auth_nonce = NULL;
+	}
+	wsi->http.digest_auth_nc = 0;
 #endif
 #endif
 

--- a/lib/roles/h2/ops-h2.c
+++ b/lib/roles/h2/ops-h2.c
@@ -939,6 +939,27 @@ lws_h2_bind_for_post_before_action(struct lws *wsi)
 			return lws_http_transaction_completed(wsi);
 		}
 #endif
+#if defined(LWS_WITH_HTTP_DIGEST_AUTH)
+
+		/* digest auth? */
+
+		if ((hit->auth_mask & AUTH_MODE_MASK) == LWSAUTHM_DIGEST_AUTH) {
+			switch (lws_check_digest_auth(wsi,
+						      hit->basic_auth_login_file,
+						      hit->basic_auth_realm)) {
+			case LCBA_CONTINUE:
+			case LCBA_AUTH_RETRY_KEEPALIVE:
+				break;
+			case LCBA_FAILED_AUTH:
+				return lws_unauthorised_digest_auth(wsi,
+						hit->basic_auth_realm);
+			case LCBA_END_TRANSACTION:
+				lws_return_http_status(wsi,
+						HTTP_STATUS_FORBIDDEN, NULL);
+				return lws_http_transaction_completed(wsi);
+			}
+		}
+#endif
 	}
 
 	methidx = lws_http_get_uri_and_method(wsi, &uri_ptr, &uri_len);

--- a/lib/roles/http/private-lib-roles-http.h
+++ b/lib/roles/http/private-lib-roles-http.h
@@ -306,6 +306,10 @@ struct _lws_http_mode_related {
 	char auth_username[64];
 	char auth_password[64];
 	char *digest_auth_hdr;
+#if defined(LWS_WITH_HTTP_DIGEST_AUTH)
+	char *digest_auth_nonce;  /**< nonce sent in last Digest 401 challenge (server-side) */
+	uint32_t digest_auth_nc;  /**< last nc value seen on this connection */
+#endif
 	char *extra_onward_headers;
 };
 
@@ -341,6 +345,14 @@ lws_check_basic_auth(struct lws *wsi, const char *basic_auth_login_file, unsigne
 
 int
 lws_unauthorised_basic_auth(struct lws *wsi);
+
+#if defined(LWS_WITH_HTTP_DIGEST_AUTH)
+enum lws_check_basic_auth_results
+lws_check_digest_auth(struct lws *wsi, const char *htdigest_file, const char *realm);
+
+int
+lws_unauthorised_digest_auth(struct lws *wsi, const char *realm);
+#endif
 
 #if defined(LWS_ROLE_H1)
 int

--- a/lib/roles/http/server/server.c
+++ b/lib/roles/http/server/server.c
@@ -1435,6 +1435,588 @@ lws_check_basic_auth(struct lws *wsi, const char *basic_auth_login_file,
 
 #endif
 
+#if defined(LWS_WITH_HTTP_DIGEST_AUTH)
+
+/*
+ * Parse an htdigest-format file (username:realm:HA1hex\n per line).
+ * Returns 1 and copies HA1 hex into ha1_hex if the username:realm pair is
+ * found, otherwise returns 0.
+ */
+static int
+lws_find_htdigest_ha1(const char *filename, const char *username,
+		      const char *realm, char *ha1_hex, size_t ha1_hex_len)
+{
+	size_t ulen = strlen(username), rlen = strlen(realm);
+	char buf[256], cbuf[128];
+	int fd, n = 0, pos = 0, found = 0;
+	int field = 0, cpos = 0;
+	int umatch = 0, rmatch = 0;
+
+	if (!filename || !username || !realm)
+		return 0;
+
+	fd = lws_open(filename, O_RDONLY);
+	if (fd < 0) {
+		lwsl_err("can't open htdigest file: %s\n", filename);
+		return 0;
+	}
+
+	for (;;) {
+		char c;
+
+		if (pos == n) {
+			do {
+				n = (int)read(fd, buf, sizeof(buf));
+			} while (n < 0 && errno == EINTR);
+			if (n <= 0) {
+				/* flush last line with no trailing newline */
+				if (field == 2 && umatch && rmatch && cpos > 0 &&
+				    (size_t)cpos < ha1_hex_len) {
+					memcpy(ha1_hex, cbuf, (size_t)cpos);
+					ha1_hex[cpos] = '\0';
+					found = 1;
+				}
+				break;
+			}
+			pos = 0;
+		}
+		c = buf[pos++];
+
+		if (c == '\r')
+			continue;
+
+		if (c == '\n') {
+			if (field == 2 && umatch && rmatch && cpos > 0 &&
+			    (size_t)cpos < ha1_hex_len) {
+				memcpy(ha1_hex, cbuf, (size_t)cpos);
+				ha1_hex[cpos] = '\0';
+				found = 1;
+				break;
+			}
+			/* reset for next line */
+			field = 0;
+			cpos = 0;
+			umatch = 0;
+			rmatch = 0;
+			continue;
+		}
+
+		if (c == ':' && field < 2) {
+			/* end of a colon-separated field */
+			cbuf[cpos] = '\0';
+			if (field == 0)
+				umatch = ((size_t)cpos == ulen &&
+					  !strncmp(cbuf, username, ulen));
+			else /* field == 1 */
+				rmatch = ((size_t)cpos == rlen &&
+					  !strncmp(cbuf, realm, rlen));
+			field++;
+			cpos = 0;
+			continue;
+		}
+
+		if (cpos < (int)sizeof(cbuf) - 1)
+			cbuf[cpos++] = c;
+	}
+
+	close(fd);
+
+	return found;
+}
+
+/*
+ * Send HTTP 401 Unauthorized with a Digest auth challenge.
+ * Generates a fresh random nonce, stores it in the wsi for later verification
+ * on keep-alive connections, and writes the response.
+ */
+int
+lws_unauthorised_digest_auth(struct lws *wsi, const char *realm)
+{
+	struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
+	unsigned char *start = pt->serv_buf + LWS_PRE,
+		      *p = start, *end = p + 2048;
+	char buf[256], nonce[33];
+	int n;
+
+	if (!realm)
+		realm = "lwsws";
+
+	/* Generate a fresh random nonce and remember it for later validation */
+	lws_free_set_NULL(wsi->http.digest_auth_nonce);
+	wsi->http.digest_auth_nc = 0;
+	if (lws_hex_random(wsi->a.context, nonce, sizeof(nonce)))
+		return -1;
+
+	wsi->http.digest_auth_nonce = lws_strdup(nonce);
+	if (!wsi->http.digest_auth_nonce)
+		return -1;
+
+	if (lws_add_http_header_status(wsi, HTTP_STATUS_UNAUTHORIZED, &p, end))
+		return -1;
+
+	n = lws_snprintf(buf, sizeof(buf),
+			 "Digest realm=\"%s\", nonce=\"%s\", "
+			 "algorithm=MD5, qop=\"auth\"",
+			 realm, nonce);
+	if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_WWW_AUTHENTICATE,
+					 (unsigned char *)buf, n, &p, end))
+		return -1;
+
+	if (lws_add_http_header_content_length(wsi, 0, &p, end))
+		return -1;
+
+	if (lws_finalize_http_header(wsi, &p, end))
+		return -1;
+
+	n = lws_write(wsi, start, lws_ptr_diff_size_t(p, start),
+		      LWS_WRITE_HTTP_HEADERS | LWS_WRITE_H2_STREAM_END);
+	if (n < 0)
+		return -1;
+
+	return lws_http_transaction_completed(wsi);
+}
+
+/* token indices matching the srv_digest_toks array below */
+#define SDT_DIGEST    0
+#define SDT_USERNAME  1
+#define SDT_REALM     2
+#define SDT_NONCE     3
+#define SDT_URI       4
+#define SDT_RESPONSE  5
+#define SDT_OPAQUE    6
+#define SDT_QOP       7
+#define SDT_ALGORITHM 8
+#define SDT_NC        9
+#define SDT_CNONCE   10
+
+static const char * const srv_digest_toks[] = {
+	"Digest",    /* SDT_DIGEST    */
+	"username",  /* SDT_USERNAME  */
+	"realm",     /* SDT_REALM     */
+	"nonce",     /* SDT_NONCE     */
+	"uri",       /* SDT_URI       */
+	"response",  /* SDT_RESPONSE  */
+	"opaque",    /* SDT_OPAQUE    */
+	"qop",       /* SDT_QOP       */
+	"algorithm", /* SDT_ALGORITHM */
+	"nc",        /* SDT_NC        */
+	"cnonce",    /* SDT_CNONCE    */
+};
+
+#define SDIGST_PEND_NAME_EQ  -1   /* expecting name= token */
+#define SDIGST_PEND_DELIM    -2   /* expecting comma delimiter */
+#define SDIGST_PEND_SKIP     -3   /* skip next value (unknown field) */
+
+/*
+ * Parse the incoming Authorization: Digest ... header and validate it against
+ * the specified htdigest file.  htdigest file format is one entry per line:
+ *
+ *   username:realm:HA1_hex
+ *
+ * where HA1_hex = lowercase hex MD5("username:realm:password").
+ *
+ * On success (LCBA_CONTINUE), rewrites WSI_TOKEN_HTTP_AUTHORIZATION to
+ * contain only the authenticated username, matching the Basic Auth behaviour.
+ */
+enum lws_check_basic_auth_results
+lws_check_digest_auth(struct lws *wsi, const char *htdigest_file,
+		      const char *realm)
+{
+#if defined(LWS_WITH_FILE_OPS)
+	char b64[512];
+	char username[64], req_realm[64], nonce_in[256], uri_in[256];
+	char response_hex[LWS_GENHASH_LARGEST * 2 + 1];
+	char cnonce[256], qop[32], nc_str[16];
+	/* ha1_hex is exactly 32 hex chars for MD5 */
+	char ha1_hex[LWS_GENHASH_LARGEST * 2 + 1];
+	char tmp[sizeof(ha1_hex) + sizeof(nonce_in) + sizeof(nc_str) +
+		 sizeof(cnonce) + sizeof(qop) +
+		 (LWS_GENHASH_LARGEST * 2 + 1) + 32];
+	char a2_hex[LWS_GENHASH_LARGEST * 2 + 1];
+	char expected_hex[LWS_GENHASH_LARGEST * 2 + 1];
+	uint8_t digest_raw[LWS_GENHASH_LARGEST];
+	struct lws_genhash_ctx hc;
+	struct lws_tokenize ts;
+	lws_tokenize_elem e;
+	int seen = 0, pend = SDIGST_PEND_NAME_EQ, m, fi, n;
+	const char *method, *eff_realm;
+	char *uri_ptr;
+	int uri_len;
+
+	if (!htdigest_file)
+		return LCBA_CONTINUE;
+
+	eff_realm = realm ? realm : "lwsws";
+
+	/* Did the client send an Authorization header? */
+	m = lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_AUTHORIZATION);
+	if (!m)
+		return LCBA_FAILED_AUTH;
+
+	/* Disallow header fragmentation */
+	fi = wsi->http.ah->frag_index[WSI_TOKEN_HTTP_AUTHORIZATION];
+	if (wsi->http.ah->frags[fi].nfrag) {
+		lwsl_err("fragmented digest auth header not allowed\n");
+		return LCBA_FAILED_AUTH;
+	}
+
+	m = lws_hdr_copy(wsi, b64, sizeof(b64), WSI_TOKEN_HTTP_AUTHORIZATION);
+	if (m < 7)
+		return LCBA_END_TRANSACTION;
+
+	/* Initialise field buffers */
+	username[0] = '\0';
+	req_realm[0] = '\0';
+	nonce_in[0] = '\0';
+	uri_in[0] = '\0';
+	response_hex[0] = '\0';
+	cnonce[0] = '\0';
+	qop[0] = '\0';
+	nc_str[0] = '\0';
+
+	lws_tokenize_init(&ts, b64, LWS_TOKENIZE_F_MINUS_NONTERM |
+				    LWS_TOKENIZE_F_NO_INTEGERS |
+				    LWS_TOKENIZE_F_RFC7230_DELIMS);
+	do {
+		int do_str_val = 0;
+
+		e = lws_tokenize(&ts);
+		switch (e) {
+
+		case LWS_TOKZE_TOKEN:
+			if (pend >= 0 || pend == SDIGST_PEND_SKIP) {
+				do_str_val = 1;
+				break;
+			}
+
+			/* First token must be "Digest" */
+			if (!strncasecmp(ts.token, "Digest", ts.token_len) &&
+			    ts.token_len == 6) {
+				seen |= 1 << SDT_DIGEST;
+				break;
+			}
+			lwsl_err("digest auth: not a Digest authorization\n");
+			return LCBA_END_TRANSACTION;
+
+		case LWS_TOKZE_TOKEN_NAME_EQUALS:
+			if (!(seen & (1 << SDT_DIGEST)) ||
+			    pend != SDIGST_PEND_NAME_EQ)
+				return LCBA_END_TRANSACTION;
+
+			for (n = 0; n < (int)LWS_ARRAY_SIZE(srv_digest_toks); n++)
+				if (!strncasecmp(ts.token, srv_digest_toks[n],
+						 ts.token_len) &&
+				    srv_digest_toks[n][ts.token_len] == '\0')
+					break;
+
+			if (n == (int)LWS_ARRAY_SIZE(srv_digest_toks)) {
+				pend = SDIGST_PEND_SKIP; /* unknown field */
+				break;
+			}
+
+			pend = n;
+			break;
+
+		case LWS_TOKZE_QUOTED_STRING:
+			do_str_val = 1;
+			break;
+
+		case LWS_TOKZE_DELIMITER:
+			if (*ts.token == ',') {
+				if (pend != SDIGST_PEND_DELIM)
+					return LCBA_END_TRANSACTION;
+				pend = SDIGST_PEND_NAME_EQ;
+				break;
+			}
+			break;
+
+		case LWS_TOKZE_ENDED:
+			break;
+
+		default:
+			lwsl_err("digest auth: unexpected token %d\n", e);
+			return LCBA_END_TRANSACTION;
+		}
+
+		if (do_str_val) {
+			if (pend == SDIGST_PEND_SKIP) {
+				pend = SDIGST_PEND_DELIM;
+				continue;
+			}
+			if (pend < 0)
+				return LCBA_END_TRANSACTION;
+
+			switch (pend) {
+			case SDT_USERNAME:
+				if (ts.token_len >= (int)sizeof(username))
+					return LCBA_END_TRANSACTION;
+				strncpy(username, ts.token, ts.token_len);
+				username[ts.token_len] = '\0';
+				break;
+			case SDT_REALM:
+				if (ts.token_len >= (int)sizeof(req_realm))
+					return LCBA_END_TRANSACTION;
+				strncpy(req_realm, ts.token, ts.token_len);
+				req_realm[ts.token_len] = '\0';
+				break;
+			case SDT_NONCE:
+				if (ts.token_len >= (int)sizeof(nonce_in))
+					return LCBA_END_TRANSACTION;
+				strncpy(nonce_in, ts.token, ts.token_len);
+				nonce_in[ts.token_len] = '\0';
+				break;
+			case SDT_URI:
+				if (ts.token_len >= (int)sizeof(uri_in))
+					return LCBA_END_TRANSACTION;
+				strncpy(uri_in, ts.token, ts.token_len);
+				uri_in[ts.token_len] = '\0';
+				break;
+			case SDT_RESPONSE:
+				if (ts.token_len >= (int)sizeof(response_hex))
+					return LCBA_END_TRANSACTION;
+				strncpy(response_hex, ts.token, ts.token_len);
+				response_hex[ts.token_len] = '\0';
+				break;
+			case SDT_OPAQUE:
+				break; /* ignored */
+			case SDT_QOP:
+				if (ts.token_len >= (int)sizeof(qop))
+					return LCBA_END_TRANSACTION;
+				strncpy(qop, ts.token, ts.token_len);
+				qop[ts.token_len] = '\0';
+				break;
+			case SDT_ALGORITHM:
+				/* htdigest stores MD5-based HA1; reject others */
+				if (ts.token_len != 3 ||
+				    strncasecmp(ts.token, "MD5", 3)) {
+					lwsl_err("digest auth: only MD5 supported\n");
+					return LCBA_END_TRANSACTION;
+				}
+				break;
+			case SDT_NC:
+				if (ts.token_len >= (int)sizeof(nc_str))
+					return LCBA_END_TRANSACTION;
+				strncpy(nc_str, ts.token, ts.token_len);
+				nc_str[ts.token_len] = '\0';
+				break;
+			case SDT_CNONCE:
+				if (ts.token_len >= (int)sizeof(cnonce))
+					return LCBA_END_TRANSACTION;
+				strncpy(cnonce, ts.token, ts.token_len);
+				cnonce[ts.token_len] = '\0';
+				break;
+			}
+			seen |= 1 << pend;
+			pend = SDIGST_PEND_DELIM;
+		}
+	} while (e > 0);
+
+	/* Require at minimum: username, realm, nonce, response */
+	if (!(seen & (1 << SDT_USERNAME)) ||
+	    !(seen & (1 << SDT_REALM))    ||
+	    !(seen & (1 << SDT_NONCE))    ||
+	    !(seen & (1 << SDT_RESPONSE))) {
+		lwsl_err("digest auth: missing required fields (seen=0x%x)\n",
+			 seen);
+		return LCBA_END_TRANSACTION;
+	}
+
+	/*
+	 * Reject legacy no-qop responses: qop="auth" is mandatory to
+	 * prevent a replay-downgrade attack where an MITM strips
+	 * qop="auth" from the 401 challenge so the client omits nc.
+	 * Without nc there is no nonce-count replay check on the
+	 * same connection (RFC 7616 §3.4.1).
+	 */
+	if (!(seen & (1 << SDT_QOP)) || strcasecmp(qop, "auth")) {
+		lwsl_err("digest auth: qop=\"auth\" required\n");
+		return LCBA_FAILED_AUTH;
+	}
+
+	/* When qop is "auth", nc and cnonce MUST be present (RFC 7616). */
+	if (!(seen & (1 << SDT_NC)) || !(seen & (1 << SDT_CNONCE))) {
+		lwsl_err("digest auth: nc and cnonce required\n");
+		return LCBA_FAILED_AUTH;
+	}
+
+	/* Verify realm matches our configuration */
+	if (strcmp(req_realm, eff_realm)) {
+		lwsl_err("digest auth: realm mismatch: got '%s', expected '%s'\n",
+			 req_realm, eff_realm);
+		return LCBA_FAILED_AUTH;
+	}
+
+	/*
+	 * Verify nonce matches the one we issued for this connection.
+	 * If no nonce has been issued (new connection without prior 401),
+	 * the client cannot be pre-emptively authenticated.
+	 */
+	if (!wsi->http.digest_auth_nonce ||
+	    strcmp(nonce_in, wsi->http.digest_auth_nonce)) {
+		lwsl_err("digest auth: %s\n",
+			 wsi->http.digest_auth_nonce ?
+				"nonce mismatch" :
+				"no nonce stored for this connection");
+		return LCBA_FAILED_AUTH;
+	}
+
+	/* Look up the pre-hashed HA1 in the htdigest file */
+	if (!lws_find_htdigest_ha1(htdigest_file, username, eff_realm,
+				   ha1_hex, sizeof(ha1_hex))) {
+		lwsl_err("digest auth: user '%s' not found in htdigest\n",
+			 username);
+		return LCBA_FAILED_AUTH;
+	}
+
+	/*
+	 * Get the HTTP method for HA2 = MD5(method:uri).
+	 * H2 mux substreams carry the method in :method pseudo-header
+	 * and path in :path.
+	 */
+	method = NULL;
+#if defined(LWS_ROLE_H2)
+	if (wsi->mux_substream) {
+		method = lws_hdr_simple_ptr(wsi, WSI_TOKEN_HTTP_COLON_METHOD);
+		uri_ptr = lws_hdr_simple_ptr(wsi,
+					     WSI_TOKEN_HTTP_COLON_PATH);
+		uri_len = lws_hdr_total_length(wsi,
+					       WSI_TOKEN_HTTP_COLON_PATH);
+	} else
+#endif
+	{
+		int methidx = lws_http_get_uri_and_method(wsi, &uri_ptr,
+							  &uri_len);
+		if (methidx >= 0 &&
+		    methidx < (int)LWS_ARRAY_SIZE(method_names))
+			method = method_names[methidx];
+	}
+	if (!method)
+		method = "GET";
+
+	/*
+	 * Validate URI from Authorization header matches the actual
+	 * request URI (RFC 7616 section 3.4.1).  Without this check an
+	 * attacker could reuse a valid auth header captured from one
+	 * endpoint to access a different resource.
+	 *
+	 * H2 :path already includes the query string; for H1 we must
+	 * reconstruct the full URI from the path + query args.
+	 */
+	if (uri_ptr && uri_in[0]) {
+		char full_uri[512];
+
+#if defined(LWS_ROLE_H2)
+		if (wsi->mux_substream)
+			lws_strnncpy(full_uri, uri_ptr, (size_t)uri_len,
+				     sizeof(full_uri));
+		else
+#endif
+		{
+			int flen = lws_snprintf(full_uri, sizeof(full_uri),
+						"%s", uri_ptr);
+			if (lws_hdr_total_length(wsi,
+						 WSI_TOKEN_HTTP_URI_ARGS)) {
+				int qlen = lws_hdr_copy(wsi,
+					    full_uri +
+						    (unsigned int)(flen + 1),
+					    (int)sizeof(full_uri) - flen - 1,
+					    WSI_TOKEN_HTTP_URI_ARGS);
+				if (qlen > 0) {
+					full_uri[flen] = '?';
+					flen += 1 + qlen;
+					full_uri[flen] = '\0';
+				}
+			}
+		}
+		if (strcmp(uri_in, full_uri)) {
+			lwsl_err("digest auth: uri mismatch (header '%s' != "
+				 "request '%s')\n", uri_in, full_uri);
+			return LCBA_FAILED_AUTH;
+		}
+	}
+
+	/* HA2 = MD5(method ":" uri) -- use uri from auth header per RFC 2617 */
+	n = lws_snprintf(tmp, sizeof(tmp), "%s:%s",
+			 method, uri_in[0] ? uri_in : "/");
+	if (lws_genhash_init(&hc, LWS_GENHASH_TYPE_MD5) ||
+	    lws_genhash_update(&hc, tmp, (size_t)n) ||
+	    lws_genhash_destroy(&hc, digest_raw)) {
+		lws_genhash_destroy(&hc, NULL);
+		return LCBA_FAILED_AUTH;
+	}
+	lws_hex_from_byte_array(digest_raw,
+				lws_genhash_size(LWS_GENHASH_TYPE_MD5),
+				a2_hex, sizeof(a2_hex));
+
+	/*
+	 * Compute the expected response:
+	 *   qop=auth:  MD5(HA1:nonce:nc:cnonce:qop:HA2)
+	 *   no qop:    MD5(HA1:nonce:HA2)
+	 */
+	if (qop[0])
+		n = lws_snprintf(tmp, sizeof(tmp), "%s:%s:%s:%s:%s:%s",
+				 ha1_hex, nonce_in, nc_str, cnonce, qop,
+				 a2_hex);
+	else
+		n = lws_snprintf(tmp, sizeof(tmp), "%s:%s:%s",
+				 ha1_hex, nonce_in, a2_hex);
+
+	if (lws_genhash_init(&hc, LWS_GENHASH_TYPE_MD5) ||
+	    lws_genhash_update(&hc, tmp, (size_t)n) ||
+	    lws_genhash_destroy(&hc, digest_raw)) {
+		lws_genhash_destroy(&hc, NULL);
+		return LCBA_FAILED_AUTH;
+	}
+	lws_hex_from_byte_array(digest_raw,
+				lws_genhash_size(LWS_GENHASH_TYPE_MD5),
+				expected_hex, sizeof(expected_hex));
+
+	/* Constant-time comparison to avoid timing side-channels */
+	if (strlen(expected_hex) != strlen(response_hex) ||
+	    lws_timingsafe_bcmp(expected_hex, response_hex,
+				(uint32_t)strlen(expected_hex))) {
+		lwsl_err("digest auth: response mismatch for user '%s'\n",
+			 username);
+		return LCBA_FAILED_AUTH;
+	}
+
+	/*
+	 * Validate nonce count (nc) to detect replay within the same
+	 * keep-alive connection.  The nc value must increase monotonically.
+	 */
+	if (nc_str[0]) {
+		unsigned long ul;
+		char *endptr;
+
+		ul = strtoul(nc_str, &endptr, 16);
+		if (*endptr || !endptr || ul == ULONG_MAX ||
+		    (uint32_t)ul <= wsi->http.digest_auth_nc) {
+			lwsl_err("digest auth: nc replay detected "
+				 "(nc=%lu, last=%u)\n",
+				 ul, wsi->http.digest_auth_nc);
+			return LCBA_FAILED_AUTH;
+		}
+		wsi->http.digest_auth_nc = (uint32_t)ul;
+	}
+
+	/*
+	 * Rewrite WSI_TOKEN_HTTP_AUTHORIZATION so it contains only the
+	 * authenticated username -- same convention as Basic Auth.
+	 */
+	lws_authorization_rewrite(wsi, username, strlen(username));
+
+	lwsl_wsi_info(wsi, "digest auth accepted for '%s'\n", username);
+
+	return LCBA_CONTINUE;
+#else
+	if (!htdigest_file)
+		return LCBA_CONTINUE;
+	return LCBA_FAILED_AUTH;
+#endif
+}
+
+#endif /* LWS_WITH_HTTP_DIGEST_AUTH */
+
 #if defined(LWS_WITH_HTTP_PROXY)
 /*
  * Set up an onward http proxy connection according to the mount this
@@ -2199,6 +2781,26 @@ lws_http_action(struct lws *wsi)
 	case LCBA_END_TRANSACTION:
 		lws_return_http_status(wsi, HTTP_STATUS_FORBIDDEN, NULL);
 		return lws_http_transaction_completed(wsi);
+	}
+#endif
+
+#if defined(LWS_WITH_HTTP_DIGEST_AUTH)
+
+	/* digest auth? */
+
+	if ((hit->auth_mask & AUTH_MODE_MASK) == LWSAUTHM_DIGEST_AUTH) {
+		switch (lws_check_digest_auth(wsi, hit->basic_auth_login_file,
+					      hit->basic_auth_realm)) {
+		case LCBA_CONTINUE:
+		case LCBA_AUTH_RETRY_KEEPALIVE:
+			break;
+		case LCBA_FAILED_AUTH:
+			return lws_unauthorised_digest_auth(wsi,
+						hit->basic_auth_realm);
+		case LCBA_END_TRANSACTION:
+			lws_return_http_status(wsi, HTTP_STATUS_FORBIDDEN, NULL);
+			return lws_http_transaction_completed(wsi);
+		}
 	}
 #endif
 

--- a/lib/roles/ws/server-ws.c
+++ b/lib/roles/ws/server-ws.c
@@ -300,6 +300,40 @@ lws_process_ws_upgrade2(struct lws *wsi)
 		}
 	}
 #endif
+#if defined(LWS_WITH_HTTP_DIGEST_AUTH)
+	{
+		const struct lws_protocol_vhost_options *dpvos =
+			lws_vhost_protocol_options(wsi->a.vhost,
+						   wsi->a.protocol->name);
+		const char *ws_prot_digest_auth = NULL;
+		const char *ws_prot_digest_realm = NULL;
+
+		if (dpvos && dpvos->options &&
+		    lws_pvo_search(dpvos->options, "digest-auth")) {
+			const struct lws_protocol_vhost_options *pvo_realm;
+
+			ws_prot_digest_auth = lws_pvo_search(dpvos->options,
+						     "digest-auth")->value;
+			pvo_realm = lws_pvo_search(dpvos->options,
+						   "digest-auth-realm");
+			if (pvo_realm)
+				ws_prot_digest_realm = pvo_realm->value;
+			switch (lws_check_digest_auth(wsi, ws_prot_digest_auth,
+						      ws_prot_digest_realm)) {
+			case LCBA_CONTINUE:
+			case LCBA_AUTH_RETRY_KEEPALIVE:
+				break;
+			case LCBA_FAILED_AUTH:
+				return lws_unauthorised_digest_auth(wsi,
+						ws_prot_digest_realm);
+			case LCBA_END_TRANSACTION:
+				lws_return_http_status(wsi,
+						HTTP_STATUS_FORBIDDEN, NULL);
+				return lws_http_transaction_completed(wsi);
+			}
+		}
+	}
+#endif
 
 	/*
 	 * We are upgrading to ws, so http/1.1 + h2 and keepalive + pipelined

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(lws-minimal-http-server-digestauth C)
+cmake_minimum_required(VERSION 3.10)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SAMP lws-minimal-http-server-digestauth)
+set(SRCS minimal-http-server-digestauth.c)
+
+set(requirements 1)
+require_lws_config(LWS_ROLE_H1 1 requirements)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
+require_lws_config(LWS_WITH_HTTP_DIGEST_AUTH 1 requirements)
+
+if (requirements)
+	add_executable(${SAMP} ${SRCS})
+
+	if (websockets_shared)
+		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${SAMP} websockets_shared)
+	else()
+		target_link_libraries(${SAMP} websockets ${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+endif()

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/README.md
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/README.md
@@ -1,0 +1,51 @@
+# lws minimal http server digest auth
+
+Demonstrates protecting a mount with HTTP Digest Auth using an
+htdigest-format password file.
+
+The demo has two mounts: a normal one at `/` and one protected by
+Digest Auth at `/secret`.
+
+The file `./da-passwords` contains valid credentials in htdigest format:
+
+```
+username:realm:HA1hex
+```
+
+where `HA1hex` is the lowercase hex MD5 digest of `"username:realm:password"`.
+
+The supplied file has `user:lwsws:f919cc9b...` which corresponds to
+username `user`, realm `lwsws`, password `password`.
+
+You can manage the file with the standard `htdigest` tool:
+
+```
+htdigest -c ./da-passwords lwsws user
+```
+
+## Discovering the authenticated user
+
+After successful authentication, the `WSI_TOKEN_HTTP_AUTHORIZATION` token
+contains the authenticated username, matching the Basic Auth convention.
+
+## build
+
+```
+ $ cmake . && make
+```
+
+## usage
+
+```
+ $ ./lws-minimal-http-server-digestauth
+[...] USER: LWS minimal http server digest auth | visit http://localhost:7681
+```
+
+Visit `http://localhost:7681`, follow the link to `/secret`, and enter
+`user` / `password` when the browser prompts.
+
+You can also test with `curl`:
+
+```
+$ curl --digest -u user:password http://localhost:7681/secret/index.html
+```

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/da-passwords
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/da-passwords
@@ -1,0 +1,1 @@
+user:lwsws:f919cc9b26ce72f3731ab604a9c7b4ff

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/minimal-http-server-digestauth.c
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/minimal-http-server-digestauth.c
@@ -1,0 +1,87 @@
+/*
+ * lws-minimal-http-server-digestauth
+ *
+ * Written in 2010-2026 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ *
+ * This demonstrates a minimal http server with a second mount that
+ * is protected using an htdigest password file and HTTP Digest Auth.
+ *
+ * To keep it simple, it serves the static stuff from the subdirectory
+ * "./mount-origin" of the directory it was started in.
+ *
+ * The /secret mount is protected by Digest Auth using the file
+ * ./da-passwords (htdigest format: username:realm:HA1hex per line).
+ *
+ * You can create or manage the password file with the htdigest tool:
+ *
+ *   htdigest -c ./da-passwords lwsws user
+ *
+ * The supplied ./da-passwords has credentials user:password for realm lwsws.
+ */
+
+#include <libwebsockets.h>
+#include <string.h>
+#include <signal.h>
+
+static int interrupted;
+
+/* /secret mount protected by Digest Auth */
+static const struct lws_http_mount mount_secret = {
+	.mountpoint		= "/secret",
+	.origin			= "./mount-secret-origin",
+	.def			= "index.html",
+	.origin_protocol	= LWSMPRO_FILE,
+	.mountpoint_len		= 7,
+	.basic_auth_login_file	= "./da-passwords",
+	.basic_auth_realm	= "lwsws",
+	.auth_mask		= LWSAUTHM_DIGEST_AUTH,
+};
+
+/* default mount serves the URL space from ./mount-origin */
+static const struct lws_http_mount mount = {
+	.mount_next		= &mount_secret,
+	.mountpoint		= "/",
+	.origin			= "./mount-origin",
+	.def			= "index.html",
+	.origin_protocol	= LWSMPRO_FILE,
+	.mountpoint_len		= 1,
+};
+
+void sigint_handler(int sig)
+{
+	interrupted = 1;
+}
+
+int main(int argc, const char **argv)
+{
+	struct lws_context_creation_info info;
+	struct lws_context *context;
+	int n = 0;
+
+	signal(SIGINT, sigint_handler);
+
+	lwsl_user("LWS minimal http server digest auth | visit http://localhost:7681\n");
+
+	lws_context_info_defaults(&info, NULL);
+	lws_cmdline_option_handle_builtin(argc, argv, &info);
+	info.port = 7681;
+	info.mounts = &mount;
+	info.options =
+		LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE;
+
+	context = lws_create_context(&info);
+	if (!context) {
+		lwsl_err("lws init failed\n");
+		return 1;
+	}
+
+	while (n >= 0 && !interrupted)
+		n = lws_service(context, 0);
+
+	lws_context_destroy(context);
+
+	return 0;
+}

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/mount-origin/index.html
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/mount-origin/index.html
@@ -1,0 +1,17 @@
+<html>
+ <head>
+  <meta charset=utf-8 http-equiv="Content-Language" content="en"/>
+ </head>
+ <body>
+  <b>lws minimal http server digest auth example</b>
+  <p>
+  This is a static page served from ./mount-origin/index.html.
+  <p>
+  The URL space under /secret is protected by HTTP Digest Auth.<br>
+  Your browser will prompt for credentials.  The htdigest file<br>
+  ./da-passwords contains the entry for realm "lwsws":<br>
+  username <b>user</b>, password <b>password</b>.
+  <p>
+  <a href="/secret/" target=_blank>/secret</a>
+ </body>
+</html>

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/mount-secret-origin/index.html
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-digestauth/mount-secret-origin/index.html
@@ -1,0 +1,8 @@
+<html>
+ <head>
+  <meta charset=utf-8 http-equiv="Content-Language" content="en"/>
+ </head>
+ <body>
+  This is the secret area protected by <b>HTTP Digest Auth</b>.
+ </body>
+</html>


### PR DESCRIPTION
Add server-side HTTP Digest Auth support using the standard htdigest file format (username:realm:HA1_hex per line).

- New mount auth mode LWSAUTHM_DIGEST_AUTH
- New mount field basic_auth_realm for the auth realm
- lws_check_digest_auth() parses Authorization: Digest headers and validates against the htdigest file
- lws_unauthorised_digest_auth() sends 401 with a fresh random nonce
- Nonce is stored per-wsi and verified on keep-alive retries
- Constant-time response comparison via lws_timingsafe_bcmp
- Wired into HTTP/1.1, HTTP/2 and WS upgrade paths
- Added minimal example minimal-http-server-digestauth
- LWS_WITH_HTTP_DIGEST_AUTH now implies LWS_WITH_HTTP_BASIC_AUTH so the shared lws_authorization_rewrite helper is available