### PR TITLE
gnutls x509 ecc curve bit fix

### DIFF
--- a/lib/tls/gnutls/gnutls-x509.c
+++ b/lib/tls/gnutls/gnutls-x509.c
@@ -61,7 +61,12 @@ lws_x509_create_cert(struct lws_context *context,
 			goto bail;
 		}
 
-		if (gnutls_x509_privkey_generate(key, GNUTLS_PK_ECC, curve, 0))
+		info->key_bits = curvegnutls_ecc_curve_get_size(curve) * 8;
+		if (info->key_bits == 0) {
+			info->key_bits = 256;
+		}
+
+		if (gnutls_x509_privkey_generate(key, GNUTLS_PK_ECC, info->key_bits, 0))
 			goto bail;
 	} else {
 		if (gnutls_x509_privkey_generate(key, GNUTLS_PK_RSA, (unsigned int)(info->key_bits ? info->key_bits : 2048), 0))


### PR DESCRIPTION
Using the gnutls_ecc_curve_t types is incorrect for generating an x509 cert using any of them will result in a legacy 192 bit curve, which breaks things. You could opt to get rid of the the curve type and just hard code the bits in. I decided to make use of the get size function which should also work.