### PR TITLE
ws: allow '+' in subprotocol names

### DIFF
--- a/lib/roles/ws/server-ws.c
+++ b/lib/roles/ws/server-ws.c
@@ -544,6 +544,7 @@ lws_process_ws_upgrade(struct lws *wsi)
 	lws_tokenize_init(&ts, buf, LWS_TOKENIZE_F_COMMA_SEP_LIST |
 				    LWS_TOKENIZE_F_MINUS_NONTERM |
 				    LWS_TOKENIZE_F_DOT_NONTERM |
+				    LWS_TOKENIZE_F_PLUS_NONTERM |
 				    LWS_TOKENIZE_F_RFC7230_DELIMS);
 	n = lws_hdr_copy(wsi, buf, sizeof(buf) - 1, WSI_TOKEN_PROTOCOL);
 	if (n < 0) {


### PR DESCRIPTION
RFC 6455 defines Sec-WebSocket-Protocol values using HTTP token syntax, where '+' is valid.  It is used by registered subprotocols such as OPC UA's 'opcua+uacp'.

The LWS 5 server upgrade path parses the protocol list with the generic tokenizer.  Without LWS_TOKENIZE_F_PLUS_NONTERM, it rejects names containing '+' as a malformed protocol list before the user protocol callback can run.

Keep '+' inside the token so normal vhost protocol selection can match these subprotocols.