### PR TITLE
Name the arguments the public header docs actually describe

### DIFF
--- a/include/libwebsockets/lws-async-dns.h
+++ b/include/libwebsockets/lws-async-dns.h
@@ -103,7 +103,7 @@ lws_async_dns_query(struct lws_context *context, int tsi, const char *name,
 /**
  * lws_async_dns_freeaddrinfo() - decrement refcount on cached addrinfo results
  *
- * \param pai: a pointert to a pointer to first addrinfo returned as result in the callback
+ * \param ai: a pointert to a pointer to first addrinfo returned as result in the callback
  *
  * Decrements the cache object's reference count.  When it reaches zero, the
  * cached object may be reaped subject to LRU rules.

--- a/include/libwebsockets/lws-conmon.h
+++ b/include/libwebsockets/lws-conmon.h
@@ -124,7 +124,7 @@ struct lws_conmon {
 /**
  * lws_conmon_wsi_take() - create a connection latency object from client wsi
  *
- * \param context: lws wsi
+ * \param wsi: lws wsi
  * \param dest: conmon struct to fill
  *
  * Copies wsi conmon data into the caller's struct.  Passes ownership of

--- a/include/libwebsockets/lws-dht.h
+++ b/include/libwebsockets/lws-dht.h
@@ -148,7 +148,7 @@ struct lws_dht_stats {
 /**
  * lws_dht_get_stats() - Retrieve current and historical DHT metrics
  *
- * \param ctx: DHT context
+ * \param vh: the vhost the DHT is running on
  * \param current: Pointer to store current un-rotated metrics, or NULL
  * \param history: Pointer to receive the internal history array pointer
  * \param head: Receives the index of the oldest history frame (next to be overwritten)

--- a/include/libwebsockets/lws-display.h
+++ b/include/libwebsockets/lws-display.h
@@ -191,7 +191,7 @@ lws_display_state_init(lws_display_state_t *lds, struct lws_context *ctx,
  * lws_display_state_set_brightness() - gradually change the brightness
  *
  * \param lds: the display state we are changing
- * \param target: the target brightness to transition to
+ * \param pwmseq: the sequence definition to transition the brightness along
  *
  * Adjusts the brightness gradually twoards the target at 20Hz
  */

--- a/include/libwebsockets/lws-fault-injection.h
+++ b/include/libwebsockets/lws-fault-injection.h
@@ -113,7 +113,7 @@ lws_fi(const lws_fi_ctx_t *fic, const char *fi_name);
  * lws_fi_range() - get a random number from a range
  *
  * \param fic: fault injection tracking context
- * \param fi_name: name of fault injection
+ * \param name: name of fault injection
  * \param result: points to uint64_t to be set to the result
  *
  * This lets you get a random number from an externally-set range, set using a

--- a/include/libwebsockets/lws-gencrypto.h
+++ b/include/libwebsockets/lws-gencrypto.h
@@ -137,7 +137,7 @@ lws_base64_size(int bytes);
 /**
  * lws_gencrypto_padded_length() - returns PKCS#5/#7 padded length
  *
- * @param blocksize - blocksize to pad to
+ * @param block_size - blocksize to pad to
  * @param len - Length of input to pad
  *
  * Returns the length of a buffer originally of size len after PKCS#5 or PKCS#7

--- a/include/libwebsockets/lws-http.h
+++ b/include/libwebsockets/lws-http.h
@@ -1044,7 +1044,7 @@ lws_http_is_redirected_to_get(struct lws *wsi);
  * \param wsi: the wsi to check
  * \param name: name of the cookie
  * \param buf: buffer to store the cookie contents into
- * \param max_len: on entry, maximum length of buf... on exit, used len of buf
+ * \param max: on entry, maximum length of buf... on exit, used len of buf
  *
  * If no cookie header, or no cookie of the requested name, or the value is
  * larger than can fit in buf, returns nonzero.

--- a/include/libwebsockets/lws-jose.h
+++ b/include/libwebsockets/lws-jose.h
@@ -174,7 +174,7 @@ lws_gencrypto_jwe_alg_to_definition(const char *alg,
 /**
  * lws_gencrypto_jwe_enc_to_definition() - look up a jwe enc name
  *
- * \param alg: the jwe enc name
+ * \param enc: the jwe enc name
  * \param jose: pointer to the pointer to the info struct to set on success
  *
  * Returns 0 if *jose set, else nonzero for failure

--- a/include/libwebsockets/lws-jwe.h
+++ b/include/libwebsockets/lws-jwe.h
@@ -89,8 +89,7 @@ lws_jwe_json_parse(struct lws_jwe *jwe, const uint8_t *buf, int len,
 /**
  * lws_jwe_auth_and_decrypt() - confirm and decrypt JWE
  *
- * \param jose: jose context
- * \param jws: jws / jwe context... .map and .map_b64 must be filled already
+ * \param jwe: the JWE context, its .jws.map and .jws.map_b64 must be filled already
  *
  * This is a high level JWE decrypt api that takes a jws with the maps
  * already processed, and if the authentication passes, returns the decrypted
@@ -115,8 +114,7 @@ lws_jwe_auth_and_decrypt(struct lws_jwe *jwe, char *temp, int *temp_len);
 /**
  * lws_jwe_encrypt() - perform JWE encryption
  *
- * \param jose: the JOSE header information (encryption types, etc)
- * \param jws: the JWE elements, pointer to jwk etc
+ * \param jwe: the JWE context, holding the JOSE header information, the JWE elements and the jwk
  * \param temp: parent-owned buffer to "allocate" elements into
  * \param temp_len: amount of space available in temp
  *
@@ -137,7 +135,7 @@ lws_jwe_encrypt(struct lws_jwe *jwe, char *temp, int *temp_len);
  * \param nonce: Nonse string to include in protected header
  * \param out: buffer to take signed packet
  * \param out_len: size of \p out buffer
- * \param conext: lws_context to get random from
+ * \param context: lws_context to get random from
  *
  * This creates a "flattened" JWS packet from the jwk and the plaintext
  * payload, and signs it.  The packet is written into \p out.

--- a/include/libwebsockets/lws-jws.h
+++ b/include/libwebsockets/lws-jws.h
@@ -507,7 +507,7 @@ lws_jwt_sign_via_info(struct lws_context *ctx, struct lws_jwk *jwk,
  * \param csrf_in: NULL, or the csrf token that came in on a URL
  * \param sub: a buffer to hold the subject name in the JWT (eg, account name)
  * \param sub_len: the max length of the sub buffer
- * \param secs_left: set to the number of seconds of valid auth left if valid
+ * \param exp_unix_time: set to the token expiry as a unix time, if valid
  *
  * This performs some generic sanity tests on validated JWT payload...
  *

--- a/include/libwebsockets/lws-led.h
+++ b/include/libwebsockets/lws-led.h
@@ -120,7 +120,7 @@ lws_led_gpio_destroy(struct lws_led_state *lcs);
  * lws_led_gpio_intensity() - set the static intensity of an led
  *
  * \param lo: the base class of the led controller
- * \param index: which led in the controller set
+ * \param name: which led in the controller set
  * \param inten: 16-bit unsigned intensity
  *
  * For LEDs controlled by a BOOL like GPIO, only inten b15 is significant.

--- a/include/libwebsockets/lws-lwsac.h
+++ b/include/libwebsockets/lws-lwsac.h
@@ -290,7 +290,7 @@ lwsac_scan_extant(struct lwsac *head, uint8_t *find, size_t len, int nul);
 /**
  * lwsac_assert_valid() - checks if check..check + len is a valid pointer into memory owned by ac
  *
- * \param ac: the lwsac to confirm with
+ * \param aco: the lwsac to confirm with
  * \param check: the pointer to check
  * \param len: length in bytes of check area
  *

--- a/include/libwebsockets/lws-lwsac.h
+++ b/include/libwebsockets/lws-lwsac.h
@@ -290,7 +290,7 @@ lwsac_scan_extant(struct lwsac *head, uint8_t *find, size_t len, int nul);
 /**
  * lwsac_assert_valid() - checks if check..check + len is a valid pointer into memory owned by ac
  *
- * \param aco: the lwsac to confirm with
+ * \param ac: the lwsac to confirm with
  * \param check: the pointer to check
  * \param len: length in bytes of check area
  *

--- a/include/libwebsockets/lws-mqtt.h
+++ b/include/libwebsockets/lws-mqtt.h
@@ -376,7 +376,7 @@ lws_mqtt_client_send_subcribe(struct lws *wsi, lws_mqtt_subscribe_param_t *sub);
  * lws_mqtt_client_send_unsubcribe() - lws_write a unsubscribe packet
  *
  * \param wsi: the mqtt child wsi
- * \param sub: which topic(s) we want to unsubscribe from
+ * \param unsub: which topic(s) we want to unsubscribe from
  *
  * For topics other child streams are not subscribed to, send a packet
  * to the server asking to unsubscribe from them.  If all topics

--- a/include/libwebsockets/lws-purify.h
+++ b/include/libwebsockets/lws-purify.h
@@ -46,7 +46,7 @@ lws_sql_purify(char *escaped, const char *string, size_t len);
 /**
  * lws_sql_purify_len() - return length of purified version of input string
  *
- * \param string: input buffer ('/0' terminated)
+ * \param p: input buffer ('/0' terminated)
  *
  * Calculates any character escaping without writing it anywhere and returns the
  * calculated length of the purified string.

--- a/include/libwebsockets/lws-retry.h
+++ b/include/libwebsockets/lws-retry.h
@@ -36,7 +36,7 @@ typedef struct lws_retry_bo {
 /**
  * lws_retry_get_delay_ms() - get next delay from backoff table
  *
- * \param lws_context: the lws context (used for getting random)
+ * \param context: the lws context (used for getting random)
  * \param retry: the retry backoff table we are using, or NULL for default
  * \param ctry: pointer to the try counter
  * \param conceal: pointer to flag set to nonzero if the try should be concealed
@@ -59,7 +59,7 @@ lws_retry_get_delay_ms(struct lws_context *context, const lws_retry_bo_t *retry,
 /**
  * lws_retry_sul_schedule() - schedule a sul according to the backoff table
  *
- * \param lws_context: the lws context (used for getting random)
+ * \param context: the lws context (used for getting random)
  * \param sul: pointer to the sul to schedule
  * \param retry: the retry backoff table we are using, or NULL for default
  * \param cb: the callback for when the sul schedule time arrives

--- a/include/libwebsockets/lws-smd.h
+++ b/include/libwebsockets/lws-smd.h
@@ -103,7 +103,7 @@ lws_smd_msg_free(void **payload);
  * lws_smd_msg_send() - queue a previously allocated message
  *
  * \param ctx: the lws_context
- * \param msg: the prepared message
+ * \param payload: the prepared message
  *
  * Queues an allocated, prepared message for delivery to smd clients
  *

--- a/include/libwebsockets/lws-state.h
+++ b/include/libwebsockets/lws-state.h
@@ -54,7 +54,7 @@ typedef struct lws_state_manager {
 /**
  * lws_state_reg_notifier() - add dep handler for state notifications
  *
- * \param context: the lws_context
+ * \param mgr: the state manager
  * \param nl: the handler to add to the notifier linked-list
  *
  * Add \p notify_link to the context's list of notification handlers for system
@@ -79,7 +79,7 @@ lws_state_reg_deregister(lws_state_notify_link_t *nl);
 /**
  * lws_state_reg_notifier_list() - add dep handlers for state notifications
  *
- * \param context: the lws_context
+ * \param mgr: the state manager
  * \param nl: list of notification handlers
  *
  * Add a NULL-terminated list of notification handler pointers to a notification

--- a/include/libwebsockets/lws-system.h
+++ b/include/libwebsockets/lws-system.h
@@ -503,7 +503,7 @@ enum {
 /**
  * lws_system_adopt_stdin(): add stdin to be a wsi handled by the event loop
  *
- * \param context: the lws_context
+ * \param cx: the lws_context
  *
  * The user code should call this after context creation.  It will add stdin
  * to the context event loop and handle it one of two ways


### PR DESCRIPTION
Was reading `lws_jwt_token_sanity` to work out what it hands back. The doc says `secs_left`, set to the number of seconds of valid auth left. The argument is `exp_unix_time`, and in `jws.c` it takes the `exp` claim straight off the token, so it is an absolute unix time. Anything trusting that line computes the wrong thing.

Went through the rest of `include/libwebsockets/` after that and the same thing turns up across a spread of headers. Most are ordinary renames the comment never followed, `pai` for `ai`, `blocksize` for `block_size`, `max_len` for `max`. Two are more than a name: `lws_jwe_encrypt` and `lws_jwe_auth_and_decrypt` still document the old `jose` and `jws` pair from before those were folded into `struct lws_jwe`, so each collapses into the single argument they take now. Where a rename left the description pointing at the wrong thing I took that too, `mgr` in `lws-state.h` was still described as the lws_context and `pwmseq` as a target brightness when it is a sequence definition.

Left alone deliberately: the `#define` helpers such as `lws_ptr_diff` and `lws_end_foreach_ll_safe`, where the documented name genuinely is the macro parameter, and the NXP SDK vendored under `minimal-examples/embedded/rt595`, which is not yours to carry. `lwsac_assert_valid` is the same case and nearly caught me out, since the docblock sits directly above `_lwsac_assert_valid` and that one does take `aco`, but the block is titled for the macro and `check` and `len` match the macro too.
