### PR TITLE
dht: clean up name when node ID allocation fails

### DIFF
--- a/lib/misc/dht/dht.c
+++ b/lib/misc/dht/dht.c
@@ -705,9 +705,7 @@ lws_dht_create(const lws_dht_info_t *info)
 
 	if (!ctx->myid) {
 		lwsl_err("ctx->myid creation failed\n");
-		lws_free(ctx);
-
-		return NULL;
+		goto fail;
 	}
 
 	if (info->v) {

--- a/minimal-examples-lowlevel/api-tests/api-test-dht-create/CMakeLists.txt
+++ b/minimal-examples-lowlevel/api-tests/api-test-dht-create/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(lws-api-test-dht-create C)
+cmake_minimum_required(VERSION 3.10)
+find_package(libwebsockets CONFIG REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${LWS_CMAKE_DIR})
+include(CheckCSourceCompiles)
+include(LwsCheckRequirements)
+
+set(SAMP lws-api-test-dht-create)
+set(SRCS main.c)
+
+set(requirements 1)
+require_lws_config(LWS_WITH_DHT 1 requirements)
+require_lws_config(LWS_PLAT_OPTEE 0 requirements)
+
+if (requirements)
+
+	add_executable(${SAMP} ${SRCS})
+	add_test(NAME api-test-dht-create COMMAND lws-api-test-dht-create)
+
+	if (websockets_shared)
+		target_link_libraries(${SAMP} websockets_shared ${LIBWEBSOCKETS_DEP_LIBS})
+		add_dependencies(${SAMP} websockets_shared)
+	else()
+		target_link_libraries(${SAMP} websockets ${LIBWEBSOCKETS_DEP_LIBS})
+	endif()
+
+endif()

--- a/minimal-examples-lowlevel/api-tests/api-test-dht-create/README.md
+++ b/minimal-examples-lowlevel/api-tests/api-test-dht-create/README.md
@@ -1,0 +1,17 @@
+# lws-api-test-dht-create
+
+This API test covers cleanup when DHT context creation cannot allocate its
+random node ID.
+
+It installs a custom lws allocator, injects a failure for the
+`lws_dht_hash_create` allocation, and checks that every allocation made while
+`lws_dht_create()` was active has been released before the function returns.
+
+The test does not open a listening socket and does not require network access.
+
+Build as part of the main tree with DHT enabled, for example:
+
+```
+cmake -DLWS_WITH_DHT=ON -DLWS_WITH_MINIMAL_EXAMPLES=ON ..
+ctest -R api-test-dht-create --output-on-failure
+```

--- a/minimal-examples-lowlevel/api-tests/api-test-dht-create/main.c
+++ b/minimal-examples-lowlevel/api-tests/api-test-dht-create/main.c
@@ -1,0 +1,162 @@
+/*
+ * lws-api-test-dht-create
+ *
+ * Fault-injection coverage for cleanup when DHT context creation cannot
+ * allocate its random node ID.
+ *
+ * This file is made available under the Creative Commons CC0 1.0
+ * Universal Public Domain Dedication.
+ */
+
+#include <libwebsockets.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_TRACKED 16
+
+static void *tracked[MAX_TRACKED];
+static size_t tracked_count;
+static int tracking;
+static int injected_failures;
+
+static int
+tracked_index(void *ptr)
+{
+	size_t n;
+
+	for (n = 0; n < tracked_count; n++)
+		if (tracked[n] == ptr)
+			return (int)n;
+
+	return -1;
+}
+
+static void
+tracked_add(void *ptr)
+{
+	if (!ptr)
+		return;
+
+	if (tracked_count == LWS_ARRAY_SIZE(tracked)) {
+		lwsl_err("too many tracked allocations\n");
+		abort();
+	}
+
+	tracked[tracked_count++] = ptr;
+}
+
+static void
+tracked_remove(void *ptr)
+{
+	int n = tracked_index(ptr);
+
+	if (n < 0)
+		return;
+
+	tracked[(size_t)n] = tracked[--tracked_count];
+}
+
+static void *
+test_realloc(void *ptr, size_t size, const char *reason)
+{
+	int n = tracked_index(ptr);
+	void *p;
+
+	if (!size) {
+		tracked_remove(ptr);
+		free(ptr);
+
+		return NULL;
+	}
+
+	if (tracking && !ptr && reason &&
+	    !strcmp(reason, "lws_dht_hash_create")) {
+		injected_failures++;
+
+		return NULL;
+	}
+
+	p = realloc(ptr, size);
+	if (!p)
+		return NULL;
+
+	if (n >= 0)
+		tracked[(size_t)n] = p;
+	else if (tracking && !ptr)
+		tracked_add(p);
+
+	return p;
+}
+
+int main(int argc, const char **argv)
+{
+	struct lws_context_creation_info info;
+	struct lws_dht_info dht_info;
+	struct lws_dht_ctx *dht;
+	struct lws_context *context;
+	struct lws_vhost *vhost;
+	int fails = 0;
+
+	lwsl_user("LWS API selftest: dht-create allocation failure\n");
+
+	lws_set_allocator(test_realloc);
+	lws_context_info_defaults(&info, NULL);
+	lws_cmdline_option_handle_builtin(argc, argv, &info);
+	info.port = CONTEXT_PORT_NO_LISTEN;
+
+	context = lws_create_context(&info);
+	if (!context) {
+		fprintf(stderr, "lws init failed\n");
+
+		return 1;
+	}
+
+	info.vhost_name = "dht-create-test";
+	vhost = lws_create_vhost(context, &info);
+	if (!vhost) {
+		lwsl_err("test vhost creation failed\n");
+		lws_context_destroy(context);
+
+		return 1;
+	}
+
+	memset(&dht_info, 0, sizeof(dht_info));
+	dht_info.vhost = vhost;
+	dht_info.name = "allocation-failure-test";
+	dht_info.port = -1;
+
+	tracking = 1;
+	dht = lws_dht_create(&dht_info);
+	tracking = 0;
+
+	if (dht) {
+		lwsl_err("DHT creation unexpectedly succeeded\n");
+		lws_dht_destroy(&dht);
+		fails++;
+	}
+
+	if (injected_failures != 1) {
+		lwsl_err("expected one injected hash allocation failure, got %d\n",
+			 injected_failures);
+		fails++;
+	}
+
+	if (tracked_count) {
+		lwsl_err("DHT creation failure leaked %zu allocation(s)\n",
+			 tracked_count);
+		fails++;
+	}
+
+	while (tracked_count)
+		free(tracked[--tracked_count]);
+
+	lws_context_destroy(context);
+
+	if (fails)
+		lwsl_user("Completed with %d failed checks\n", fails);
+	else
+		lwsl_user("Completed with no failed checks\n");
+
+	return fails ? 1 : 0;
+}


### PR DESCRIPTION
### Problem

When `lws_dht_create()` is given a name, it duplicates that string before
creating the node ID hash. If the hash allocation fails, the current error path
frees only the DHT context and returns, leaving the duplicated name allocated.

This requires an allocation failure while optional DHT support is in use, so the
change is presented as failure-path robustness rather than a security claim.

### Fix

Route the node ID allocation failure through the existing `fail:` cleanup path.
That path calls `lws_dht_destroy()`, which already handles a partially initialized
context and releases both `ctx->name` and the context. The existing error log is
preserved.

### Test

Add `api-test-dht-create`, which installs a custom allocator and fails the
`lws_dht_hash_create` allocation by its allocation reason. It checks that DHT
creation fails and that no allocations made by `lws_dht_create()` remain live.

On macOS arm64 with Apple Clang 21 and DHT/DHT backend enabled:

- the new test fails on the unmodified tree with one live allocation;
- the new test passes with this patch;
- the existing `api-test-dht-msg-parse` test passes;
- both shared and static library targets build successfully;
- the new test passes in an AddressSanitizer build without a sanitizer report.

The candidate was initially found with RepoAudit, and the production cleanup was
suggested by PailGen using Gemini 3.6 Flash. The regression test and submission
preparation were co-developed with OpenAI Codex based on GPT-5. The failure path,
ownership, final patch, and test were manually reviewed and verified.
