### PR TITLE
pollfd: route the fds-removal io stop through _lws_event_loop_ops_io()

### DIFF
--- a/lib/core-net/pollfd.c
+++ b/lib/core-net/pollfd.c
@@ -392,8 +392,8 @@ __remove_wsi_socket_from_fds(struct lws *wsi)
 	/* these are the only valid possibilities for position_in_fds_table */
 	assert(m == LWS_NO_FDS_POS || (m >= 0 && (unsigned int)m < pt->fds_count));
 
-	if (context->event_loop_ops->io)
-		context->event_loop_ops->io(wsi, LWS_EV_STOP | LWS_EV_READ |
+	if (context->event_loop_ops->io || context->event_loop_ops->io_parallel)
+		_lws_event_loop_ops_io(wsi, LWS_EV_STOP | LWS_EV_READ |
 							       LWS_EV_WRITE);
 /*
 	lwsl_notice("%s: wsi=%s, skt=%d, fds pos=%d, end guy pos=%d, endfd=%d\n",


### PR DESCRIPTION
Third one found while implementing the parallel-connect event lib ops (`d31f2d830` "event-loop: HE races") in a custom event lib driving lws off a libuv loop.

`__remove_wsi_socket_from_fds()` calls `event_loop_ops->io()` directly, bypassing the parallel routing that `_lws_event_loop_ops_io()` performs:

```c
	if (context->event_loop_ops->io)
		context->event_loop_ops->io(wsi, LWS_EV_STOP | LWS_EV_READ |
							       LWS_EV_WRITE);
```

`lws_remove_parallel_fd_safely()` points `wsi->desc` and `position_in_fds_table` at the racer it is removing and *then* calls `__remove_wsi_socket_from_fds()`, so this raw call reaches the event lib as "stop everything on this wsi". Event libs resolve their watcher from the wsi — lws's own libuv `elops_io_uv()` uses `wsi_to_priv_uv(wsi)->w_read`, i.e. the primary — so it stops the **primary** socket's watcher, when the racer's is the one being torn down. The `lws_plat_delete_socket_from_fds()` call right after does go through `_lws_event_loop_ops_io()` and correctly stops the racer, so the net effect is: racer stopped (intended) *and* primary stopped (not intended).

The primary is typically still connecting when a racer is removed (e.g. an unroutable AAAA racer failing first), and nothing re-enables its POLLOUT afterwards — `_lws_change_pollfd()` short-circuits on `pa->prev_events == pa->events`, and from lws's point of view the primary's fds entry never changed — so the connect attempt hangs until it times out. Symptom on our side was `Timed out waiting SSL` on hosts with more than one address.

This routes it the same way the two `lws_plat_{insert,delete}_socket_into_fds()` call sites were routed by 'event-loop: HE races', so the stop lands on the socket `wsi->desc` actually refers to.

Note this one is not needed by an event lib that resolves its watcher by fd rather than by wsi (which is what we ended up doing), but it does affect the in-tree libuv/libev/libevent/glib/sdevent/uloop libs, which all key off the wsi.
