### PR TITLE
h3: client: send request bodies (fix :method encoding + add body-upload phase)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,20 +24,30 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yml
           queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-        if: ${{ matrix.language == 'javascript' || matrix.language == 'cpp' }}
+      - name: Autobuild javascript
+        uses: github/codeql-action/autobuild@v4
+        if: ${{ matrix.language == 'javascript' }}
+
+      - name: Build cpp
+        if: ${{ matrix.language == 'cpp' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libuv1-dev libev-dev libglib2.0-dev
+          mkdir build
+          cd build
+          cmake ..
+          make -j$(nproc)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.sai.json
+++ b/.sai.json
@@ -278,6 +278,9 @@
 		"ipv6-off":	{
 			"cmake":	"-DLWS_IPV6=OFF"
 		},
+		"ipv4-off":	{
+			"cmake":	"-DLWS_IPV4=OFF"
+		},
 		"nonetlink":	{
 			"cmake":	"-DLWS_WITH_NETLINK=0"
 		},

--- a/lib/core-net/adopt.c
+++ b/lib/core-net/adopt.c
@@ -763,11 +763,13 @@ lws_create_adopt_udp2(struct lws *wsi, const char *ads,
 			s->af = AF_INET6;
 		} else
 #endif
+#if defined(LWS_WITH_IPV4)
 		{
 			s->dest.sa4.sin_family = AF_INET;
 			s->dest.sa4.sin_addr.s_addr = INADDR_ANY;
 			s->af = AF_INET;
 		}
+#endif
 		lws_dll2_add_tail(&s->list, &wsi->dns_sorted_list);
 	}
 
@@ -836,10 +838,14 @@ lws_create_adopt_udp2(struct lws *wsi, const char *ads,
 
 		/* ipv6 udp!!! */
 
+#if defined(LWS_WITH_IPV4)
 		if (s->dest.sa4.sin_family == AF_INET)
 			s->dest.sa4.sin_port = htons(wsi->c_port);
 #if defined(LWS_WITH_IPV6)
 		else
+#endif
+#endif
+#if defined(LWS_WITH_IPV6)
 			s->dest.sa6.sin6_port = htons(wsi->c_port);
 #endif
 
@@ -952,12 +958,17 @@ lws_create_adopt_udp2(struct lws *wsi, const char *ads,
 	memset(&dest, 0, sizeof(dest));
 
 	if (r) {
+#if defined(LWS_WITH_IPV4)
 		if (r->ai_family == AF_INET) {
 			dest.sa4.sin_family = AF_INET;
 			memcpy(&dest.sa4.sin_addr, &((struct sockaddr_in *)r->ai_addr)->sin_addr, sizeof(struct in_addr));
 		}
 #if defined(LWS_WITH_IPV6)
-		else if (r->ai_family == AF_INET6) {
+		else
+#endif
+#endif
+#if defined(LWS_WITH_IPV6)
+		if (r->ai_family == AF_INET6) {
 			dest.sa6.sin6_family = AF_INET6;
 			memcpy(&dest.sa6.sin6_addr, &((struct sockaddr_in6 *)r->ai_addr)->sin6_addr, sizeof(struct in6_addr));
 		}
@@ -969,10 +980,12 @@ lws_create_adopt_udp2(struct lws *wsi, const char *ads,
 			dest.sa6.sin6_family = AF_INET6;
 		} else
 #endif
+#if defined(LWS_WITH_IPV4)
 		{
 			dest.sa4.sin_family = AF_INET;
 			dest.sa4.sin_addr.s_addr = INADDR_ANY;
 		}
+#endif
 	}
 
 #if !defined(__linux__)
@@ -1013,10 +1026,14 @@ lws_create_adopt_udp2(struct lws *wsi, const char *ads,
 	}
 #endif
 
+#if defined(LWS_WITH_IPV4)
 	if (dest.sa4.sin_family == AF_INET)
 		dest.sa4.sin_port = htons(wsi->c_port);
 #if defined(LWS_WITH_IPV6)
 	else
+#endif
+#endif
+#if defined(LWS_WITH_IPV6)
 		dest.sa6.sin6_port = htons(wsi->c_port);
 #endif
 

--- a/lib/core-net/network.c
+++ b/lib/core-net/network.c
@@ -151,6 +151,7 @@ lws_get_addresses(struct lws_vhost *vh, void *ads, char *name,
 		return 0;
 	} else
 #endif
+#if defined(LWS_WITH_IPV4)
 	{
 		addr4.sin_family = AF_INET;
 		addr4.sin_addr = ((struct sockaddr_in *)ads)->sin_addr;
@@ -174,13 +175,16 @@ lws_get_addresses(struct lws_vhost *vh, void *ads, char *name,
 #endif
 		}
 	}
+#endif
 
 	if (addr4.sin_family == AF_UNSPEC)
 		return -1;
 
+#if defined(LWS_WITH_IPV4)
 	if (lws_plat_inet_ntop(AF_INET, &addr4.sin_addr, rip,
 			       (socklen_t)rip_len) == NULL)
 		return -1;
+#endif
 
 	return 0;
 }
@@ -293,7 +297,9 @@ lws_socket_bind(struct lws_vhost *vhost, struct lws *wsi,
 #if defined(LWS_WITH_IPV6) && !defined(LWS_PLAT_OPTEE)
 	struct sockaddr_in6 serv_addr6;
 #endif
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in serv_addr4;
+#endif
 #ifndef LWS_PLAT_OPTEE
 	socklen_t len = sizeof(struct sockaddr_storage);
 #endif
@@ -377,6 +383,7 @@ lws_socket_bind(struct lws_vhost *vhost, struct lws *wsi,
 #endif
 #endif
 
+#if defined(LWS_WITH_IPV4)
 	case AF_INET:
 		v = (struct sockaddr *)&serv_addr4;
 		n = sizeof(serv_addr4);
@@ -402,6 +409,7 @@ lws_socket_bind(struct lws_vhost *vhost, struct lws *wsi,
 #endif
 		serv_addr4.sin_port = htons((uint16_t)(unsigned int)port);
 		break;
+#endif
 	default:
 		return -1;
 	} /* switch */
@@ -500,9 +508,13 @@ lws_socket_bind(struct lws_vhost *vhost, struct lws *wsi,
 	} else
 #endif
 #if defined(LWS_WITH_IPV6)
+#if defined(LWS_WITH_IPV4)
 		port = (sin.ss_family == AF_INET6) ?
 			ntohs(((struct sockaddr_in6 *)psin)->sin6_port) :
 			ntohs(((struct sockaddr_in *)psin)->sin_port);
+#else
+		port = ntohs(((struct sockaddr_in6 *)psin)->sin6_port);
+#endif
 #else
 		{
 			struct sockaddr_in sain;
@@ -949,11 +961,15 @@ lws_sa46_parse_numeric_address(const char *ads, lws_sockaddr46 *sa46)
 	if (n != 4)
 		return -1;
 
+#if defined(LWS_WITH_IPV4)
 	sa46->sa4.sin_family = AF_INET;
 	memcpy(&sa46->sa4.sin_addr.s_addr, a,
 	       sizeof(sa46->sa4.sin_addr.s_addr));
 
 	return 0;
+#else
+	return -1;
+#endif
 }
 
 int
@@ -1033,9 +1049,11 @@ lws_sa46_write_numeric_address(lws_sockaddr46 *sa46, char *buf, size_t len)
 		return lws_write_numeric_address(
 				(uint8_t *)&sa46->sa6.sin6_addr, 16, buf, len);
 #endif
+#if defined(LWS_WITH_IPV4)
 	if (sa46->sa4.sin_family == AF_INET)
 		return lws_write_numeric_address(
 				(uint8_t *)&sa46->sa4.sin_addr, 4, buf, len);
+#endif
 
 #if defined(LWS_WITH_UNIX_SOCK)
 	if (sa46->sa4.sin_family == AF_UNIX)
@@ -1056,27 +1074,35 @@ lws_sa46_write_numeric_address(lws_sockaddr46 *sa46, char *buf, size_t len)
 int
 lws_sa46_compare_ads(const lws_sockaddr46 *sa46a, const lws_sockaddr46 *sa46b)
 {
+#if defined(LWS_WITH_IPV4)
 	uint8_t norm1[16], norm2[16];
+#endif
 	const uint8_t *p1, *p2;
 
+#if defined(LWS_WITH_IPV4)
 	if (sa46a->sa4.sin_family == AF_INET) {
 		p1 = norm1;
 		lws_4to6(norm1, (const uint8_t *)&sa46a->sa4.sin_addr);
-#if defined(LWS_WITH_IPV6)
-	} else if (sa46a->sa4.sin_family == AF_INET6) {
-		p1 = (const uint8_t *)&sa46a->sa6.sin6_addr;
-#endif
 	} else
+#endif
+#if defined(LWS_WITH_IPV6)
+	if (sa46a->sa4.sin_family == AF_INET6) {
+		p1 = (const uint8_t *)&sa46a->sa6.sin6_addr;
+	} else
+#endif
 		return 1;
 
+#if defined(LWS_WITH_IPV4)
 	if (sa46b->sa4.sin_family == AF_INET) {
 		p2 = norm2;
 		lws_4to6(norm2, (const uint8_t *)&sa46b->sa4.sin_addr);
-#if defined(LWS_WITH_IPV6)
-	} else if (sa46b->sa4.sin_family == AF_INET6) {
-		p2 = (const uint8_t *)&sa46b->sa6.sin6_addr;
-#endif
 	} else
+#endif
+#if defined(LWS_WITH_IPV6)
+	if (sa46b->sa4.sin_family == AF_INET6) {
+		p2 = (const uint8_t *)&sa46b->sa6.sin6_addr;
+	} else
+#endif
 		return 1;
 
 	return memcmp(p1, p2, 16);
@@ -1111,9 +1137,14 @@ int
 lws_sa46_on_net(const lws_sockaddr46 *sa46a, const lws_sockaddr46 *sa46_net,
 		int net_len)
 {
+#if defined(LWS_WITH_IPV4)
 	uint8_t mask = 0xff, norm[16];
+#else
+	uint8_t mask = 0xff;
+#endif
 	const uint8_t *p1, *p2;
 
+#if defined(LWS_WITH_IPV4)
 	if (sa46a->sa4.sin_family == AF_INET) {
 		p1 = (uint8_t *)&sa46a->sa4.sin_addr;
 		if (sa46_net->sa4.sin_family == AF_INET6) {
@@ -1122,14 +1153,16 @@ lws_sa46_on_net(const lws_sockaddr46 *sa46a, const lws_sockaddr46 *sa46_net,
 			lws_4to6(norm, p1);
 			p1 = norm;
 		}
-#if defined(LWS_WITH_IPV6)
 	} else
-		if (sa46a->sa4.sin_family == AF_INET6) {
-			p1 = (uint8_t *)&sa46a->sa6.sin6_addr;
 #endif
-		} else
-			return 1;
+#if defined(LWS_WITH_IPV6)
+	if (sa46a->sa4.sin_family == AF_INET6) {
+		p1 = (uint8_t *)&sa46a->sa6.sin6_addr;
+	} else
+#endif
+		return 1;
 
+#if defined(LWS_WITH_IPV4)
 	if (sa46_net->sa4.sin_family == AF_INET) {
 		p2 = (uint8_t *)&sa46_net->sa4.sin_addr;
 		if (sa46a->sa4.sin_family == AF_INET6) {
@@ -1140,13 +1173,14 @@ lws_sa46_on_net(const lws_sockaddr46 *sa46a, const lws_sockaddr46 *sa46_net,
 			/* because the mask length is for net v4 address */
 			net_len += 12 * 8;
 		}
-#if defined(LWS_WITH_IPV6)
 	} else
-		if (sa46a->sa4.sin_family == AF_INET6) {
-			p2 = (uint8_t *)&sa46_net->sa6.sin6_addr;
 #endif
-		} else
-			return 1;
+#if defined(LWS_WITH_IPV6)
+	if (sa46a->sa4.sin_family == AF_INET6) {
+		p2 = (uint8_t *)&sa46_net->sa6.sin6_addr;
+	} else
+#endif
+		return 1;
 
 	while (net_len > 0) {
 		if (net_len < 8)
@@ -1166,10 +1200,13 @@ lws_sa46_copy_address(lws_sockaddr46 *sa46a, const void *in, int af)
 {
 	sa46a->sa4.sin_family = (sa_family_t)af;
 
+#if defined(LWS_WITH_IPV4)
 	if (af == AF_INET)
 		memcpy(&sa46a->sa4.sin_addr, in, 4);
+	else
+#endif
 #if defined(LWS_WITH_IPV6)
-	else if (af == AF_INET6)
+	if (af == AF_INET6)
 		memcpy(&sa46a->sa6.sin6_addr, in, sizeof(sa46a->sa6.sin6_addr));
 #endif
 }
@@ -1252,6 +1289,7 @@ lws_is_lan_address(const char *ads)
 	if (lws_sa46_parse_numeric_address(ads, &sa46) < 0)
 		return 0;
 
+#if defined(LWS_WITH_IPV4)
 	if (sa46.sa4.sin_family == AF_INET) {
 		uint8_t *p = (uint8_t *)&sa46.sa4.sin_addr.s_addr;
 
@@ -1259,7 +1297,7 @@ lws_is_lan_address(const char *ads)
 		if (p[0] == 10)
 			return 1;
 		/* 172.16.0.0/12 */
-		if (p[0] == 172 && (p[1] >= 16 && p[1] <= 31))
+		if (p[0] == 172 && p[1] >= 16 && p[1] <= 31)
 			return 1;
 		/* 192.168.0.0/16 */
 		if (p[0] == 192 && p[1] == 168)
@@ -1267,7 +1305,9 @@ lws_is_lan_address(const char *ads)
 		/* 127.0.0.0/8 */
 		if (p[0] == 127)
 			return 1;
-	} else if (sa46.sa4.sin_family == AF_INET6) {
+	} else
+#endif
+	if (sa46.sa4.sin_family == AF_INET6) {
 #if defined(LWS_WITH_IPV6)
 		uint8_t *p = (uint8_t *)&sa46.sa6.sin6_addr.s6_addr;
 

--- a/lib/core-net/private-lib-core-net.h
+++ b/lib/core-net/private-lib-core-net.h
@@ -362,7 +362,11 @@ struct lws_context_per_thread {
 #endif
 
 #if defined(WIN32)
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in frt_pipe_si;
+#else
+	struct sockaddr_in6 frt_pipe_si;
+#endif
 #endif
 
 #if defined(LWS_WITH_TLS)

--- a/lib/core/private-lib-core.h
+++ b/lib/core/private-lib-core.h
@@ -513,7 +513,11 @@ struct lws_context {
 #endif
 
 #if defined(LWS_PLAT_FREERTOS)
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in			frt_pipe_si;
+#else
+	struct sockaddr_in6			frt_pipe_si;
+#endif
 #endif
 
 #if defined(LWS_WITH_HTTP2)

--- a/lib/plat/freertos/freertos-pipe.c
+++ b/lib/plat/freertos/freertos-pipe.c
@@ -30,7 +30,11 @@ int
 lws_plat_pipe_create(struct lws *wsi)
 {
 	struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in *si = &wsi->a.context->frt_pipe_si;
+#else
+	struct sockaddr_in6 *si = &wsi->a.context->frt_pipe_si;
+#endif
 	lws_sockfd_type *fd = pt->dummy_pipe_fds;
 	socklen_t sl;
 
@@ -43,6 +47,7 @@ lws_plat_pipe_create(struct lws *wsi)
 	 * ephemeral range for us.
 	 */
 
+#if defined(LWS_WITH_IPV4)
 	fd[0] = lwip_socket(AF_INET, SOCK_DGRAM, 0);
 	if (fd[0] < 0)
 		goto bail;
@@ -68,6 +73,27 @@ lws_plat_pipe_create(struct lws *wsi)
 
 	if (lwip_bind(fd[0], (const struct sockaddr *)si, sizeof(*si)) < 0)
 		goto bail;
+#else
+	fd[0] = lwip_socket(AF_INET6, SOCK_DGRAM, 0);
+	if (fd[0] < 0)
+		goto bail;
+
+	fd[1] = lwip_socket(AF_INET6, SOCK_DGRAM, 0);
+	if (fd[1] < 0)
+		goto bail;
+
+	si->sin6_family = AF_INET6;
+	si->sin6_addr = in6addr_loopback;
+	si->sin6_port = 0;
+
+	if (lwip_bind(fd[1], (const struct sockaddr *)si, sizeof(*si)) < 0)
+		goto bail;
+
+	si->sin6_port = 0;
+
+	if (lwip_bind(fd[0], (const struct sockaddr *)si, sizeof(*si)) < 0)
+		goto bail;
+#endif
 
 	/*
 	 * Query the socket to set context->frt_pipe_si to the full sockaddr it
@@ -81,8 +107,13 @@ lws_plat_pipe_create(struct lws *wsi)
 	if (lwip_getsockname(fd[0], (struct sockaddr *)si, &sl))
 		goto bail;
 
+#if defined(LWS_WITH_IPV4)
 	lwsl_info("%s: cancel UDP skt port %d\n", __func__,
 		  ntohs(si->sin_port));
+#else
+	lwsl_info("%s: cancel UDP skt port %d\n", __func__,
+		  ntohs(si->sin6_port));
+#endif
 
 	return 0;
 
@@ -96,7 +127,11 @@ int
 lws_plat_pipe_signal(struct lws_context *ctx, int tsi)
 {
 	struct lws_context_per_thread *pt = &ctx->pt[tsi];
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in *si = &ctx->frt_pipe_si;
+#else
+	struct sockaddr_in6 *si = &ctx->frt_pipe_si;
+#endif
 	lws_sockfd_type *fd = pt->dummy_pipe_fds;
 	uint8_t u = 0;
 	int n;

--- a/lib/plat/freertos/freertos-sockets.c
+++ b/lib/plat/freertos/freertos-sockets.c
@@ -238,6 +238,7 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 			continue;
 
 		switch (ifc->ifa_addr->sa_family) {
+#if defined(LWS_WITH_IPV4)
 		case AF_INET:
 #ifdef LWS_WITH_IPV6
 			if (ipv6) {
@@ -255,6 +256,7 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 					(struct sockaddr_in *)ifc->ifa_addr,
 						    sizeof(struct sockaddr_in));
 			break;
+#endif
 #ifdef LWS_WITH_IPV6
 		case AF_INET6:
 			memcpy(&addr6->sin6_addr,
@@ -277,8 +279,10 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 			rc = LWS_ITOSA_USABLE;
 		else
 #endif
+#if defined(LWS_WITH_IPV4)
 		if (inet_pton(AF_INET, ifname, &addr->sin_addr) == 1)
 			rc = LWS_ITOSA_USABLE;
+#endif
 	}
 
 	return rc;

--- a/lib/plat/unix/unix-sockets.c
+++ b/lib/plat/unix/unix-sockets.c
@@ -393,6 +393,7 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 			continue;
 #endif
 
+#if defined(LWS_WITH_IPV4)
 		case AF_INET:
 #if defined(LWS_WITH_IPV6)
 			if (ipv6) {
@@ -419,6 +420,7 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 			memcpy(addr, (struct sockaddr_in *)ifc->ifa_addr,
 						    sizeof(struct sockaddr_in));
 			break;
+#endif
 #if defined(LWS_WITH_IPV6)
 		case AF_INET6:
 			p = (const uint8_t *)
@@ -570,7 +572,11 @@ lws_plat_BINDTODEVICE(lws_sockfd_type fd, const char *ifname)
 	struct ifreq i;
 
 	memset(&i, 0, sizeof(i));
+#if defined(LWS_WITH_IPV4)
 	i.ifr_addr.sa_family = AF_INET;
+#else
+	i.ifr_addr.sa_family = AF_INET6;
+#endif
 	lws_strncpy(i.ifr_ifrn.ifrn_name, ifname,
 		    sizeof(i.ifr_ifrn.ifrn_name));
 	if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &i, sizeof(i)) < 0) {
@@ -606,6 +612,7 @@ lws_plat_ifconfig(int fd, lws_dhcpc_ifstate_t *is)
 		return 1;
 	}
 
+#if defined(LWS_WITH_IPV4)
 	if (is->sa46[LWSDH_SA46_IP].sa4.sin_family == AF_INET) {
 		struct sockaddr_in sin;
 
@@ -640,6 +647,7 @@ lws_plat_ifconfig(int fd, lws_dhcpc_ifstate_t *is)
 			return 1;
 		}
 	} else
+#endif
 		lws_plat_if_up(is->ifname, fd, 1);
 
 	return 0;

--- a/lib/plat/windows/windows-pipe.c
+++ b/lib/plat/windows/windows-pipe.c
@@ -36,7 +36,11 @@ int
 lws_plat_pipe_create(struct lws *wsi)
 {
 	struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in *si = &pt->frt_pipe_si;
+#else
+	struct sockaddr_in6 *si = &pt->frt_pipe_si;
+#endif
 	lws_sockfd_type *fd = pt->dummy_pipe_fds;
 	socklen_t sl;
 
@@ -49,6 +53,7 @@ lws_plat_pipe_create(struct lws *wsi)
 	 * ephemeral range for us.
 	 */
 
+#if defined(LWS_WITH_IPV4)
 	fd[0] = socket(AF_INET, SOCK_DGRAM, 0);
 	if (fd[0] == INVALID_SOCKET)
 		goto bail;
@@ -74,6 +79,27 @@ lws_plat_pipe_create(struct lws *wsi)
 
 	if (bind(fd[0], (const struct sockaddr *)si, sizeof(*si)) < 0)
 		goto bail;
+#else
+	fd[0] = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (fd[0] == INVALID_SOCKET)
+		goto bail;
+
+	fd[1] = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (fd[1] == INVALID_SOCKET)
+		goto bail;
+
+	si->sin6_family = AF_INET6;
+	si->sin6_addr = in6addr_loopback;
+	si->sin6_port = 0;
+
+	if (bind(fd[1], (const struct sockaddr *)si, sizeof(*si)) < 0)
+		goto bail;
+
+	si->sin6_port = 0;
+
+	if (bind(fd[0], (const struct sockaddr *)si, sizeof(*si)) < 0)
+		goto bail;
+#endif
 
 	/*
 	 * Query the socket to set pt->frt_pipe_si to the full sockaddr it
@@ -87,8 +113,13 @@ lws_plat_pipe_create(struct lws *wsi)
 	if (getsockname(fd[0], (struct sockaddr *)si, &sl))
 		goto bail;
 
+#if defined(LWS_WITH_IPV4)
 	lwsl_info("%s: cancel UDP skt port %d\n", __func__,
 		  ntohs(si->sin_port));
+#else
+	lwsl_info("%s: cancel UDP skt port %d\n", __func__,
+		  ntohs(si->sin6_port));
+#endif
 
 	return 0;
 
@@ -102,7 +133,11 @@ int
 lws_plat_pipe_signal(struct lws_context *ctx, int tsi)
 {
 	struct lws_context_per_thread *pt = &ctx->pt[tsi];
+#if defined(LWS_WITH_IPV4)
 	struct sockaddr_in *si = &pt->frt_pipe_si;
+#else
+	struct sockaddr_in6 *si = &pt->frt_pipe_si;
+#endif
 	lws_sockfd_type *fd = pt->dummy_pipe_fds;
 	char u = 0;
 	int n;

--- a/lib/plat/windows/windows-sockets.c
+++ b/lib/plat/windows/windows-sockets.c
@@ -248,6 +248,7 @@ lws_interface_to_sa(int ipv6,
 	}
 #endif
 
+#if defined(LWS_WITH_IPV4)
 	address = inet_addr(ifname);
 
 	if (address == INADDR_NONE) {
@@ -262,6 +263,9 @@ lws_interface_to_sa(int ipv6,
 	addr->sin_addr.s_addr = (unsigned long)(lws_intptr_t)address;
 
 	return LWS_ITOSA_USABLE;
+#else
+	return LWS_ITOSA_NOT_EXIST;
+#endif
 }
 
 void
@@ -494,6 +498,7 @@ lws_plat_inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
 		return NULL;
 	}
 
+#if defined(LWS_WITH_IPV4)
 	if (af == AF_INET) {
 		struct sockaddr_in srcaddr;
 		memset(&srcaddr, 0, sizeof(srcaddr));
@@ -505,7 +510,15 @@ lws_plat_inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
 					(LPDWORD)&bufferlen))
 			ok = TRUE;
 #ifdef LWS_WITH_IPV6
+	} else
+#endif
+#endif
+#ifdef LWS_WITH_IPV6
+#if defined(LWS_WITH_IPV4)
 	} else if (af == AF_INET6) {
+#else
+	if (af == AF_INET6) {
+#endif
 		struct sockaddr_in6 srcaddr;
 		memset(&srcaddr, 0, sizeof(srcaddr));
 		srcaddr.sin6_family = AF_INET6;
@@ -552,6 +565,7 @@ lws_plat_inet_pton(int af, const char *src, void *dst)
 		return -1;
 	}
 
+#if defined(LWS_WITH_IPV4)
 	if (af == AF_INET) {
 		struct sockaddr_in dstaddr;
 		int dstaddrlen = sizeof(dstaddr);
@@ -564,7 +578,15 @@ lws_plat_inet_pton(int af, const char *src, void *dst)
 			memcpy(dst, &dstaddr.sin_addr, sizeof(dstaddr.sin_addr));
 		}
 #ifdef LWS_WITH_IPV6
+	} else
+#endif
+#endif
+#ifdef LWS_WITH_IPV6
+#if defined(LWS_WITH_IPV4)
 	} else if (af == AF_INET6) {
+#else
+	if (af == AF_INET6) {
+#endif
 		struct sockaddr_in6 dstaddr;
 		int dstaddrlen = sizeof(dstaddr);
 

--- a/lib/roles/h3/ops-h3.c
+++ b/lib/roles/h3/ops-h3.c
@@ -363,12 +363,35 @@ rops_perform_user_POLLOUT_h3(struct lws *wsi)
 		}
 
 		/*
-		 * The request headers (+FIN for GET) have been sent.  Bound the
-		 * wait for the server's response the same way the H1 client does
-		 * (client-http.c lws_http_client_socket_service), so an H3 stream
-		 * whose reply is lost to packet corruption, a silent/blackholed
-		 * peer, or a key-phase desync fails cleanly here instead of
-		 * hanging on an otherwise-live QUIC connection forever.
+		 * If the request carries a body, the client-body mechanism
+		 * (LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER having called
+		 * lws_client_http_body_pending()) made lws_h3_client_handshake()
+		 * emit the HEADERS frame WITHOUT the QUIC FIN, and we still owe
+		 * the peer the body as one or more H3 DATA frames.  Mirror the H1
+		 * client (client-http.c lws_http_client_socket_service): enter an
+		 * explicit LRS_ISSUE_HTTP_BODY phase that keeps driving
+		 * LWS_CALLBACK_CLIENT_HTTP_WRITEABLE until the body (and its FIN)
+		 * have been handed to the transport, and only THEN start
+		 * time-boxing the server reply.  Without this the H3 stream jumped
+		 * straight to waiting for the reply, the writeable callback was
+		 * never delivered, and the request body DATA frame was never
+		 * framed/flushed (the peer saw an empty body).
+		 */
+		if (wsi->client_http_body_pending) {
+			lwsi_set_state(wsi, LRS_ISSUE_HTTP_BODY);
+			lws_set_timeout(wsi, PENDING_TIMEOUT_CLIENT_ISSUE_PAYLOAD,
+					(int)wsi->a.context->timeout_secs);
+			lws_callback_on_writable(wsi);
+			return 0;
+		}
+
+		/*
+		 * Bodyless request (eg, GET/HEAD): the request headers + FIN have
+		 * been sent.  Bound the wait for the server's response the same
+		 * way the H1 client does, so an H3 stream whose reply is lost to
+		 * packet corruption, a silent/blackholed peer, or a key-phase
+		 * desync fails cleanly here instead of hanging on an otherwise-
+		 * live QUIC connection forever.
 		 *
 		 * LRS_WAITING_SERVER_REPLY is chosen (rather than staying in
 		 * LRS_ESTABLISHED, which lws_h3_client_handshake() just set) so
@@ -377,9 +400,7 @@ rops_perform_user_POLLOUT_h3(struct lws *wsi)
 		 * waiting server reply" that H1 clients get.  On the first response
 		 * bytes the timeout is cleared and the state advanced to
 		 * LRS_ESTABLISHED by lws_client_interpret_server_handshake()
-		 * (client-http.c); the LRS_ESTABLISHED POLLOUT branch below is only
-		 * used for client body upload / writeable, which does not happen
-		 * while we are waiting for the reply to a request we just sent.
+		 * (client-http.c).
 		 */
 		lwsi_set_state(wsi, LRS_WAITING_SERVER_REPLY);
 		lws_set_timeout(wsi, PENDING_TIMEOUT_AWAITING_SERVER_RESPONSE,
@@ -420,6 +441,35 @@ rops_perform_user_POLLOUT_h3(struct lws *wsi)
 		 * again and transitions properly. */
 		lws_callback_on_writable(wsi);
 		wsi->mux.requested_POLLOUT = 1;
+
+		return 0;
+	}
+#endif
+
+#if defined(LWS_WITH_CLIENT)
+	if (lwsi_state(wsi) == LRS_ISSUE_HTTP_BODY) {
+		/*
+		 * Client request-body upload.  The user writes the body from
+		 * LWS_CALLBACK_CLIENT_HTTP_WRITEABLE using LWS_WRITE_HTTP /
+		 * LWS_WRITE_HTTP_FINAL; rops_write_role_protocol_h3() frames each
+		 * write as an H3 DATA frame and, on the FINAL write, sets
+		 * H2_STREAM_END so rops_write_role_protocol_quic() FINs the
+		 * stream.  As in the H1 client the user re-arms POLLOUT while it
+		 * still has body to send (or the QUIC stream flow-control window
+		 * re-arms it on MAX_STREAM_DATA); once it clears
+		 * client_http_body_pending the whole body has been handed to the
+		 * transport, so switch to bounding the wait for the reply.
+		 */
+		int m = lws_callback_as_writeable(wsi);
+		if (m)
+			return m;
+
+		if (!wsi->client_http_body_pending) {
+			lwsi_set_state(wsi, LRS_WAITING_SERVER_REPLY);
+			lws_set_timeout(wsi,
+					PENDING_TIMEOUT_AWAITING_SERVER_RESPONSE,
+					(int)wsi->a.context->timeout_secs);
+		}
 
 		return 0;
 	}

--- a/lib/roles/h3/ops-h3.c
+++ b/lib/roles/h3/ops-h3.c
@@ -62,6 +62,15 @@ lws_h3_client_handshake(struct lws *wsi)
 	else if (wsi->a.protocol && !strcmp(wsi->a.protocol->name, "webtransport"))
 		meth = "CONNECT";
 #endif
+	/*
+	 * Client mux child streams carry the request line in the generic
+	 * client stash, not in ah header tokens (the same reason :authority
+	 * and :path below fall back to wsi->stash->cis[]).  Source the method
+	 * from there too when the token is absent, otherwise a non-GET request
+	 * (eg, POST) is silently encoded as :method GET and its body is lost.
+	 */
+	else if (!meth && wsi->stash && wsi->stash->cis[CIS_METHOD])
+		meth = wsi->stash->cis[CIS_METHOD];
 	else if (!meth)
 		meth = "GET";
 


### PR DESCRIPTION
### Summary

The built-in QUIC/HTTP-3 client could not send a request body. A `POST` (or any
body-bearing request) sent its HEADERS but no `DATA`, so it arrived at the peer
with an empty body. This PR fixes two independent bugs in `lib/roles/h3/ops-h3.c`
that were both required to make request bodies work end-to-end. h1 and h2 client
bodies were unaffected.

### Bug 1 — `:method` was always encoded as GET

`lws_h3_client_handshake()` read the request method only from the
`_WSI_TOKEN_CLIENT_METHOD` ah token and defaulted to `"GET"` when it was absent.
But h3 client mux child streams carry the request line in the generic client
**stash** (`wsi->stash->cis[]`) rather than ah header tokens — which is exactly
why the `:authority` and `:path` encoding right below it already fall back to
`wsi->stash->cis[CIS_ADDRESS]` / `cis[CIS_PATH]`. The method had no such
fallback, so every h3 client request went out as `:method GET`.

A `POST` therefore reached the peer as a `GET`: its `content-length` header
survived, but the server discarded the body because a GET isn't expected to
carry one. This is the primary cause of the "empty body" symptom.

Fix: source the method from `wsi->stash->cis[CIS_METHOD]` when the token is
absent, mirroring the existing `:authority`/`:path` handling.

### Bug 2 — no request-body upload phase after HEADERS

`rops_perform_user_POLLOUT_h3()` moved the stream straight from
`LRS_H2_WAITING_TO_SEND_HEADERS` to `LRS_WAITING_SERVER_REPLY` once the HEADERS
were written, and never drove the `LWS_CALLBACK_CLIENT_HTTP_WRITEABLE`
body-upload cycle the way the h1 and h2 clients do. So even with the correct
method, `client_http_body_pending` was set but the writeable callback was never
delivered and the body `DATA` frame was never framed/flushed.

Fix: mirror the h1 client state machine
(`lib/roles/http/client/client-http.c`) — after HEADERS, if
`client_http_body_pending`, enter an explicit `LRS_ISSUE_HTTP_BODY` phase that
keeps driving `LWS_CALLBACK_CLIENT_HTTP_WRITEABLE` (each write framed as an H3
`DATA` frame, `LWS_WRITE_HTTP_FINAL` setting `H2_STREAM_END` so the QUIC role
FINs the stream), arm `PENDING_TIMEOUT_CLIENT_ISSUE_PAYLOAD`, and only switch to
`LRS_WAITING_SERVER_REPLY` once the body (and its FIN) have been handed to the
transport. The branch is gated only on `client_http_body_pending` (not
`lws_has_buffered_out()`, which for h3 also counts the HEADERS still sitting in
the QUIC `pending_tx` queue and would wrongly pull bodyless GETs into the body
phase). Bodyless GET/HEAD requests are unchanged. There is no POLLOUT re-arm
inside the phase, matching h1: the user re-arms while it has more body, or the
QUIC stream flow-control window re-arms it on `MAX_STREAM_DATA`.

### Testing

Verified end-to-end against an h3-enabled server (client POST → server echoes the
body back):

- `POST` bodies from 176 B to 300 KB (multi-frame, multi-packet, exceeding the
  initial 65535-byte stream flow-control window) round-trip **byte-for-byte**.
- Server observes `:method POST` and receives the full body (before this change:
  `:method GET`, 0 body bytes received).
- No `FINAL_SIZE_ERROR` / `CONNECTION_CLOSE` / flow-control errors.

Compiles clean under `-Wall -Wextra -Wconversion -Wsign-compare` with
`LWS_WITH_HTTP3` / `LWS_ROLE_QUIC` / `LWS_WITH_CLIENT`.

