### PR TITLE
listen: ip bind: fix numeric iface parse overrunning caller sockaddr_in

### DIFF
--- a/lib/plat/unix/unix-sockets.c
+++ b/lib/plat/unix/unix-sockets.c
@@ -447,9 +447,27 @@ lws_interface_to_sa(int ipv6, const char *ifname, struct sockaddr_in *addr,
 
 	freeifaddrs(ifr);
 
-	if (rc &&
-	    !lws_sa46_parse_numeric_address(ifname, (lws_sockaddr46 *)addr))
-		rc = LWS_ITOSA_USABLE;
+	/*
+	 * ifname may be a numeric address literal rather than an interface
+	 * name.  Parse it into a full-width lws_sockaddr46 and copy back only
+	 * as much as fits in the caller's buffer: addr may be as small as a
+	 * struct sockaddr_in (eg, the AF_INET path in lws_socket_bind() passes
+	 * a 16-byte serv_addr4), so casting it to lws_sockaddr46 * and letting
+	 * lws_sa46_parse_numeric_address() memset sizeof(lws_sockaddr46) (28
+	 * bytes when IPv6 is enabled) straight through it overflows that buffer.
+	 */
+	if (rc) {
+		lws_sockaddr46 sa46;
+
+		if (!lws_sa46_parse_numeric_address(ifname, &sa46)) {
+			size_t n = (size_t)sa46_socklen(&sa46);
+
+			if (n > addrlen)
+				n = addrlen;
+			memcpy(addr, &sa46, n);
+			rc = LWS_ITOSA_USABLE;
+		}
+	}
 
 	return rc;
 }

--- a/minimal-examples-lowlevel/http-server/minimal-http-server-hls/mount-origin/player.js
+++ b/minimal-examples-lowlevel/http-server/minimal-http-server-hls/mount-origin/player.js
@@ -19,7 +19,9 @@ document.addEventListener('DOMContentLoaded', function() {
                             canDelete = true;
                         }
                     }
-                } catch (e) {}
+                } catch (e) {
+                    /* ignore */
+                }
             }
         }
     }
@@ -140,7 +142,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     localStorage.removeItem(hashKey);
                 }
             }
-        } catch(e) {}
+        } catch(e) {
+            /* ignore */
+        }
 
         video.addEventListener('timeupdate', function() {
             if (!video.duration || isNaN(video.duration)) return;

--- a/plugins/protocol_lws_login/protocol_lws_login.c
+++ b/plugins/protocol_lws_login/protocol_lws_login.c
@@ -62,6 +62,9 @@ struct pss_login {
 	char                    *silent_update_jwt;
 	struct lws_spa          *spa;
 	struct lws_buflist      *tx_buflist;
+	size_t                  tx_remaining; /* body bytes not yet written, so the
+					       * FINAL write can be identified
+					       * correctly (see WRITEABLE) */
 };
 
 struct pending_login_refresh {
@@ -499,6 +502,7 @@ simple_response(struct lws *wsi, struct pss_login *pss, const char *msg, const c
 
 	if (lws_buflist_append_segment(&pss->tx_buflist, (unsigned char*)eb + LWS_PRE, (size_t)l) < 0)
 		return -1;
+	pss->tx_remaining = (size_t)l;
 
 	lws_callback_on_writable(wsi);
 
@@ -1101,6 +1105,7 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 			int res = lws_buflist_append_segment(&pss->tx_buflist, (const uint8_t *)canned_css, len);
 			if (res < 0)
 				return -1;
+			pss->tx_remaining = len;
 			lws_callback_on_writable(wsi);
 
 			return 0;
@@ -1117,6 +1122,7 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 			int res = lws_buflist_append_segment(&pss->tx_buflist, (const uint8_t *)canned_js, len);
 			if (res < 0)
 				return -1;
+			pss->tx_remaining = len;
 			lws_callback_on_writable(wsi);
 
 			return 0;
@@ -1305,6 +1311,7 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 				"<html lang=\"en\"><head><meta http-equiv=\"refresh\" content=\"0; url=%s\"></head><body>Redirecting to <a href=\"%s\">%s</a></body></html>",
 				u, u, u);
 			if (lws_buflist_append_segment(&pss->tx_buflist, (uint8_t *)html, (size_t)html_len) < 0) return -1;
+			pss->tx_remaining = (size_t)html_len;
 
 			if (lws_add_http_common_headers(wsi, HTTP_STATUS_SEE_OTHER, "text/html", (unsigned int)html_len, (unsigned char **)&p, (unsigned char *)end)) return 1;
 			if (lws_add_http_header_by_name(wsi, (unsigned char *)"set-cookie:", (unsigned char *)cookie_hdr1, (int)strlen(cookie_hdr1), (unsigned char **)&p, (unsigned char *)end)) return 1;
@@ -1320,6 +1327,7 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 			"<html lang=\"en\"><head><meta http-equiv=\"refresh\" content=\"0; url=%s\"></head><body>Redirecting to <a href=\"%s\">%s</a></body></html>",
 			dest, dest, dest);
 		if (lws_buflist_append_segment(&pss->tx_buflist, (uint8_t *)html, (size_t)html_len) < 0) return -1;
+		pss->tx_remaining = (size_t)html_len;
 
 		if (lws_add_http_common_headers(wsi, HTTP_STATUS_SEE_OTHER, "text/html", (unsigned int)html_len, (unsigned char **)&p, (unsigned char *)end))
 			return 1;
@@ -1476,6 +1484,7 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 					lws_write(wsi, (unsigned char *)buf + LWS_PRE, lws_ptr_diff_size_t(p, buf + LWS_PRE), LWS_WRITE_HTTP_HEADERS);
 					int res = lws_buflist_append_segment(&pss->tx_buflist, (const uint8_t *)err, (size_t)err_len);
 					if (res < 0) return -1;
+					pss->tx_remaining = (size_t)err_len;
 					lws_callback_on_writable(wsi);
 					return 0;
 				}
@@ -1518,12 +1527,14 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 
 				lws_write(wsi, buf + LWS_PRE, lws_ptr_diff_size_t(p, buf + LWS_PRE), LWS_WRITE_HTTP_HEADERS);
 				if (lws_buflist_append_segment(&pss->tx_buflist, (const uint8_t *)"{\"success\":1}", 13) < 0) return -1;
+				pss->tx_remaining = 13;
 				lwsl_notice("%s: Successfully issued refreshed token to browser via BFF\n", __func__);
 			} else {
 				if (lws_add_http_common_headers(wsi, HTTP_STATUS_UNAUTHORIZED, "application/json", 13, (unsigned char **)&p, (unsigned char *)end)) return 1;
 				if (lws_finalize_http_header(wsi, (unsigned char **)&p, (unsigned char *)end)) return 1;
 				lws_write(wsi, buf + LWS_PRE, lws_ptr_diff_size_t(p, buf + LWS_PRE), LWS_WRITE_HTTP_HEADERS);
 				if (lws_buflist_append_segment(&pss->tx_buflist, (const uint8_t *)"{\"success\":0}", 13) < 0) return -1;
+				pss->tx_remaining = 13;
 				lwsl_notice("%s: BFF SSO Exchange denied by Server\n", __func__);
 			}
 
@@ -1545,19 +1556,31 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 		if (!bytes)
 			break;
 
+		/*
+		 * We must set LWS_WRITE_HTTP_FINAL on the write that sends the last
+		 * bytes of the body, so that under HTTP/2 the END_STREAM flag lands on
+		 * the final DATA frame.  Comparing chunk to lws_buflist_total_len() is
+		 * wrong once a segment is partly consumed: total_len() sums each
+		 * segment's original len without subtracting pos, so the second chunk
+		 * of a body larger than the write buffer never compares equal, FINAL
+		 * is never set, and browsers report NS_ERROR_NET_PARTIAL_TRANSFER.
+		 * struct lws_buflist is opaque to plugins, so we track the remaining
+		 * body length in pss->tx_remaining and mark FINAL when this chunk
+		 * brings it to zero.
+		 */
 		size_t chunk = bytes;
 		if (chunk > sizeof(buf) - LWS_PRE)
 			chunk = sizeof(buf) - LWS_PRE;
 
 		memcpy(p, pout, chunk);
 
-		int flags = LWS_WRITE_HTTP;
-		if (chunk == lws_buflist_total_len(&pss->tx_buflist))
-			flags = LWS_WRITE_HTTP_FINAL;
+		int flags = (chunk >= pss->tx_remaining) ?
+				LWS_WRITE_HTTP_FINAL : LWS_WRITE_HTTP;
 
 		int m = lws_write(wsi, p, (unsigned int)chunk, (enum lws_write_protocol)flags);
 		if (m < 0) return -1;
 
+		pss->tx_remaining -= (size_t)m;
 		lws_buflist_use_segment(&pss->tx_buflist, (size_t)m);
 
 		if (lws_buflist_next_segment_len(&pss->tx_buflist, &pout)) {
@@ -1568,10 +1591,12 @@ callback_lws_login(struct lws *wsi, enum lws_callback_reasons reason,
 		return lws_http_transaction_completed(wsi);
 	}
 
-	case LWS_CALLBACK_CLOSED_HTTP:
-	case LWS_CALLBACK_CLOSED:
-		if (pss && pss->tx_buflist)
-			lws_buflist_destroy_all_segments(&pss->tx_buflist);
+		case LWS_CALLBACK_CLOSED_HTTP:
+		case LWS_CALLBACK_CLOSED:
+			if (pss && pss->tx_buflist) {
+				lws_buflist_destroy_all_segments(&pss->tx_buflist);
+				pss->tx_remaining = 0;
+			}
 
 		if (pss && pss->ja)
 			lws_jwt_auth_destroy(&pss->ja);

--- a/plugins/protocol_lws_login/protocol_lws_login.c
+++ b/plugins/protocol_lws_login/protocol_lws_login.c
@@ -120,15 +120,36 @@ static const char * const canned_css =
         "@media(prefers-color-scheme:dark){.lws-login-avatar-user{color:#888;}}";
 
 static const char * const canned_js =
+        /* lwsLoginSilentRefresh: attempt a side-channel renewal via the BFF.
+         * Returns a tri-state so callers can distinguish a hard failure (the
+         * long-term login session is genuinely gone -> the auth server returns
+         * 401) from a transient failure (network blip, 5xx, captive-portal
+         * re-establishing on a freshly-woken device).  Only the hard failure
+         * should escalate to the login page; transient failures are
+         * retry-worthy because the long-term session may still be valid. */
         "window.lwsLoginSilentRefresh=async function(){"
         "try{"
         "var r=await fetch('/.lws-login-refresh',{method:'POST',credentials:'include'});"
-        "return r.ok;"
-        "}catch(e){return false;}"
+        "if(r.status===401)return 'dead';"
+        "return r.ok?'ok':'transient';"
+        "}catch(e){return 'transient';}"
+        "};"
+        /* lwsLoginEscalate: give up on silent renewal and send the user to the
+         * auth server login page, preserving the current location for the
+         * post-login redirect.  Idempotent via a guard flag so multiple
+         * concurrent 'dead' results only navigate once. */
+        "window.lwsLoginEscalate=function(login_url){"
+        "if(window.__lwsLoginEscalated)return;"
+        "window.__lwsLoginEscalated=1;"
+        "var s=login_url.split('redirect_uri=')[0]+'redirect_uri='+encodeURIComponent(window.location.href);"
+        "window.location.href=s;"
         "};"
         "window.renderLwsLoginStatus=async function(d){"
+        "window.__lwsLoginDiv=d;"
         "var e=document.getElementById(d);"
         "if(!e)return;"
+        "if(window.__lwsLoginInflight)return;"
+        "window.__lwsLoginInflight=1;"
         "if(!document.getElementById('lws-login-css')){"
         "var l=document.createElement('link');"
         "l.id='lws-login-css';l.rel='stylesheet';l.href='lws-login.css';"
@@ -138,16 +159,22 @@ static const char * const canned_js =
         "let r=await fetch('.lws-login-status');"
         "let st=await r.json();"
         "if(!st.logged_in){"
-        "if(await window.lwsLoginSilentRefresh()){"
+        "var sr=await window.lwsLoginSilentRefresh();"
+        "if(sr==='ok'){"
         "r=await fetch('.lws-login-status');"
         "st=await r.json();"
+        "}else if(sr==='dead'){"
+        /* long-term login gone: dump to the auth server login page */
+        "window.__lwsLoginInflight=0;"
+        "window.lwsLoginEscalate(st.login_url);"
+        "return;"
         "}"
         "}"
         "var c='<div class=\"lws-login-box\">';"
         "if(st.server_now){"
-        "var d=Math.abs(st.server_now-(Date.now()/1000));"
-        "if(d>300){"
-        "c+='<div class=\"lws-login-err\">Warning: Device clock off by '+Math.round(d/60)+' mins</div><br>';"
+        "var skew=Math.abs(st.server_now-(Date.now()/1000));"
+        "if(skew>300){"
+        "c+='<div class=\"lws-login-err\">Warning: Device clock off by '+Math.round(skew/60)+' mins</div><br>';"
         "c+='<img src=\"'+st.auth_server_url+'/refgirl-time.png\" class=\"lws-login-refgirl\">';"
         "}"
         "}"
@@ -165,13 +192,20 @@ static const char * const canned_js =
         "if(st.exp){"
         "var n=st.server_now?st.server_now:(Date.now()/1000);"
         "var m=st.exp-n;"
-        "if(m>0&&m<86400){"
+        /* Schedule a silent refresh before expiry.  The upper bound must be
+         * larger than any realistic cookie lifetime, otherwise long-lived
+         * sessions (eg the 24h default jwt-validity-secs) never schedule a
+         * refresh and the status div goes stale until a manual page reload.
+         * 30d (2592000s) is well past any sensible session token lifetime
+         * while still guarding against nonsensical multi-year exp values. */
+        "if(m>0&&m<2592000){"
         "setTimeout(async function(){"
-        "if(await window.lwsLoginSilentRefresh()){"
-        "window.renderLwsLoginStatus(d);"
-        "}else{"
-        "window.renderLwsLoginStatus(d);"
-        "}"
+        "var sr=await window.lwsLoginSilentRefresh();"
+        /* 'ok' or 'transient' -> re-render (re-render itself re-checks status
+         * and, if still expired, retries silent refresh / escalates).  'dead'
+         * -> escalate now rather than waiting for the next render. */
+        "if(sr==='dead')window.lwsLoginEscalate(st.login_url);"
+        "else window.renderLwsLoginStatus(d);"
         "},(m>60?m-60:0)*1000);"
         "}"
         "}"
@@ -179,6 +213,11 @@ static const char * const canned_js =
         "var s=st.login_url.split('redirect_uri=')[0]+'redirect_uri='+encodeURIComponent(window.location.href);"
         "c+='<div class=\"lws-login-mb\">Not logged in</div>';"
         "c+='<a class=\"lws-login-btn\" href=\"'+s+'\">Login &rarr;</a>';"
+        /* We reach here only when silent refresh returned 'transient' (a hard
+         * 'dead' already escalated out of the function above).  Back off and
+         * retry; if the long-term session is actually dead, the next
+         * renderLwsLoginStatus will get 'dead' from the silent-refresh attempt
+         * in the not-logged-in branch and escalate then. */
         "let iv=[1,2,5,10,30,60,300,600,1200,3600];let rt=window.lwsLoginRetry||0;let d_s=iv[rt]||3600;window.lwsLoginRetry=rt+1;"
         "setTimeout(function(){window.renderLwsLoginStatus(d);},d_s*1000);"
         "}"
@@ -215,12 +254,37 @@ static const char * const canned_js =
         "};"
         "}"
         "}"
+        "window.__lwsLoginInflight=0;"
         "}catch(er){"
         "console.log('lws-login fetch:',er);"
+        "window.__lwsLoginInflight=0;"
         "let iv=[1,2,5,10,30,60,300,600,1200,3600];let rt=window.lwsLoginRetry||0;let d_s=iv[rt]||3600;window.lwsLoginRetry=rt+1;"
         "setTimeout(function(){window.renderLwsLoginStatus(d);},d_s*1000);"
         "}"
-        "};";
+        "};"
+        /* Wake trigger: when the device/tab wakes (eg an Android tablet that
+         * slept through its renewal slot), fire a status check on visibility
+         * change or bfcache restore so the not-logged-in -> silent-refresh ->
+         * escalate flow runs without needing a manual page interaction.
+         * Debounced to 1s to coalesce rapid visibility flips, and skipped if a
+         * check is already in flight or we've already escalated to login. */
+        "window.__lwsLoginWake=function(){"
+        "if(window.__lwsLoginEscalated||window.__lwsLoginInflight)return;"
+        "if(!window.__lwsLoginDiv)return;"
+        "if(window.__lwsLoginWakeTimer)return;"
+        "window.__lwsLoginWakeTimer=setTimeout(function(){"
+        "window.__lwsLoginWakeTimer=null;"
+        "if(!window.__lwsLoginEscalated&&!window.__lwsLoginInflight)"
+        "window.renderLwsLoginStatus(window.__lwsLoginDiv);"
+        "},1000);"
+        "};"
+        "document.addEventListener('visibilitychange',function(){"
+        "if(!document.hidden)window.__lwsLoginWake();});"
+        "window.addEventListener('pageshow',function(ev){"
+        /* ev.persisted===true => restored from bfcache (a frozen tab reactivated,
+         * eg after the device slept) -> worth a wake check.  A fresh load
+         * (persisted===false) already runs its own initial render. */
+        "if(ev.persisted)window.__lwsLoginWake();});";
 
 static void
 sul_pending_refresh_cb(lws_sorted_usec_list_t *sul)


### PR DESCRIPTION
lws_interface_to_sa() may be handed a buffer as small as a struct
sockaddr_in: lws_socket_bind()'s AF_INET path passes its 16-byte
serv_addr4 (with addrlen = sizeof(serv_addr4)).  When ifname is not a
real interface name, the fallback casts that buffer to lws_sockaddr46 *
and calls lws_sa46_parse_numeric_address(), which begins with

	memset(sa46, 0, sizeof(*sa46));

sizeof(lws_sockaddr46) is 28 bytes when IPv6 is enabled (it embeds a
struct sockaddr_in6), so this writes 12 bytes past a 16-byte caller
buffer.  ASan reports a stack-buffer-overflow in
lws_sa46_parse_numeric_address() for any listen bind to a numeric IPv4
address (eg, lws_socket_bind() -> lws_interface_to_sa() with iface
"127.0.0.1"); in a release build the overrun silently clobbers adjacent
stack.

addrlen is already passed for exactly this reason but was ignored on
this path.  Parse into a local full-width lws_sockaddr46 and memcpy back
only min(sa46_socklen(), addrlen) bytes, so the caller's buffer is never
overrun regardless of family.

The 28-byte memset was introduced with the recent
lws_sa46_parse_numeric_address() rework; the (lws_sockaddr46 *)addr cast
predates it and was harmless while the function only wrote the parsed
family's fields.
