### PR TITLE
openHiTLS: fix no-client and reduced-log builds

### DIFF
--- a/lib/tls/CMakeLists.txt
+++ b/lib/tls/CMakeLists.txt
@@ -241,9 +241,12 @@ if (LWS_WITH_SSL)
 	elseif (LWS_WITH_OPENHITLS)
 		list(APPEND SOURCES
 			tls/openhitls/openhitls-tls.c
-			tls/openhitls/openhitls-session.c
 			tls/openhitls/openhitls-ssl.c
 			tls/openhitls/openhitls-x509.c)
+		if (LWS_WITH_TLS_SESSIONS)
+			list(APPEND SOURCES
+				tls/openhitls/openhitls-session.c)
+		endif()
 		if (NOT LWS_WITHOUT_SERVER)
 			list(APPEND SOURCES
 				tls/openhitls/openhitls-server.c)
@@ -860,4 +863,3 @@ set(TEST_SERVER_SSL_KEY "${TEST_SERVER_SSL_KEY}" PARENT_SCOPE)
 set(TEST_SERVER_SSL_CERT "${TEST_SERVER_SSL_CERT}" PARENT_SCOPE)
 set(TEST_SERVER_DATA ${TEST_SERVER_DATA} PARENT_SCOPE)
 set(LWS_DEP_LIB_PATHS ${LWS_DEP_LIB_PATHS} PARENT_SCOPE)
-

--- a/lib/tls/openhitls/openhitls-ssl.c
+++ b/lib/tls/openhitls/openhitls-ssl.c
@@ -84,7 +84,7 @@ lws_openhitls_klog_dump(HITLS_Ctx *ctx, const char *line)
 int
 lws_openhitls_describe_cipher(struct lws *wsi)
 {
-#if !defined(LWS_WITH_NO_LOGS)
+#if (_LWS_ENABLED_LOGS & LLL_INFO)
 	const HITLS_Cipher *cipher;
 	const char *desc = "";
 	const char *name = "(NONE)";


### PR DESCRIPTION
openhitls: fix no-client and reduced-log builds

Only compile the openHiTLS session implementation when TLS session
support is enabled, matching the other TLS backends.

Guard cipher-description code by the INFO log level to avoid unused
variable errors in Release builds with -Werror.