### PR TITLE
quic: select AEAD and header-protection cipher from negotiated suite

### DIFF
--- a/include/libwebsockets/lws-quic.h
+++ b/include/libwebsockets/lws-quic.h
@@ -38,6 +38,22 @@ enum lws_tls_quic_secret_type {
 	LWS_TLS_QUIC_SECRET_SERVER_APPLICATION,
 };
 
+/*
+ * RFC 9001 4.1 / 5.3 / 5.4: the QUIC packet-protection AEAD and the header-
+ * protection cipher are both fixed by the negotiated TLS 1.3 cipher suite, and
+ * cannot be inferred from the traffic-secret length alone (TLS_AES_128_GCM_
+ * SHA256 and TLS_CHACHA20_POLY1305_SHA256 both use SHA-256 and so produce a
+ * 32-byte secret).  The TLS backend reports the negotiated AEAD to the QUIC
+ * role via wsi->tls.quic_aead so the correct algorithms are selected.
+ */
+enum lws_tls_quic_aead {
+	LWS_TLS_QUIC_AEAD_UNKNOWN,	   /**< backend didn't report; caller
+					     * falls back to length heuristic */
+	LWS_TLS_QUIC_AEAD_AES_128_GCM,	   /**< TLS_AES_128_GCM_SHA256 */
+	LWS_TLS_QUIC_AEAD_AES_256_GCM,	   /**< TLS_AES_256_GCM_SHA384 */
+	LWS_TLS_QUIC_AEAD_CHACHA20_POLY1305, /**< TLS_CHACHA20_POLY1305_SHA256 */
+};
+
 enum lws_0rtt_status {
 	LWS_0RTT_STATUS_NONE,       /**< No 0-RTT attempted */
 	LWS_0RTT_STATUS_ATTEMPTED,  /**< Client sent 0-RTT, awaiting server decision */

--- a/lib/roles/h3/ops-h3.c
+++ b/lib/roles/h3/ops-h3.c
@@ -361,6 +361,29 @@ rops_perform_user_POLLOUT_h3(struct lws *wsi)
 			lwsl_wsi_err(wsi, "lws_h3_client_handshake failed!");
 			return -1;
 		}
+
+		/*
+		 * The request headers (+FIN for GET) have been sent.  Bound the
+		 * wait for the server's response the same way the H1 client does
+		 * (client-http.c lws_http_client_socket_service), so an H3 stream
+		 * whose reply is lost to packet corruption, a silent/blackholed
+		 * peer, or a key-phase desync fails cleanly here instead of
+		 * hanging on an otherwise-live QUIC connection forever.
+		 *
+		 * LRS_WAITING_SERVER_REPLY is chosen (rather than staying in
+		 * LRS_ESTABLISHED, which lws_h3_client_handshake() just set) so
+		 * that, if the timeout fires, lws_sul_wsitimeout_cb() delivers the
+		 * informative LWS_CALLBACK_CLIENT_CONNECTION_ERROR "Timed out
+		 * waiting server reply" that H1 clients get.  On the first response
+		 * bytes the timeout is cleared and the state advanced to
+		 * LRS_ESTABLISHED by lws_client_interpret_server_handshake()
+		 * (client-http.c); the LRS_ESTABLISHED POLLOUT branch below is only
+		 * used for client body upload / writeable, which does not happen
+		 * while we are waiting for the reply to a request we just sent.
+		 */
+		lwsi_set_state(wsi, LRS_WAITING_SERVER_REPLY);
+		lws_set_timeout(wsi, PENDING_TIMEOUT_AWAITING_SERVER_RESPONSE,
+				(int)wsi->a.context->timeout_secs);
 #endif
 		return 0;
 	}

--- a/lib/roles/quic/crypto-quic.c
+++ b/lib/roles/quic/crypto-quic.c
@@ -39,6 +39,39 @@ static const uint8_t quic_v2_initial_salt[20] = {
 	0xf9, 0xbd, 0x2e, 0xd9
 };
 
+/*
+ * RFC 9001 5.3 / 5.4: the QUIC packet-protection AEAD and the header-protection
+ * cipher are both fixed by the negotiated TLS 1.3 cipher suite:
+ *
+ *   TLS_AES_128_GCM_SHA256       -> AEAD AES-128-GCM,       HP AES-128-ECB
+ *   TLS_AES_256_GCM_SHA384       -> AEAD AES-256-GCM,       HP AES-256-ECB
+ *   TLS_CHACHA20_POLY1305_SHA256 -> AEAD ChaCha20-Poly1305, HP ChaCha20
+ *
+ * They must NOT be inferred from the traffic-secret length: AES-128-GCM and
+ * ChaCha20-Poly1305 both use SHA-256, so both yield a 32-byte secret.  The TLS
+ * backend reports the negotiated AEAD in wsi->tls.quic_aead; only when it did
+ * not (LWS_TLS_QUIC_AEAD_UNKNOWN, e.g. a backend that doesn't plumb it through)
+ * do we fall back to the length heuristic, which can still tell AES-256-GCM
+ * (48-byte / SHA-384) from AES-128-GCM but is blind to ChaCha20.
+ *
+ * Maps to the internal cipher_type used throughout this file:
+ *   0 = AES-128-GCM, 1 = ChaCha20-Poly1305, 2 = AES-256-GCM.
+ */
+static uint8_t
+lws_quic_cipher_type(struct lws *wsi, size_t secret_len)
+{
+	switch (wsi->tls.quic_aead) {
+	case LWS_TLS_QUIC_AEAD_AES_128_GCM:
+		return 0;
+	case LWS_TLS_QUIC_AEAD_CHACHA20_POLY1305:
+		return 1;
+	case LWS_TLS_QUIC_AEAD_AES_256_GCM:
+		return 2;
+	default:
+		return (secret_len == 48) ? 2 : 0;
+	}
+}
+
 static int
 lws_quic_derive_key_iv_hp(uint8_t *secret, size_t secret_len, uint8_t cipher_type,
 			  uint8_t *iv, size_t iv_len,
@@ -265,7 +298,7 @@ lws_quic_set_keys(struct lws *wsi, enum lws_tls_quic_secret_type type, const uin
                 }
                 k->secret_len = secret_len > 48 ? 48 : secret_len;
                 memcpy(k->secret_rx, secret, k->secret_len);
-                if (k->cipher_type != 1) k->cipher_type = (k->secret_len == 48) ? 2 : 0;
+                k->cipher_type = lws_quic_cipher_type(wsi, k->secret_len);
                 if (lws_quic_derive_key_iv_hp(k->secret_rx, k->secret_len, k->cipher_type, k->iv_rx, sizeof(k->iv_rx),
                                               &k->el_aead_rx, k->key_aead_rx, &k->el_hp_rx, k->key_hp_rx))
                         return -1;
@@ -276,7 +309,7 @@ lws_quic_set_keys(struct lws *wsi, enum lws_tls_quic_secret_type type, const uin
                 }
                 k->secret_len = secret_len > 48 ? 48 : secret_len;
                 memcpy(k->secret_tx, secret, k->secret_len);
-                if (k->cipher_type != 1) k->cipher_type = (k->secret_len == 48) ? 2 : 0;
+                k->cipher_type = lws_quic_cipher_type(wsi, k->secret_len);
                 if (lws_quic_derive_key_iv_hp(k->secret_tx, k->secret_len, k->cipher_type, k->iv_tx, sizeof(k->iv_tx),
                                               &k->el_aead_tx, k->key_aead_tx, &k->el_hp_tx, k->key_hp_tx))
                         return -1;

--- a/lib/tls/gnutls/gnutls-quic.c
+++ b/lib/tls/gnutls/gnutls-quic.c
@@ -72,6 +72,27 @@ gnutls_quic_secret_func(gnutls_session_t session,
 	if (!wsi || !wsi->tls.quic_secret_cb || secret_size > 48)
 		return 0;
 
+	/*
+	 * RFC 9001: report the negotiated AEAD so the QUIC role selects the
+	 * matching packet-protection and header-protection ciphers instead of
+	 * guessing from the secret length (AES-128-GCM and ChaCha20-Poly1305
+	 * both yield a 32-byte SHA-256 secret).
+	 */
+	switch (gnutls_cipher_get(session)) {
+	case GNUTLS_CIPHER_AES_128_GCM:
+		wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_AES_128_GCM;
+		break;
+	case GNUTLS_CIPHER_AES_256_GCM:
+		wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_AES_256_GCM;
+		break;
+	case GNUTLS_CIPHER_CHACHA20_POLY1305:
+		wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_CHACHA20_POLY1305;
+		break;
+	default:
+		/* leave any previously-reported suite in force */
+		break;
+	}
+
 	if (wsi->a.vhost)
 		is_client = lwsi_role_client(wsi) ? 1 : 0;
 	else

--- a/lib/tls/mbedtls/mbedtls-quic.c
+++ b/lib/tls/mbedtls/mbedtls-quic.c
@@ -24,6 +24,7 @@
 
 #include "private-lib-core.h"
 #include "private-lib-tls-mbedtls.h"
+#include <mbedtls/ssl_ciphersuites.h>
 
 void
 mbedtls_quic_bio_free(struct lws *wsi);
@@ -113,7 +114,8 @@ mbedtls_quic_set_traffic_secrets(mbedtls_ssl_context *ssl,
 			    mbedtls_ssl_secret_type_t type,
 			    const unsigned char *client_secret,
 			    const unsigned char *server_secret,
-			    size_t secret_len)
+			    size_t secret_len,
+			    int ciphersuite_id)
 {
 	struct lws *wsi = (struct lws *)mbedtls_ssl_get_user_data_p(ssl);
 	enum lws_tls_quic_secret_type ct, st;
@@ -123,6 +125,30 @@ mbedtls_quic_set_traffic_secrets(mbedtls_ssl_context *ssl,
 
 	if (wsi->tls.quic_secret_cb == (lws_tls_quic_secret_cb)1)
 		return 0;
+
+	/*
+	 * RFC 9001: the QUIC AEAD and header-protection algorithms are fixed
+	 * by the negotiated TLS 1.3 cipher suite, not by the secret length
+	 * (AES-128-GCM and ChaCha20-Poly1305 both use a 32-byte SHA-256
+	 * secret).  Record which one is in force so the QUIC role selects the
+	 * matching AEAD / HP cipher.  The negotiated suite is only available
+	 * here via the export callback: mbedtls_ssl_get_ciphersuite_id_from_
+	 * ssl() reads ssl->session, which is not yet populated mid-handshake.
+	 */
+	switch (ciphersuite_id) {
+	case MBEDTLS_TLS1_3_AES_128_GCM_SHA256:
+		wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_AES_128_GCM;
+		break;
+	case MBEDTLS_TLS1_3_AES_256_GCM_SHA384:
+		wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_AES_256_GCM;
+		break;
+	case MBEDTLS_TLS1_3_CHACHA20_POLY1305_SHA256:
+		wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_CHACHA20_POLY1305;
+		break;
+	default:
+		/* leave any previously-reported suite in force */
+		break;
+	}
 
 	switch (type) {
 	case MBEDTLS_SSL_SECRET_TYPE_EARLY:

--- a/lib/tls/openssl/openssl-quic.c
+++ b/lib/tls/openssl/openssl-quic.c
@@ -33,6 +33,30 @@
 
 #if defined(LWS_HAVE_BORINGSSL_QUIC_API)
 
+/*
+ * RFC 9001: the QUIC AEAD and header-protection ciphers are fixed by the
+ * negotiated TLS 1.3 cipher suite, not by the traffic-secret length
+ * (AES-128-GCM and ChaCha20-Poly1305 both use a 32-byte SHA-256 secret).  Map
+ * the negotiated suite's IANA code point to the enum the QUIC role consumes.
+ * SSL_CIPHER_get_id() returns 0x0300<id> on OpenSSL/BoringSSL, so mask to the
+ * low 16 bits; an unrecognised id leaves LWS_TLS_QUIC_AEAD_UNKNOWN and the QUIC
+ * role falls back to its length heuristic.
+ */
+static enum lws_tls_quic_aead
+lws_openssl_quic_aead_from_id(uint32_t cipher_id)
+{
+	switch (cipher_id & 0xffff) {
+	case 0x1301: /* TLS_AES_128_GCM_SHA256 */
+		return LWS_TLS_QUIC_AEAD_AES_128_GCM;
+	case 0x1302: /* TLS_AES_256_GCM_SHA384 */
+		return LWS_TLS_QUIC_AEAD_AES_256_GCM;
+	case 0x1303: /* TLS_CHACHA20_POLY1305_SHA256 */
+		return LWS_TLS_QUIC_AEAD_CHACHA20_POLY1305;
+	default:
+		return LWS_TLS_QUIC_AEAD_UNKNOWN;
+	}
+}
+
 #if defined(USE_WOLFSSL)
 
 static int
@@ -43,9 +67,20 @@ set_encryption_secrets(WOLFSSL *ssl, enum wolfssl_encryption_level_t level,
 {
 	struct lws *wsi = (struct lws *)SSL_get_app_data((SSL *)ssl);
 	enum lws_tls_quic_secret_type rt, wt;
+	const SSL_CIPHER *c;
 
 	if (!wsi || secret_len > 48)
 		return 0;
+
+	/*
+	 * Report the negotiated AEAD (see lws_openssl_quic_aead_from_id). The
+	 * wolfSSL callback carries no cipher, so query the negotiated one via
+	 * the OpenSSL-compat API this file already uses for wolfSSL.
+	 */
+	c = SSL_get_current_cipher((SSL *)ssl);
+	if (c)
+		wsi->tls.quic_aead = lws_openssl_quic_aead_from_id(
+					(uint32_t)SSL_CIPHER_get_id(c));
 
 	switch (level) {
 	case wolfssl_encryption_early_data:
@@ -150,6 +185,11 @@ set_read_secret(SSL *ssl, enum ssl_encryption_level_t level,
 	if (!wsi || secret_len > 48)
 		return 0;
 
+	/* Report the negotiated AEAD (see lws_openssl_quic_aead_from_id). */
+	if (cipher)
+		wsi->tls.quic_aead = lws_openssl_quic_aead_from_id(
+					(uint32_t)SSL_CIPHER_get_id(cipher));
+
 	switch (level) {
 	case ssl_encryption_early_data:
 		t = LWS_TLS_QUIC_SECRET_CLIENT_EARLY;
@@ -180,6 +220,11 @@ set_write_secret(SSL *ssl, enum ssl_encryption_level_t level,
 
 	if (!wsi || secret_len > 48)
 		return 0;
+
+	/* Report the negotiated AEAD (see lws_openssl_quic_aead_from_id). */
+	if (cipher)
+		wsi->tls.quic_aead = lws_openssl_quic_aead_from_id(
+					(uint32_t)SSL_CIPHER_get_id(cipher));
 
 	switch (level) {
 	case ssl_encryption_early_data:

--- a/lib/tls/private-network.h
+++ b/lib/tls/private-network.h
@@ -131,6 +131,9 @@ struct lws_lws_tls {
 	size_t			quic_tp_send_len;
 	lws_tls_quic_secret_cb	quic_secret_cb;
 	int			quic_alert;
+	uint8_t			quic_aead; /* enum lws_tls_quic_aead, set by the
+					    * TLS backend from the negotiated
+					    * TLS 1.3 cipher suite */
 
 	unsigned int		use_ssl;
 	unsigned int		redirect_to_https:1;

--- a/lib/tls/schannel/schannel-quic.c
+++ b/lib/tls/schannel/schannel-quic.c
@@ -528,6 +528,21 @@ lws_tls_quic_advance_handshake(struct lws *wsi, int level,
 						return -1;
 					}
 
+					/*
+					 * RFC 9001: report the negotiated AEAD so the QUIC role
+					 * picks the matching packet-/header-protection ciphers
+					 * rather than guessing from the secret length. SChannel
+					 * hands us the symmetric algorithm and key size directly;
+					 * it does not currently negotiate ChaCha20-Poly1305, but
+					 * map it too for completeness.
+					 */
+					if (!wcscmp(secrets->SymmetricAlgId, L"CHACHA20_POLY1305"))
+						wsi->tls.quic_aead = LWS_TLS_QUIC_AEAD_CHACHA20_POLY1305;
+					else if (!wcscmp(secrets->SymmetricAlgId, L"AES"))
+						wsi->tls.quic_aead = secrets->KeySize == 256 ?
+							LWS_TLS_QUIC_AEAD_AES_256_GCM :
+							LWS_TLS_QUIC_AEAD_AES_128_GCM;
+
 					/* SChannel outputs `1` and `2` for BOTH Handshake and Application secrets. */
 					if (type == 1 || type == 2) {
 						int idx = type - 1; /* 0 for Client, 1 for Server */

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-timeout-h3/CMakeLists.txt
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-timeout-h3/CMakeLists.txt
@@ -1,0 +1,49 @@
+project(lws-minimal-http-client-timeout-h3 C)
+cmake_minimum_required(VERSION 3.10)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SAMP lws-minimal-http-client-timeout-h3)
+set(SRCS minimal-http-client-timeout-h3.c)
+
+set(requirements 1)
+require_lws_config(LWS_ROLE_QUIC 1 requirements)
+require_lws_config(LWS_WITH_HTTP3 1 requirements)
+require_lws_config(LWS_WITH_CLIENT 1 requirements)
+require_lws_config(LWS_WITH_SERVER 1 requirements)
+
+if (requirements)
+	add_executable(${SAMP} ${SRCS})
+
+	if (websockets_shared)
+		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${SAMP} websockets_shared)
+	else()
+		target_link_libraries(${SAMP} websockets ${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+
+	if (LWS_WITH_MINIMAL_EXAMPLES)
+		#
+		# The test starts the blackhole QUIC server (-s) on a free port,
+		# gives it a moment to bind, runs the client against it, then
+		# kills the server.  The client's success condition is that it
+		# times out awaiting the reply (the server never answers), which
+		# exercises the H3 client reply timeout.  We bundle server +
+		# client into a single ctest command with a tiny inline shell
+		# wrapper so the test is self-contained and does not depend on
+		# netstat/lsof-based port detection helpers.
+		#
+		# Expected exit codes: server (-s) always returns 0; the client
+		# returns 0 if it saw the timeout and non-zero otherwise, so the
+		# client exit code is the test result.
+		lws_get_free_port(PORT_H3TO)
+
+		add_test(NAME h3to COMMAND sh -c
+			"$<TARGET_FILE:${SAMP}> -s -p ${PORT_H3TO} -d1039 2>/dev/null & SRV=$!; sleep 2; $<TARGET_FILE:${SAMP}> -p ${PORT_H3TO} -d1039; RC=$?; kill $SRV 2>/dev/null; wait $SRV 2>/dev/null; exit $RC")
+		set_tests_properties(h3to PROPERTIES
+				     WORKING_DIRECTORY .
+				     TIMEOUT 40)
+	endif()
+endif()

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-timeout-h3/README.md
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-timeout-h3/README.md
@@ -1,0 +1,43 @@
+# lws-minimal-http-client-timeout-h3
+
+This tests the HTTP/3 client reply timeout.
+
+It runs as a single binary in two modes:
+
+ - by default, as a client that issues a single `GET` over HTTP/3 against the
+   blackhole server described below, and
+ - with `-s`, as a "blackhole" QUIC/H3 server that completes the QUIC + TLS
+   handshake but then deliberately never sends any H3 response.
+
+The intended outcome is that the **client times out** waiting for the server's
+reply and receives `LWS_CALLBACK_CLIENT_CONNECTION_ERROR` ("Timed out waiting
+server reply") within the context timeout — rather than hanging on the live
+QUIC connection indefinitely, which was the historical gap this example pins
+down.
+
+When run under ctest, the blackhole server is started with `-s` on a free port
+as a background fixture, and the client is then run against it.  The client
+returns `0` if it timed out as expected, and non-zero otherwise.
+
+## Build
+
+```bash
+ $ cmake . && make
+```
+
+## Usage (manual)
+
+In one terminal, start the blackhole server:
+
+```bash
+ $ ./lws-minimal-http-client-timeout-h3 -s -p 7681 -d 1039
+```
+
+In another, run the client against it:
+
+```bash
+ $ ./lws-minimal-http-client-timeout-h3 -p 7681 -d 1039
+```
+
+The client should report `Completed: OK (timed out as expected)` after the
+short reply timeout configured via `info.timeout_secs`.

--- a/minimal-examples-lowlevel/http-client/minimal-http-client-timeout-h3/minimal-http-client-timeout-h3.c
+++ b/minimal-examples-lowlevel/http-client/minimal-http-client-timeout-h3/minimal-http-client-timeout-h3.c
@@ -1,0 +1,427 @@
+/*
+ * lws-minimal-http-client-timeout-h3
+ *
+ * Written in 2026 by Andy Green <andy@warmcat.com>
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ *
+ * This demonstrates and tests the H3 client reply timeout: an HTTP/3 GET is
+ * issued against a "blackhole" server that completes the QUIC + TLS handshake
+ * but then deliberately never sends any H3 response.  The client must receive
+ * LWS_CALLBACK_CLIENT_CONNECTION_ERROR ("Timed out waiting server reply")
+ * within the context timeout, rather than hanging on the live QUIC connection
+ * forever.
+ *
+ * Run with no args: client mode (connects to --server/-p, expects a timeout).
+ * Run with -s:     server mode, the blackhole responder (listens on -p).
+ *
+ * The test is driven by ctest, which starts the server (-s) as a background
+ * fixture and then runs the client against it.
+ */
+
+#include <libwebsockets.h>
+#include <string.h>
+#include <signal.h>
+
+/* A short, deterministic reply timeout for the client. */
+#define CLIENT_TIMEOUT_SECS	4
+
+static int interrupted, bad = 1;
+static struct lws *client_wsi;
+static int _argc;
+static const char **_argv;
+static int server_mode;
+
+/*
+ * We reuse the canned self-signed cert/key that the other QUIC examples ship,
+ * so the test is fully self-contained and needs no on-disk artefacts.
+ */
+static const char * const test_cert =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIF5jCCA86gAwIBAgIJANq50IuwPFKgMA0GCSqGSIb3DQEBCwUAMIGGMQswCQYD\n"
+"VQQGEwJHQjEQMA4GA1UECAwHRXJld2hvbjETMBEGA1UEBwwKQWxsIGFyb3VuZDEb\n"
+"MBkGA1UECgwSbGlid2Vic29ja2V0cy10ZXN0MRIwEAYDVQQDDAlsb2NhbGhvc3Qx\n"
+"HzAdBgkqhkiG9w0BCQEWEG5vbmVAaW52YWxpZC5vcmcwIBcNMTgwMzIwMDQxNjA3\n"
+"WhgPMjExODAyMjQwNDE2MDdaMIGGMQswCQYDVQQGEwJHQjEQMA4GA1UECAwHRXJl\n"
+"d2hvbjETMBEGA1UEBwwKQWxsIGFyb3VuZDEbMBkGA1UECgwSbGlid2Vic29ja2V0\n"
+"cy10ZXN0MRIwEAYDVQQDDAlsb2NhbGhvc3QxHzAdBgkqhkiG9w0BCQEWEG5vbmVA\n"
+"aW52YWxpZC5vcmcwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCjYtuW\n"
+"aICCY0tJPubxpIgIL+WWmz/fmK8IQr11Wtee6/IUyUlo5I602mq1qcLhT/kmpoR8\n"
+"Di3DAmHKnSWdPWtn1BtXLErLlUiHgZDrZWInmEBjKM1DZf+CvNGZ+EzPgBv5nTek\n"
+"LWcfI5ZZtoGuIP1Dl/IkNDw8zFz4cpiMe/BFGemyxdHhLrKHSm8Eo+nT734tItnH\n"
+"KT/m6DSU0xlZ13d6ehLRm7/+Nx47M3XMTRH5qKP/7TTE2s0U6+M0tsGI2zpRi+m6\n"
+"jzhNyMBTJ1u58qAe3ZW5/+YAiuZYAB6n5bhUp4oFuB5wYbcBywVR8ujInpF8buWQ\n"
+"Ujy5N8pSNp7szdYsnLJpvAd0sibrNPjC0FQCNrpNjgJmIK3+mKk4kXX7ZTwefoAz\n"
+"TK4l2pHNuC53QVc/EF++GBLAxmvCDq9ZpMIYi7OmzkkAKKC9Ue6Ef217LFQCFIBK\n"
+"Izv9cgi9fwPMLhrKleoVRNsecBsCP569WgJXhUnwf2lon4fEZr3+vRuc9shfqnV0\n"
+"nPN1IMSnzXCast7I2fiuRXdIz96KjlGQpP4XfNVA+RGL7aMnWOFIaVrKWLzAtgzo\n"
+"GMTvP/AuehKXncBJhYtW0ltTioVx+5yTYSAZWl+IssmXjefxJqYi2/7QWmv1QC9p\n"
+"sNcjTMaBQLN03T1Qelbs7Y27sxdEnNUth4kI+wIDAQABo1MwUTAdBgNVHQ4EFgQU\n"
+"9mYU23tW2zsomkKTAXarjr2vjuswHwYDVR0jBBgwFoAU9mYU23tW2zsomkKTAXar\n"
+"jr2vjuswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEANjIBMrow\n"
+"YNCbhAJdP7dhlhT2RUFRdeRUJD0IxrH/hkvb6myHHnK8nOYezFPjUlmRKUgNEDuA\n"
+"xbnXZzPdCRNV9V2mShbXvCyiDY7WCQE2Bn44z26O0uWVk+7DNNLH9BnkwUtOnM9P\n"
+"wtmD9phWexm4q2GnTsiL6Ul6cy0QlTJWKVLEUQQ6yda582e23J1AXqtqFcpfoE34\n"
+"H3afEiGy882b+ZBiwkeV+oq6XVF8sFyr9zYrv9CvWTYlkpTQfLTZSsgPdEHYVcjv\n"
+"xQ2D+XyDR0aRLRlvxUa9dHGFHLICG34Juq5Ai6lM1EsoD8HSsJpMcmrH7MWw2cKk\n"
+"ujC3rMdFTtte83wF1uuF4FjUC72+SmcQN7A386BC/nk2TTsJawTDzqwOu/VdZv2g\n"
+"1WpTHlumlClZeP+G/jkSyDwqNnTu1aodDmUa4xZodfhP1HWPwUKFcq8oQr148QYA\n"
+"AOlbUOJQU7QwRWd1VbnwhDtQWXC92A2w1n/xkZSR1BM/NUSDhkBSUU1WjMbWg6Gg\n"
+"mnIZLRerQCu1Oozr87rOQqQakPkyt8BUSNK3K42j2qcfhAONdRl8Hq8Qs5pupy+s\n"
+"8sdCGDlwR3JNCMv6u48OK87F4mcIxhkSefFJUFII25pCGN5WtE4p5l+9cnO1GrIX\n"
+"e2Hl/7M0c/lbZ4FvXgARlex2rkgS0Ka06HE=\n"
+"-----END CERTIFICATE-----\n";
+static const char * const test_key =
+"-----BEGIN PRIVATE KEY-----\n"
+"MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQCjYtuWaICCY0tJ\n"
+"PubxpIgIL+WWmz/fmK8IQr11Wtee6/IUyUlo5I602mq1qcLhT/kmpoR8Di3DAmHK\n"
+"nSWdPWtn1BtXLErLlUiHgZDrZWInmEBjKM1DZf+CvNGZ+EzPgBv5nTekLWcfI5ZZ\n"
+"toGuIP1Dl/IkNDw8zFz4cpiMe/BFGemyxdHhLrKHSm8Eo+nT734tItnHKT/m6DSU\n"
+"0xlZ13d6ehLRm7/+Nx47M3XMTRH5qKP/7TTE2s0U6+M0tsGI2zpRi+m6jzhNyMBT\n"
+"J1u58qAe3ZW5/+YAiuZYAB6n5bhUp4oFuB5wYbcBywVR8ujInpF8buWQUjy5N8pS\n"
+"Np7szdYsnLJpvAd0sibrNPjC0FQCNrpNjgJmIK3+mKk4kXX7ZTwefoAzTK4l2pHN\n"
+"uC53QVc/EF++GBLAxmvCDq9ZpMIYi7OmzkkAKKC9Ue6Ef217LFQCFIBKIzv9cgi9\n"
+"fwPMLhrKleoVRNsecBsCP569WgJXhUnwf2lon4fEZr3+vRuc9shfqnV0nPN1IMSn\n"
+"zXCast7I2fiuRXdIz96KjlGQpP4XfNVA+RGL7aMnWOFIaVrKWLzAtgzoGMTvP/Au\n"
+"ehKXncBJhYtW0ltTioVx+5yTYSAZWl+IssmXjefxJqYi2/7QWmv1QC9psNcjTMaB\n"
+"QLN03T1Qelbs7Y27sxdEnNUth4kI+wIDAQABAoICAFWe8MQZb37k2gdAV3Y6aq8f\n"
+"qokKQqbCNLd3giGFwYkezHXoJfg6Di7oZxNcKyw35LFEghkgtQqErQqo35VPIoH+\n"
+"vXUpWOjnCmM4muFA9/cX6mYMc8TmJsg0ewLdBCOZVw+wPABlaqz+0UOiSMMftpk9\n"
+"fz9JwGd8ERyBsT+tk3Qi6D0vPZVsC1KqxxL/cwIFd3Hf2ZBtJXe0KBn1pktWht5A\n"
+"Kqx9mld2Ovl7NjgiC1Fx9r+fZw/iOabFFwQA4dr+R8mEMK/7bd4VXfQ1o/QGGbMT\n"
+"G+ulFrsiDyP+rBIAaGC0i7gDjLAIBQeDhP409ZhswIEc/GBtODU372a2CQK/u4Q/\n"
+"HBQvuBtKFNkGUooLgCCbFxzgNUGc83GB/6IwbEM7R5uXqsFiE71LpmroDyjKTlQ8\n"
+"YZkpIcLNVLw0usoGYHFm2rvCyEVlfsE3Ub8cFyTFk50SeOcF2QL2xzKmmbZEpXgl\n"
+"xBHR0hjgon0IKJDGfor4bHO7Nt+1Ece8u2oTEKvpz5aIn44OeC5mApRGy83/0bvs\n"
+"esnWjDE/bGpoT8qFuy+0urDEPNId44XcJm1IRIlG56ErxC3l0s11wrIpTmXXckqw\n"
+"zFR9s2z7f0zjeyxqZg4NTPI7wkM3M8BXlvp2GTBIeoxrWB4V3YArwu8QF80QBgVz\n"
+"mgHl24nTg00UH1OjZsABAoIBAQDOxftSDbSqGytcWqPYP3SZHAWDA0O4ACEM+eCw\n"
+"au9ASutl0IDlNDMJ8nC2ph25BMe5hHDWp2cGQJog7pZ/3qQogQho2gUniKDifN77\n"
+"40QdykllTzTVROqmP8+efreIvqlzHmuqaGfGs5oTkZaWj5su+B+bT+9rIwZcwfs5\n"
+"YRINhQRx17qa++xh5mfE25c+M9fiIBTiNSo4lTxWMBShnK8xrGaMEmN7W0qTMbFH\n"
+"PgQz5FcxRjCCqwHilwNBeLDTp/ZECEB7y34khVh531mBE2mNzSVIQcGZP1I/DvXj\n"
+"W7UUNdgFwii/GW+6M0uUDy23UVQpbFzcV8o1C2nZc4Fb4zwBAoIBAQDKSJkFwwuR\n"
+"naVJS6WxOKjX8MCu9/cKPnwBv2mmI2jgGxHTw5sr3ahmF5eTb8Zo19BowytN+tr6\n"
+"2ZFoIBA9Ubc9esEAU8l3fggdfM82cuR9sGcfQVoCh8tMg6BP8IBLOmbSUhN3PG2m\n"
+"39I802u0fFNVQCJKhx1m1MFFLOu7lVcDS9JN+oYVPb6MDfBLm5jOiPuYkFZ4gH79\n"
+"J7gXI0/YKhaJ7yXthYVkdrSF6Eooer4RZgma62Dd1VNzSq3JBo6rYjF7Lvd+RwDC\n"
+"R1thHrmf/IXplxpNVkoMVxtzbrrbgnC25QmvRYc0rlS/kvM4yQhMH3eA7IycDZMp\n"
+"Y+0xm7I7jTT7AoIBAGKzKIMDXdCxBWKhNYJ8z7hiItNl1IZZMW2TPUiY0rl6yaCh\n"
+"BVXjM9W0r07QPnHZsUiByqb743adkbTUjmxdJzjaVtxN7ZXwZvOVrY7I7fPWYnCE\n"
+"fXCr4+IVpZI/ZHZWpGX6CGSgT6EOjCZ5IUufIvEpqVSmtF8MqfXO9o9uIYLokrWQ\n"
+"x1dBl5UnuTLDqw8bChq7O5y6yfuWaOWvL7nxI8NvSsfj4y635gIa/0dFeBYZEfHI\n"
+"UlGdNVomwXwYEzgE/c19ruIowX7HU/NgxMWTMZhpazlxgesXybel+YNcfDQ4e3RM\n"
+"OMz3ZFiaMaJsGGNf4++d9TmMgk4Ns6oDs6Tb9AECggEBAJYzd+SOYo26iBu3nw3L\n"
+"65uEeh6xou8pXH0Tu4gQrPQTRZZ/nT3iNgOwqu1gRuxcq7TOjt41UdqIKO8vN7/A\n"
+"aJavCpaKoIMowy/aGCbvAvjNPpU3unU8jdl/t08EXs79S5IKPcgAx87sTTi7KDN5\n"
+"SYt4tr2uPEe53NTXuSatilG5QCyExIELOuzWAMKzg7CAiIlNS9foWeLyVkBgCQ6S\n"
+"me/L8ta+mUDy37K6vC34jh9vK9yrwF6X44ItRoOJafCaVfGI+175q/eWcqTX4q+I\n"
+"G4tKls4sL4mgOJLq+ra50aYMxbcuommctPMXU6CrrYyQpPTHMNVDQy2ttFdsq9iK\n"
+"TncCggEBAMmt/8yvPflS+xv3kg/ZBvR9JB1In2n3rUCYYD47ReKFqJ03Vmq5C9nY\n"
+"56s9w7OUO8perBXlJYmKZQhO4293lvxZD2Iq4NcZbVSCMoHAUzhzY3brdgtSIxa2\n"
+"gGveGAezZ38qKIU26dkz7deECY4vrsRkwhpTW0LGVCpjcQoaKvymAoCmAs8V2oMr\n"
+"Ziw1YQ9uOUoWwOqm1wZqmVcOXvPIS2gWAs3fQlWjH9hkcQTMsUaXQDOD0aqkSY3E\n"
+"NqOvbCV1/oUpRi3076khCoAXI1bKSn/AvR3KDP14B5toHI/F5OTSEiGhhHesgRrs\n"
+"fBrpEY1IATtPq1taBZZogRqI3rOkkPk=\n"
+"-----END PRIVATE KEY-----\n";
+
+
+/*
+ * Server (blackhole) HTTP protocol: accept the request, then deliberately do
+ * nothing.  No response is ever produced, so the client's reply timeout is the
+ * only thing that can resolve the stream.
+ */
+static int
+callback_blackhole_http(struct lws *wsi, enum lws_callback_reasons reason,
+			void *user, void *in, size_t len)
+{
+	switch (reason) {
+
+	case LWS_CALLBACK_HTTP:
+		/* Acknowledge we got the request, but never answer it. */
+		lwsl_notice("%s: blackhole: received request, not responding\n",
+			    __func__);
+		return 0;
+
+	default:
+		break;
+	}
+
+	return lws_callback_http_dummy(wsi, reason, user, in, len);
+}
+
+static const struct lws_protocols server_protocols[] = {
+	{ "http", callback_blackhole_http, 0, 0, 0, NULL, 0 },
+	LWS_PROTOCOL_LIST_TERM
+};
+
+/*
+ * Client HTTP protocol: we only succeed by receiving the connection-error
+ * callback that fires when PENDING_TIMEOUT_AWAITING_SERVER_RESPONSE expires.
+ */
+static int
+callback_client_http(struct lws *wsi, enum lws_callback_reasons reason,
+		     void *user, void *in, size_t len)
+{
+	switch (reason) {
+
+	case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
+		lwsl_notice("CLIENT_CONNECTION_ERROR: %s\n",
+			    in ? (char *)in : "(null)");
+		/*
+		 * This is the expected outcome: the reply timeout fired while
+		 * we were in LRS_WAITING_SERVER_REPLY.
+		 */
+		interrupted = 1;
+		bad = 0;
+		lws_cancel_service(lws_get_context(wsi));
+		break;
+
+	case LWS_CALLBACK_ESTABLISHED_CLIENT_HTTP:
+		/* If the blackhole actually answered, the timeout is moot; the
+		 * response would be cleared and we'd come here.  That's not what
+		 * this test wants, so treat it as a failure. */
+		lwsl_err("Unexpected response from blackhole server\n");
+		interrupted = 1;
+		bad = 2;
+		lws_cancel_service(lws_get_context(wsi));
+		break;
+
+	case LWS_CALLBACK_COMPLETED_CLIENT_HTTP:
+		lwsl_err("Unexpected COMPLETED from blackhole server\n");
+		interrupted = 1;
+		bad = 2;
+		lws_cancel_service(lws_get_context(wsi));
+		break;
+
+	case LWS_CALLBACK_CLOSED_CLIENT_HTTP:
+		/* CLOSED without first seeing CONNECTION_ERROR is acceptable too
+		 * (the stream close path is also valid), as long as it wasn't a
+		 * normal completion. */
+		if (bad == 1) {
+			lwsl_notice("CLOSED_CLIENT_HTTP (timed out via close path)\n");
+			interrupted = 1;
+			bad = 0;
+			lws_cancel_service(lws_get_context(wsi));
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return lws_callback_http_dummy(wsi, reason, user, in, len);
+}
+
+static const struct lws_protocols client_protocols[] = {
+	{ "http", callback_client_http, 0, 0, 0, NULL, 0 },
+	LWS_PROTOCOL_LIST_TERM
+};
+
+static void
+sigint_handler(int sig)
+{
+	interrupted = 1;
+}
+
+static int
+connect_client(struct lws_context *context, struct lws_vhost *vh,
+	       const char *address, uint16_t port)
+{
+	struct lws_client_connect_info i;
+
+	memset(&i, 0, sizeof i);
+	i.context = context;
+	i.vhost = vh;			/* bind our own protocol, not SS _ss_default */
+	i.address = address;
+	i.port = port;
+	i.path = "/no-reply";
+	i.host = address;
+	i.origin = address;
+	i.method = "GET";
+
+	/* Force ALPN to h3 and use QUIC */
+	i.alpn = "h3";
+	i.ssl_connection = LCCSCF_USE_SSL |
+			   LCCSCF_ALLOW_SELFSIGNED |
+			   LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
+
+	i.protocol = client_protocols[0].name;
+	i.local_protocol_name = client_protocols[0].name;
+	i.pwsi = &client_wsi;
+
+	if (!lws_client_connect_via_info(&i)) {
+		lwsl_err("Client creation failed\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+/*
+ * We drive the client connect from a short deferred timer rather than the
+ * LWS_SYSTATE_OPERATIONAL notifier: that notifier is gated by the secure
+ * streams captive-portal probe, which needs outbound internet and would
+ * otherwise make this self-contained test environment-dependent.  By the time
+ * the sul fires the context + TLS global init are ready.
+ */
+static lws_sorted_usec_list_t connect_sul;
+static struct lws_context *g_context;
+static struct lws_vhost *g_client_vh;
+
+static void
+connect_sul_cb(lws_sorted_usec_list_t *sul)
+{
+	const char *p;
+	uint16_t port = 0;
+
+	if (server_mode)
+		return; /* server is already listening */
+
+	if ((p = lws_cmdline_option(_argc, _argv, "-p")))
+		port = (uint16_t)atoi(p);
+	if (!port) {
+		lwsl_err("client mode needs -p <server port>\n");
+		interrupted = 1;
+		bad = 5;
+		return;
+	}
+
+	if (connect_client(g_context, g_client_vh, "127.0.0.1", port))
+		interrupted = 1;
+}
+
+int
+main(int argc, const char **argv)
+{
+	struct lws_context_creation_info info;
+	struct lws_vhost *vh;
+	struct lws_context *context;
+	const char *p;
+	uint16_t port = 7681;
+	int n = 0;
+
+	_argc = argc;
+	_argv = argv;
+
+	signal(SIGINT, sigint_handler);
+
+	if (lws_cmdline_option(argc, argv, "-s"))
+		server_mode = 1;
+
+	if ((p = lws_cmdline_option(argc, argv, "-p"))) {
+		int __pt = atoi(p);
+		if (__pt < 0 || __pt > 65535) {
+			lwsl_err("Port %d is outside valid 16-bit range\n", __pt);
+			return 1;
+		}
+		port = (uint16_t)__pt;
+	}
+
+	lws_context_info_defaults(&info, NULL);
+	lws_cmdline_option_handle_builtin(argc, argv, &info);
+
+	info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT |
+			LWS_SERVER_OPTION_EXPLICIT_VHOSTS |
+			LWS_SERVER_OPTION_DISABLE_IPV6;
+	info.protocols = server_protocols; /* used for the server vhost */
+	/*
+	 * Client reply timeout: short and deterministic for the test.  This is
+	 * what arms PENDING_TIMEOUT_AWAITING_SERVER_RESPONSE on the H3 stream
+	 * after the request is sent.
+	 */
+	info.timeout_secs = CLIENT_TIMEOUT_SECS;
+	info.fd_limit_per_thread = 1 + 1 + 1;
+
+	lwsl_user("LWS minimal http client timeout h3 (%s mode)\n",
+		  server_mode ? "server/blackhole" : "client");
+
+	context = lws_create_context(&info);
+	if (!context) {
+		lwsl_err("lws init failed\n");
+		return 1;
+	}
+	g_context = context;
+
+	/*
+	 * Instantiate the blackhole QUIC server vhost explicitly.  We pass
+	 * CONTEXT_PORT_NO_LISTEN_SERVER so it doesn't open a TCP listener; the
+	 * UDP QUIC listener is created below via lws_create_adopt_udp().
+	 */
+	if (server_mode) {
+		struct lws_context_creation_info vinfo;
+
+		memset(&vinfo, 0, sizeof vinfo);
+		vinfo.options = info.options;
+		vinfo.protocols = server_protocols;
+		vinfo.port = CONTEXT_PORT_NO_LISTEN_SERVER;
+		vinfo.vhost_name = "blackhole";
+		vinfo.listen_accept_role = "quic";
+		vinfo.listen_accept_protocol = "http";
+		vinfo.alpn = "h3";
+		vinfo.server_ssl_cert_mem = test_cert;
+		vinfo.server_ssl_cert_mem_len = (unsigned int)strlen(test_cert);
+		vinfo.server_ssl_private_key_mem = test_key;
+		vinfo.server_ssl_private_key_mem_len =
+						(unsigned int)strlen(test_key);
+
+		vh = lws_create_vhost(context, &vinfo);
+		if (!vh) {
+			lwsl_err("Failed to create blackhole QUIC vhost\n");
+			goto bail;
+		}
+
+		if (!lws_create_adopt_udp(vh, NULL, port, LWS_CAUDP_BIND,
+					  "http", NULL, NULL, NULL, NULL,
+					  "quic_listen")) {
+			lwsl_err("Failed to bind QUIC UDP listener on %u\n",
+				 port);
+			goto bail;
+		}
+		lwsl_notice("blackhole server listening on %u (QUIC/h3)\n", port);
+	} else {
+		/*
+		 * Client mode: create our own vhost with our own client http
+		 * protocol, so the client stream binds to callback_client_http
+		 * (and not the secure-streams _ss_default vhost).  Then defer
+		 * the connect slightly so the separate blackhole server process
+		 * (when run via ctest) is ready.
+		 */
+		struct lws_context_creation_info vinfo;
+
+		memset(&vinfo, 0, sizeof vinfo);
+		vinfo.options = info.options;
+		vinfo.protocols = client_protocols;
+		vinfo.port = CONTEXT_PORT_NO_LISTEN;
+		vinfo.vhost_name = "timeout-h3-cli";
+
+		g_client_vh = lws_create_vhost(context, &vinfo);
+		if (!g_client_vh) {
+			lwsl_err("Failed to create client vhost\n");
+			goto bail;
+		}
+
+		connect_sul.cb = connect_sul_cb;
+		lws_sul_schedule(context, 0, &connect_sul, connect_sul_cb,
+				 1 * LWS_US_PER_SEC);
+	}
+
+	while (n >= 0 && !interrupted)
+		n = lws_service(context, 0);
+
+	lws_context_destroy(context);
+
+	if (!server_mode) {
+		if (bad == 0) {
+			lwsl_user("Completed: OK (timed out as expected)\n");
+			return 0;
+		}
+		lwsl_err("Completed: failed: exit %d\n", bad);
+		return 1;
+	}
+
+bail:
+	lws_context_destroy(context);
+	return !!server_mode ? 0 : 1;
+}


### PR DESCRIPTION
The built-in QUIC/H3 stack derived its packet-protection AEAD and
header-protection (HP) cipher from the length of the exported TLS 1.3
traffic secret alone: a 48-byte secret was treated as AES-256-GCM and
anything else as AES-128-GCM. ChaCha20-Poly1305 was never selected.

Per RFC 9001 (5.3, 5.4) the AEAD and HP algorithms are fixed by the
negotiated TLS 1.3 cipher suite, not by the secret length. Because
TLS_AES_128_GCM_SHA256 and TLS_CHACHA20_POLY1305_SHA256 both use SHA-256,
they produce identical 32-byte secrets, so a ChaCha20 handshake was
mis-keyed with AES header protection and failed ("reserved bits" /
decryption failure) whenever ChaCha20-Poly1305 was negotiated.

Make the choice cipher-suite aware:

  - add enum lws_tls_quic_aead and wsi->tls.quic_aead, reported by the
    TLS backend from the negotiated suite;
  - every QUIC-capable TLS backend now reports it from the negotiated
    cipher as the traffic secrets are installed:
      * mbedTLS: maps the negotiated TLS 1.3 ciphersuite id in the
        traffic-secret export callback (the suite is only available there
        mid-handshake; ssl->session, which
        mbedtls_ssl_get_ciphersuite_id_from_ssl() reads, is not yet set);
      * OpenSSL/BoringSSL/AWS-LC/LibreSSL: from the SSL_CIPHER handed to
        set_{read,write}_secret();
      * wolfSSL: from SSL_get_current_cipher() in set_encryption_secrets();
      * GnuTLS: from gnutls_cipher_get();
      * SChannel: from the SEC_TRAFFIC_SECRETS symmetric alg / key size;
  - lws_quic_set_keys() selects the internal cipher_type from the
    reported AEAD, falling back to the legacy length heuristic only when
    a backend does not report it (still correct for AES-128 vs AES-256
    GCM, blind to ChaCha20 as before).

The correct SHA-256/SHA-384 HKDF hash is still chosen from the secret
length, which is unambiguous (it mirrors the suite's PRF hash size).

Note: the mbedTLS QUIC support patch must extend the
mbedtls_ssl_transport_ops::set_traffic_secrets callback with the
negotiated ciphersuite id (handshake->ciphersuite_info->id) for the
mbedTLS backend to report it.
